### PR TITLE
PTP CI TC failure: PTP e2e tests prometheus Metrics reported by PTP pods Should all be reported by prometheus (Intermittent)

### DIFF
--- a/test/conformance/serial/prometheus.go
+++ b/test/conformance/serial/prometheus.go
@@ -3,6 +3,7 @@ package test
 import (
 	"bytes"
 	"fmt"
+	"github.com/k8snetworkplumbingwg/ptp-operator/test/pkg"
 	"log"
 	"strings"
 	"time"
@@ -85,18 +86,17 @@ func collectPrometheusMetrics(uniqueMetricKeys []string) map[string][]string {
 }
 
 func collectPtpMetrics(ptpPods []k8sv1.Pod) (map[string][]string, []string) {
-	uniqueMetricKeys := []string{}
+	var uniqueMetricKeys []string
 	ptpMonitoredEntriesByPod := map[string][]string{}
 	for _, pod := range ptpPods {
-		podEntries := []string{}
+		var podEntries []string
 		var stdout bytes.Buffer
 		var err error
 		Eventually(func() error {
-			stdout, _, err = pods.ExecCommand(client.Client, true, &pod, pod.Spec.Containers[0].Name, []string{"curl", "localhost:9091/metrics"})
+			stdout, _, err = pods.ExecCommand(client.Client, true, &pod, pkg.PtpContainerName, []string{"curl", "localhost:9091/metrics"})
 			if len(strings.Split(stdout.String(), "\n")) == 0 {
 				return fmt.Errorf("empty response")
 			}
-
 			return err
 		}, 2*time.Minute, 2*time.Second).Should(Not(HaveOccurred()))
 

--- a/test/conformance/serial/ptp.go
+++ b/test/conformance/serial/ptp.go
@@ -37,6 +37,7 @@ import (
 
 	fbprotocol "github.com/facebook/time/ptp/protocol"
 	"github.com/k8snetworkplumbingwg/ptp-operator/test/pkg/testconfig"
+	k8sv1 "k8s.io/api/core/v1"
 )
 
 type TestCase string
@@ -995,7 +996,8 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 						LabelSelector: "app=linuxptp-daemon",
 					})
 					Expect(err).ToNot(HaveOccurred())
-					ptpMonitoredEntriesByPod, uniqueMetricKeys := collectPtpMetrics(ptpPods.Items)
+					Expect(fullConfig.DiscoveredClockUnderTestPod).ToNot(BeNil())
+					ptpMonitoredEntriesByPod, uniqueMetricKeys := collectPtpMetrics([]k8sv1.Pod{*fullConfig.DiscoveredClockUnderTestPod})
 					Eventually(func() error {
 						podsPerPrometheusMetricKey := collectPrometheusMetrics(uniqueMetricKeys)
 						return containSameMetrics(ptpMonitoredEntriesByPod, podsPerPrometheusMetricKey)


### PR DESCRIPTION
PTP CI TC failure: PTP e2e tests prometheus Metrics reported by PTP pods Should all be reported by prometheus (Intermittent)