### PR TITLE
CNF-19511: (CI only) update run-functests.sh for go version

### DIFF
--- a/hack/run-functests.sh
+++ b/hack/run-functests.sh
@@ -3,7 +3,7 @@ set -x
 # Set go version
 
 # T5CI_VERSION is used in CI pipeline. Do not set it when run locally
-if [[ "$T5CI_VERSION" =~ 4.1[0-9]+ ]]; then
+if [[ -n "$T5CI_VERSION" ]]; then
   export PATH=$(echo $PATH | sed -e 's#:/usr/local/1.20/go/bin:/go/bin##g')
   export PATH=$(echo $PATH | sed -e 's#:/usr/local/1.21.11/go/bin:/go/bin##g')
   source $HOME/golang-1.22.4


### PR DESCRIPTION
The T5CI_VERSION could be 4.2x. Check if $T5CI_VERSION is defined instead.