### PR TITLE
PTP-CI: Wait until the clock is in sync before checking initial roles

### DIFF
--- a/test/conformance/serial/ptp.go
+++ b/test/conformance/serial/ptp.go
@@ -147,6 +147,7 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 		var ptpPods *v1core.PodList
 		var fifoPriorities map[string]int64
 		var fullConfig testconfig.TestConfig
+		var grandmasterID *string
 		portEngine := ptptesthelper.PortEngine{}
 
 		execute.BeforeAll(func() {
@@ -167,6 +168,17 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 			if fullConfig.PtpModeDesired != testconfig.Discovery {
 				ptphelper.RestartPTPDaemon()
 			}
+
+			isExternalMaster := ptphelper.IsExternalGM()
+
+			if fullConfig.L2Config != nil && !isExternalMaster {
+				aLabel := pkg.PtpGrandmasterNodeLabel
+				aString, err := ptphelper.GetClockIDMaster(pkg.PtpGrandMasterPolicyName, &aLabel, nil, true)
+				grandmasterID = &aString
+				Expect(err).To(BeNil())
+			}
+			By("Check sync")
+			err = ptptesthelper.BasicClockSyncCheck(fullConfig, (*ptpv1.PtpConfig)(fullConfig.DiscoveredClockUnderTestPtpConfig), grandmasterID, metrics.MetricClockStateLocked, metrics.MetricRoleSlave, true)
 
 			portEngine.Initialize(fullConfig.DiscoveredClockUnderTestPod, fullConfig.DiscoveredFollowerInterfaces)
 
@@ -374,14 +386,7 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 					Skip("Test reserved for dual follower scenario")
 				}
 				Expect(len(fullConfig.DiscoveredFollowerInterfaces) == 2)
-				isExternalMaster := ptphelper.IsExternalGM()
-				var grandmasterID *string
-				if fullConfig.L2Config != nil && !isExternalMaster {
-					aLabel := pkg.PtpGrandmasterNodeLabel
-					aString, err := ptphelper.GetClockIDMaster(pkg.PtpGrandMasterPolicyName, &aLabel, nil, true)
-					grandmasterID = &aString
-					Expect(err).To(BeNil())
-				}
+
 				// Retry until there is no error or we timeout
 				Eventually(func() error {
 					return portEngine.RolesInOnly([]metrics.MetricRole{metrics.MetricRoleSlave, metrics.MetricRoleListening})

--- a/test/pkg/ptptesthelper/ptptesthelper.go
+++ b/test/pkg/ptptesthelper/ptptesthelper.go
@@ -474,7 +474,7 @@ func (p *PortEngine) TurnPortUp(port string) error {
 	stdout, stderr, err := pods.ExecCommand(client.Client, true, p.ClockPod, pkg.RecoveryNetworkOutageDaemonSetContainerName,
 		[]string{"ip", "link", "set", port, "up"})
 
-	logrus.Infof("Turning interface: %s in pod %s down, stdout: %s, stderr: %s", port, p.ClockPod.Name, stdout.String(), stderr.String())
+	logrus.Infof("Turning interface: %s in pod %s up, stdout: %s, stderr: %s", port, p.ClockPod.Name, stdout.String(), stderr.String())
 	return err
 }
 
@@ -493,7 +493,19 @@ func (p *PortEngine) TurnAllPortsUp() error {
 
 func (p *PortEngine) SetInitialRoles() (err error) {
 	p.InitialRoles, err = metrics.GetClockIfRoles(p.Ports, &p.ClockPod.Spec.NodeName)
-	return err
+	if err != nil {
+		return err
+	}
+
+	// Display initial roles per interface name
+	logrus.Infof("Setting up initial roles for interfaces on node %s:", p.ClockPod.Spec.NodeName)
+	for i, port := range p.Ports {
+		if i < len(p.InitialRoles) {
+			logrus.Infof("  Interface %s: %s", port, p.InitialRoles[i].String())
+		}
+	}
+
+	return nil
 }
 
 func (p *PortEngine) CheckClockRole(port0, port1 string, role0, role1 metrics.MetricRole) (err error) {


### PR DESCRIPTION
Initial clock roles are sometime captured incorrectly in downstream CI because the clock takes more time to sychronize