### PR TITLE
fix build due to libresolv.so link error

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -26,4 +26,4 @@ export BIN_NAME=ptp-operator
 mkdir -p ${BIN_PATH}
 
 echo "Building ${REPO}/cmd/${WHAT} (${VERSION_OVERRIDE})"
-CGO_ENABLED=${CGO_ENABLED} GOOS=${GOOS} GOARCH=${GOARCH} go build ${GOFLAGS} -ldflags "${GLDFLAGS} -s -w" -o ${BIN_PATH}/${BIN_NAME} ${REPO}
+CGO_ENABLED=${CGO_ENABLED} CC="gcc -fuse-ld=gold" GOOS=${GOOS} GOARCH=${GOARCH} go build ${GOFLAGS} -ldflags "${GLDFLAGS} -s -w" -o ${BIN_PATH}/${BIN_NAME} ${REPO}


### PR DESCRIPTION
Fix the following build errors which broke CI.
Use gold linker instead of default /usr/bin/ld to better handle compatibility with .relr.dyn.

```
Building github.com/k8snetworkplumbingwg/ptp-operator/cmd/manager (4c6e296a-dirty)
# github.com/k8snetworkplumbingwg/ptp-operator
/usr/lib/golang/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
/usr/bin/gcc -m64 -s -o $WORK/b001/exe/a.out -Wl,--export-dynamic-symbol=_cgo_panic -Wl,--export-dynamic-symbol=_cgo_topofstack -Wl,--export-dynamic-symbol=crosscall2 -Wl,--compress-debug-sections=zlib /tmp/go-link-3558063936/go.o /tmp/go-link-3558063936/000000.o /tmp/go-link-3558063936/000001.o /tmp/go-link-3558063936/000002.o /tmp/go-link-3558063936/000003.o /tmp/go-link-3558063936/000004.o /tmp/go-link-3558063936/000005.o /tmp/go-link-3558063936/000006.o /tmp/go-link-3558063936/000007.o /tmp/go-link-3558063936/000008.o /tmp/go-link-3558063936/000009.o /tmp/go-link-3558063936/000010.o /tmp/go-link-3558063936/000011.o /tmp/go-link-3558063936/000012.o /tmp/go-link-3558063936/000013.o /tmp/go-link-3558063936/000014.o /tmp/go-link-3558063936/000015.o /tmp/go-link-3558063936/000016.o /tmp/go-link-3558063936/000017.o /tmp/go-link-3558063936/000018.o /tmp/go-link-3558063936/000019.o /tmp/go-link-3558063936/000020.o /tmp/go-link-3558063936/000021.o /tmp/go-link-3558063936/000022.o /tmp/go-link-3558063936/000023.o /tmp/go-link-3558063936/000024.o /tmp/go-link-3558063936/000025.o /tmp/go-link-3558063936/000026.o /tmp/go-link-3558063936/000027.o /tmp/go-link-3558063936/000028.o /tmp/go-link-3558063936/000029.o /tmp/go-link-3558063936/000030.o /tmp/go-link-3558063936/000031.o /tmp/go-link-3558063936/000032.o /tmp/go-link-3558063936/000033.o /tmp/go-link-3558063936/000034.o /tmp/go-link-3558063936/000035.o /tmp/go-link-3558063936/000036.o /tmp/go-link-3558063936/000037.o /tmp/go-link-3558063936/000038.o /tmp/go-link-3558063936/000039.o /tmp/go-link-3558063936/000040.o /tmp/go-link-3558063936/000041.o /tmp/go-link-3558063936/000042.o /tmp/go-link-3558063936/000043.o /tmp/go-link-3558063936/000044.o /tmp/go-link-3558063936/000045.o /tmp/go-link-3558063936/000046.o -O2 -g -lresolv -O2 -g -ldl -pthread -O2 -g -lpthread -O2 -g -no-pie
/usr/bin/ld: /usr/lib/gcc/x86_64-redhat-linux/11/../../../../lib64/libresolv.so: unknown type [0x13] section `.relr.dyn'
/usr/bin/ld: skipping incompatible /usr/lib/gcc/x86_64-redhat-linux/11/../../../../lib64/libresolv.so when searching for -lresolv
/usr/bin/ld: /lib/../lib64/libresolv.so: unknown type [0x13] section `.relr.dyn'
/usr/bin/ld: skipping incompatible /lib/../lib64/libresolv.so when searching for -lresolv
/usr/bin/ld: /usr/lib/../lib64/libresolv.so: unknown type [0x13] section `.relr.dyn'
/usr/bin/ld: skipping incompatible /usr/lib/../lib64/libresolv.so when searching for -lresolv
/usr/bin/ld: /usr/lib64/libresolv.so: unknown type [0x13] section `.relr.dyn'
/usr/bin/ld: skipping incompatible /usr/lib64/libresolv.so when searching for -lresolv
/usr/bin/ld: /lib64/libresolv.so: unknown type [0x13] section `.relr.dyn'
/usr/bin/ld: skipping incompatible /lib64/libresolv.so when searching for -lresolv
/usr/bin/ld: cannot find -lresolv
/usr/bin/ld: /usr/lib/gcc/x86_64-redhat-linux/11/../../../../lib64/libresolv.so: unknown type [0x13] section `.relr.dyn'
/usr/bin/ld: skipping incompatible /usr/lib/gcc/x86_64-redhat-linux/11/../../../../lib64/libresolv.so when searching for -lresolv
/usr/bin/ld: /lib/../lib64/libresolv.so: unknown type [0x13] section `.relr.dyn'
/usr/bin/ld: skipping incompatible /lib/../lib64/libresolv.so when searching for -lresolv
/usr/bin/ld: /usr/lib/../lib64/libresolv.so: unknown type [0x13] section `.relr.dyn'
/usr/bin/ld: skipping incompatible /usr/lib/../lib64/libresolv.so when searching for -lresolv
/usr/bin/ld: /usr/lib64/libresolv.so: unknown type [0x13] section `.relr.dyn'
/usr/bin/ld: skipping incompatible /usr/lib64/libresolv.so when searching for -lresolv
/usr/bin/ld: /lib64/libresolv.so: unknown type [0x13] section `.relr.dyn'
/usr/bin/ld: skipping incompatible /lib64/libresolv.so when searching for -lresolv
collect2: error: ld returned 1 exit status
```
