### PR TITLE
Add readOnlyRootFilesystem=true to containers missing it

### DIFF
--- a/bindata/linuxptp/ptp-daemon.yaml
+++ b/bindata/linuxptp/ptp-daemon.yaml
@@ -36,6 +36,9 @@ spec:
         - name: cloud-event-proxy
           image: {{ .SideCar }}
           imagePullPolicy: {{ .ImagePullPolicy }}
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
           args:
             - "--metrics-addr=127.0.0.1:9091"
             - "--store-path=/store"
@@ -69,6 +72,9 @@ spec:
         - name: kube-rbac-proxy
           image: {{.KubeRbacProxy}}
           imagePullPolicy: {{.ImagePullPolicy}}
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
           args:
             - --logtostderr
             - --secure-listen-address=:8443
@@ -92,6 +98,7 @@ spec:
         - name: linuxptp-daemon-container
           securityContext:
             privileged: true
+            readOnlyRootFilesystem: true
           image: {{.Image}}
           imagePullPolicy: {{.ImagePullPolicy}}
           command: [ "/bin/bash", "-c", "--" ]

--- a/bundle/manifests/ptp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ptp-operator.clusterserviceversion.yaml
@@ -61,7 +61,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/openshift/origin-ptp-operator:4.21
-    createdAt: "2025-12-30T09:24:48Z"
+    createdAt: "2026-01-12T09:53:26Z"
     description: This software enables configuration of Precision Time Protocol(PTP)
       on Kubernetes. It detects hardware capable PTP devices on each node, and configures
       linuxptp processes such as ptp4l, phc2sys and timemaster.
@@ -433,6 +433,9 @@ spec:
                   requests:
                     cpu: 50m
                     memory: 100Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  readOnlyRootFilesystem: true
                 volumeMounts:
                 - mountPath: /tmp/k8s-webhook-server/serving-certs
                   name: cert

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -11,6 +11,9 @@ spec:
       containers:
       - name: kube-rbac-proxy
         image: quay.io/openshift/origin-kube-rbac-proxy:4.15
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"
@@ -21,6 +24,9 @@ spec:
         - containerPort: 8443
           name: https
       - name: manager
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
         args:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -10,6 +10,9 @@ spec:
     spec:
       containers:
       - name: ptp-operator
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
         ports:
         - containerPort: 9443
           name: webhook-server

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -45,6 +45,9 @@ spec:
           image: controller
           command:
           - ptp-operator
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
           args:
           - --enable-leader-election
           - --logtostderr

--- a/manifests/stable/ptp-operator.clusterserviceversion.yaml
+++ b/manifests/stable/ptp-operator.clusterserviceversion.yaml
@@ -61,7 +61,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/openshift/origin-ptp-operator:4.21
-    createdAt: "2025-12-30T09:24:48Z"
+    createdAt: "2026-01-12T09:53:26Z"
     description: This software enables configuration of Precision Time Protocol(PTP)
       on Kubernetes. It detects hardware capable PTP devices on each node, and configures
       linuxptp processes such as ptp4l, phc2sys and timemaster.
@@ -433,6 +433,9 @@ spec:
                   requests:
                     cpu: 50m
                     memory: 100Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  readOnlyRootFilesystem: true
                 volumeMounts:
                 - mountPath: /tmp/k8s-webhook-server/serving-certs
                   name: cert


### PR DESCRIPTION
`readOnlyRootFilesystem` prevents containers from writing to the root filesystem, reducing attack surface and improving security posture by limiting potential malicious file modifications and ensuring immutable container runtime.

`allowPrivilegeEscalation=false` prevents containers from gaining additional privileges beyond those initially granted, further hardening the security posture by blocking privilege escalation attacks.