### PR TITLE
Skip PTP Events publisher enablement check if ENABLE_PTP_EVENT is false.

### DIFF
--- a/test/conformance/serial/ptp.go
+++ b/test/conformance/serial/ptp.go
@@ -74,15 +74,17 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 		// Setup verification
 		// if requested enabled  ptp events
 		It("Should check whether PTP operator needs to enable PTP events", func() {
-			By("Find if variable set to enable ptp events")
-			if event.Enable() {
-				apiVersion := event.GetDefaultApiVersion()
-				err := ptphelper.EnablePTPEvent(apiVersion, "")
-				Expect(err).To(BeNil(), "error when enable ptp event")
-				ptpConfig, err := client.Client.PtpV1Interface.PtpOperatorConfigs(pkg.PtpLinuxDaemonNamespace).Get(context.Background(), pkg.PtpConfigOperatorName, metav1.GetOptions{})
-				Expect(err).NotTo(HaveOccurred())
-				Expect(ptpConfig.Spec.EventConfig.EnableEventPublisher).Should(BeTrue(), "failed to enable ptp event")
+			if !event.Enable() {
+				Skip("Skipping as env var ENABLE_PTP_EVENT is not set or is set to false")
 			}
+
+			apiVersion := event.GetDefaultApiVersion()
+			err := ptphelper.EnablePTPEvent(apiVersion, "")
+			Expect(err).To(BeNil(), "error when enable ptp event")
+			ptpConfig, err := client.Client.PtpV1Interface.PtpOperatorConfigs(pkg.PtpLinuxDaemonNamespace).Get(context.Background(), pkg.PtpConfigOperatorName, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ptpConfig.Spec.EventConfig.EnableEventPublisher).Should(BeTrue(), "failed to enable ptp event")
+
 		})
 		It("Should check whether PTP operator appropriate resource exists", func() {
 			By("Getting list of available resources")


### PR DESCRIPTION
The tc was passing on either:
- ENABLE_PTP_EVENT is true and the events publisher is correctly enabled.
- ENABLE_PTP_EVENT is false <- misleading, as no actual test/assertion was performed.

I believe it must pass/fail only if env var ENABLE_PTP_EVENT is true. Otherwise, it can just be skipped.