### PR TITLE
Fix for PR #99: setting initial port role right before test and after clock sync

### DIFF
--- a/test/conformance/serial/ptp.go
+++ b/test/conformance/serial/ptp.go
@@ -169,12 +169,6 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 				ptphelper.RestartPTPDaemon()
 			}
 
-			ptphelper.WaitForPtpDaemonToExist()
-			fullConfig = testconfig.GetFullDiscoveredConfig(pkg.PtpLinuxDaemonNamespace, true)
-			podsRunningPTP4l, err := testconfig.GetPodsRunningPTP4l(&fullConfig)
-			Expect(err).NotTo(HaveOccurred())
-			ptphelper.WaitForPtpDaemonToBeReady(podsRunningPTP4l)
-
 			isExternalMaster := ptphelper.IsExternalGM()
 
 			if fullConfig.L2Config != nil && !isExternalMaster {

--- a/test/conformance/serial/ptp.go
+++ b/test/conformance/serial/ptp.go
@@ -382,6 +382,14 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 					grandmasterID = &aString
 					Expect(err).To(BeNil())
 				}
+				By("Check sync")
+				err = ptptesthelper.BasicClockSyncCheck(fullConfig, (*ptpv1.PtpConfig)(fullConfig.DiscoveredClockUnderTestPtpConfig),
+					grandmasterID, metrics.MetricClockStateLocked, metrics.MetricRoleSlave, true)
+
+				// Set initial roles
+				err = portEngine.SetInitialRoles()
+				Expect(err).To(BeNil())
+
 				// Retry until there is no error or we timeout
 				Eventually(func() error {
 					return portEngine.RolesInOnly([]metrics.MetricRole{metrics.MetricRoleSlave, metrics.MetricRoleListening})

--- a/test/pkg/ptptesthelper/ptptesthelper.go
+++ b/test/pkg/ptptesthelper/ptptesthelper.go
@@ -474,7 +474,7 @@ func (p *PortEngine) TurnPortUp(port string) error {
 	stdout, stderr, err := pods.ExecCommand(client.Client, true, p.ClockPod, pkg.RecoveryNetworkOutageDaemonSetContainerName,
 		[]string{"ip", "link", "set", port, "up"})
 
-	logrus.Infof("Turning interface: %s in pod %s up, stdout: %s, stderr: %s", port, p.ClockPod.Name, stdout.String(), stderr.String())
+	logrus.Infof("Turning interface: %s in pod %s down, stdout: %s, stderr: %s", port, p.ClockPod.Name, stdout.String(), stderr.String())
 	return err
 }
 
@@ -493,19 +493,7 @@ func (p *PortEngine) TurnAllPortsUp() error {
 
 func (p *PortEngine) SetInitialRoles() (err error) {
 	p.InitialRoles, err = metrics.GetClockIfRoles(p.Ports, &p.ClockPod.Spec.NodeName)
-	if err != nil {
-		return err
-	}
-
-	// Display initial roles per interface name
-	logrus.Infof("Setting up initial roles for interfaces on node %s:", p.ClockPod.Spec.NodeName)
-	for i, port := range p.Ports {
-		if i < len(p.InitialRoles) {
-			logrus.Infof("  Interface %s: %s", port, p.InitialRoles[i].String())
-		}
-	}
-
-	return nil
+	return err
 }
 
 func (p *PortEngine) CheckClockRole(port0, port1 string, role0, role1 metrics.MetricRole) (err error) {

--- a/test/pkg/ptptesthelper/ptptesthelper.go
+++ b/test/pkg/ptptesthelper/ptptesthelper.go
@@ -474,7 +474,7 @@ func (p *PortEngine) TurnPortUp(port string) error {
 	stdout, stderr, err := pods.ExecCommand(client.Client, true, p.ClockPod, pkg.RecoveryNetworkOutageDaemonSetContainerName,
 		[]string{"ip", "link", "set", port, "up"})
 
-		logrus.Infof("Turning interface: %s in pod %s up, stdout: %s, stderr: %s", port, p.ClockPod.Name, stdout.String(), stderr.String())
+	logrus.Infof("Turning interface: %s in pod %s up, stdout: %s, stderr: %s", port, p.ClockPod.Name, stdout.String(), stderr.String())
 	return err
 }
 
@@ -493,7 +493,19 @@ func (p *PortEngine) TurnAllPortsUp() error {
 
 func (p *PortEngine) SetInitialRoles() (err error) {
 	p.InitialRoles, err = metrics.GetClockIfRoles(p.Ports, &p.ClockPod.Spec.NodeName)
-	return err
+	if err != nil {
+		return err
+	}
+
+	// Display initial roles per interface name
+	logrus.Infof("Setting up initial roles for interfaces on node %s:", p.ClockPod.Spec.NodeName)
+	for i, port := range p.Ports {
+		if i < len(p.InitialRoles) {
+			logrus.Infof("  Interface %s: %s", port, p.InitialRoles[i].String())
+		}
+	}
+
+	return nil
 }
 
 func (p *PortEngine) CheckClockRole(port0, port1 string, role0, role1 metrics.MetricRole) (err error) {

--- a/test/pkg/ptptesthelper/ptptesthelper.go
+++ b/test/pkg/ptptesthelper/ptptesthelper.go
@@ -474,7 +474,7 @@ func (p *PortEngine) TurnPortUp(port string) error {
 	stdout, stderr, err := pods.ExecCommand(client.Client, true, p.ClockPod, pkg.RecoveryNetworkOutageDaemonSetContainerName,
 		[]string{"ip", "link", "set", port, "up"})
 
-	logrus.Infof("Turning interface: %s in pod %s down, stdout: %s, stderr: %s", port, p.ClockPod.Name, stdout.String(), stderr.String())
+		logrus.Infof("Turning interface: %s in pod %s up, stdout: %s, stderr: %s", port, p.ClockPod.Name, stdout.String(), stderr.String())
 	return err
 }
 


### PR DESCRIPTION
Fix for regression introduce by https://github.com/k8snetworkplumbingwg/ptp-operator/pull/99
the PR above initialized the port engine before all tests instead  but did not set the initial port roles before each tests. As a result the port roles change because previous tests perform a reboot. So the initial role at the beginning of the dual follower test might not match the real inital roles. 

Reverting also PR https://github.com/k8snetworkplumbingwg/ptp-operator/pull/105 since it is the same root cause 

Mock test in release repo: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_release/69707/rehearse-69707-periodic-ci-openshift-release-master-nightly-4.21-e2e-telco5g-ptp/1975633380347219968/artifacts/e2e-telco5g-ptp/telco5g-ptp-tests/artifacts/test_results_all.html
