### PR TITLE
upgrade l2discovery to support tighter security in 4.19 

### DIFF
--- a/test/pkg/testconfig/testconfig.go
+++ b/test/pkg/testconfig/testconfig.go
@@ -63,7 +63,7 @@ const (
 	phc2sysSlave                = "-a -r -n 24 -m -N 8 -R 16"
 	SCHED_OTHER                 = "SCHED_OTHER"
 	SCHED_FIFO                  = "SCHED_FIFO"
-	L2_DISCOVERY_IMAGE          = "quay.io/redhat-cne/l2discovery:v12"
+	L2_DISCOVERY_IMAGE          = "quay.io/redhat-cne/l2discovery:v13"
 )
 
 type ConfigStatus int64


### PR DESCRIPTION
related PR: https://github.com/redhat-cne/l2discovery/pull/23