### PR TITLE
Allow new T-BC settings through webhook

### DIFF
--- a/api/v1/ptpconfig_webhook.go
+++ b/api/v1/ptpconfig_webhook.go
@@ -144,6 +144,18 @@ func (r *PtpConfig) validate() error {
 					if !slices.Contains(clockTypes, v) {
 						return errors.New("clockType='" + v + "' is invalid; must be one of ['" + strings.Join(clockTypes, "', '") + "']")
 					}
+				case k == "inSyncConditionTimes":
+					// Validate inSyncConditionTimes is an unsigned integer
+					if _, err := strconv.ParseUint(v, 10, 32); err != nil {
+						return errors.New("inSyncConditionTimes='" + v + "' is invalid; must be an unsigned integer")
+					}
+				case k == "inSyncConditionThreshold":
+					// Validate inSyncConditionThreshold is an unsigned integer
+					if _, err := strconv.ParseUint(v, 10, 32); err != nil {
+						return errors.New("inSyncConditionThreshold='" + v + "' is invalid; must be an unsigned integer")
+					}
+				case k == "controlledProfile":
+					// Allow controlledProfile setting - no specific validation required for string
 				default:
 					return errors.New("profile.PtpSettings '" + k + "' is not a configurable setting")
 				}


### PR DESCRIPTION
This commit allows optional PTP settings used for T-BC configuration through the validating webhook. 
The profile.PtpSettings.inSyncConditionTimes and profile.PtpSettings.inSyncConditionThreshold together define the In-Sync condition for all T-BC transitions to the Locked state. To get to the Locked state, largest DPLL offset must be lower than inSyncConditionThreshold for inSyncConditionTimes consecutive times. 
The profile.PtpSettings.controlledProfile defines the relation between the TR profile and TT profile in the T-BC configuration
/cc @aneeshkp @josephdrichard @nocturnalastro @jzding 