### PR TITLE
Fix webhook network policy

### DIFF
--- a/bindata/linuxptp/network-policy.yaml
+++ b/bindata/linuxptp/network-policy.yaml
@@ -24,7 +24,7 @@ metadata:
 spec:
   ingress:
     - ports:
-        - port: 4343
+        - port: 9443
           protocol: TCP
   podSelector:
     matchLabels:


### PR DESCRIPTION
The webhook network policy should be allowing port 9443 instead of port 4343, otherwise all ptpconfig creations are timing out.