### PR TITLE
Increase timeout of upstream CI tests from 30mins to 60mins

### DIFF
--- a/.github/workflows/aws-ci.yaml
+++ b/.github/workflows/aws-ci.yaml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   deploy-ec2:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - name: Remove ok-to-test label if new commit
         uses: actions/github-script@v7


### PR DESCRIPTION
This is to support adding more tests