### PR TITLE
Deprecation notice

### DIFF
--- a/api/v1/ptpoperatorconfig_webhook.go
+++ b/api/v1/ptpoperatorconfig_webhook.go
@@ -57,10 +57,9 @@ func (r *PtpOperatorConfig) validate() error {
 			if r.Spec.EventConfig.ApiVersion == "1.0" {
 				return errors.New("v1 is no longer supported and has reached End " +
 					"of Life (EOL). PTP event functionality is now available only in " +
-					"v2, and the operator is running with the v2 API for events. " +
-					"Consumers using v1 will no longer be able to communicate with " +
-					"the PTP event system. Please upgrade to v2 and follow the " +
-					"documentation to make the necessary changes.")
+					"v2. Consumers using v1 will no longer be able to communicate " +
+					"with the PTP event system. Please upgrade to v2 and follow " +
+					"the documentation to make the necessary changes.")
 			}
 		}
 	}

--- a/api/v1/ptpoperatorconfig_webhook.go
+++ b/api/v1/ptpoperatorconfig_webhook.go
@@ -19,7 +19,6 @@ package v1
 import (
 	"errors"
 
-	semver "github.com/Masterminds/semver/v3"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -49,7 +48,7 @@ func (r *PtpOperatorConfig) validate() error {
 
 	if r.Spec.EventConfig != nil && r.Spec.EventConfig.EnableEventPublisher {
 		if r.Spec.EventConfig.ApiVersion != "" && !isValidVersion(r.Spec.EventConfig.ApiVersion) {
-			return errors.New("ptpEventConfig.apiVersion=" + r.Spec.EventConfig.ApiVersion + " is not a valid version. Example of valid versions: \"1.0\", \"2.0\"")
+			return errors.New("ptpEventConfig.apiVersion=" + r.Spec.EventConfig.ApiVersion + " is not a valid version. Valid version is \"2.0\"")
 		}
 	}
 
@@ -82,8 +81,6 @@ func (r *PtpOperatorConfig) ValidateDelete() (admission.Warnings, error) {
 	return admission.Warnings{}, nil
 }
 
-// check if the version is valid based semanic versioning (semver.org)
 func isValidVersion(version string) bool {
-	_, err := semver.NewVersion(version)
-	return err == nil
+	return version == "2.0"
 }

--- a/controllers/ptpoperatorconfig_controller.go
+++ b/controllers/ptpoperatorconfig_controller.go
@@ -231,8 +231,10 @@ func (r *PtpOperatorConfigReconciler) syncLinuxptpDaemon(ctx context.Context, de
 			if defaultCfg.Spec.EventConfig.StorageType != "" {
 				data.Data["StorageType"] = defaultCfg.Spec.EventConfig.StorageType
 			}
-			if defaultCfg.Spec.EventConfig.ApiVersion != "" {
-				data.Data["EventApiVersion"] = defaultCfg.Spec.EventConfig.ApiVersion
+			if defaultCfg.Spec.EventConfig.ApiVersion != data.Data["EventApiVersion"] {
+				glog.Infof("Event API version is '%s', using version %s.",
+					defaultCfg.Spec.EventConfig.ApiVersion,
+					data.Data["EventApiVersion"])
 			}
 		}
 	}


### PR DESCRIPTION
If events is enabled and APIv1 is still in use after the upgrade to 4.19, the deprecation notice should appear in logs.