### PR TITLE
Add 443 for webhook in network policy 

### DIFF
--- a/bindata/linuxptp/network-policy.yaml
+++ b/bindata/linuxptp/network-policy.yaml
@@ -26,6 +26,8 @@ spec:
     - ports:
         - port: 9443
           protocol: TCP
+        - port: 443
+          protocol: TCP
   podSelector:
     matchLabels:
       name: ptp-operator  # Target only ptp-operator Pods (adjust if needed)


### PR DESCRIPTION
network policy was preventing from  creation of ptp config due to   webhookdefinitions:
  - admissionReviewVersions:
    - v1
    containerPort: 443