### PR TITLE
Add retry when getting the port role

### DIFF
--- a/test/conformance/serial/ptp.go
+++ b/test/conformance/serial/ptp.go
@@ -404,8 +404,9 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 				err = ptptesthelper.BasicClockSyncCheck(fullConfig, (*ptpv1.PtpConfig)(fullConfig.DiscoveredClockUnderTestPtpConfig), grandmasterID, metrics.MetricClockStateLocked, metrics.MetricRoleSlave, true)
 				Expect(err).To(BeNil())
 				By("Check clock role")
-				err = portEngine.CheckClockRole(portEngine.Ports[0], portEngine.Ports[1], metrics.MetricRoleFaulty, metrics.MetricRoleSlave)
-				Expect(err).To(BeNil())
+				Eventually(func() error {
+					return portEngine.CheckClockRole(portEngine.Ports[0], portEngine.Ports[1], metrics.MetricRoleFaulty, metrics.MetricRoleSlave)
+				}, 120*time.Second, 1*time.Second).Should(BeNil())
 
 				By("Port1: down")
 				err = portEngine.TurnPortDown(portEngine.Ports[1])
@@ -417,8 +418,9 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 				err = ptptesthelper.BasicClockSyncCheck(fullConfig, (*ptpv1.PtpConfig)(fullConfig.DiscoveredClockUnderTestPtpConfig), grandmasterID, metrics.MetricClockStateFreeRun, metrics.MetricRoleFaulty, false)
 				Expect(err).To(BeNil())
 				By("Check clock role")
-				err = portEngine.CheckClockRole(portEngine.Ports[0], portEngine.Ports[1], metrics.MetricRoleFaulty, metrics.MetricRoleFaulty)
-				Expect(err).To(BeNil())
+				Eventually(func() error {
+					return portEngine.CheckClockRole(portEngine.Ports[0], portEngine.Ports[1], metrics.MetricRoleFaulty, metrics.MetricRoleFaulty)
+				}, 120*time.Second, 1*time.Second).Should(BeNil())
 
 				By("Port1: up")
 				err = portEngine.TurnPortUp(portEngine.Ports[1])
@@ -427,8 +429,9 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 				err = ptptesthelper.BasicClockSyncCheck(fullConfig, (*ptpv1.PtpConfig)(fullConfig.DiscoveredClockUnderTestPtpConfig), grandmasterID, metrics.MetricClockStateLocked, metrics.MetricRoleSlave, true)
 				Expect(err).To(BeNil())
 				By("Check clock role")
-				err = portEngine.CheckClockRole(portEngine.Ports[0], portEngine.Ports[1], metrics.MetricRoleFaulty, metrics.MetricRoleSlave)
-				Expect(err).To(BeNil())
+				Eventually(func() error {
+					return portEngine.CheckClockRole(portEngine.Ports[0], portEngine.Ports[1], metrics.MetricRoleFaulty, metrics.MetricRoleSlave)
+				}, 120*time.Second, 1*time.Second).Should(BeNil())
 
 				By("Port0: up")
 				err = portEngine.TurnPortUp(portEngine.Ports[0])
@@ -437,8 +440,9 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 				err = ptptesthelper.BasicClockSyncCheck(fullConfig, (*ptpv1.PtpConfig)(fullConfig.DiscoveredClockUnderTestPtpConfig), grandmasterID, metrics.MetricClockStateLocked, metrics.MetricRoleSlave, true)
 				Expect(err).To(BeNil())
 				By("Check clock role")
-				err = portEngine.CheckClockRole(portEngine.Ports[0], portEngine.Ports[1], portEngine.InitialRoles[0], portEngine.InitialRoles[1])
-				Expect(err).To(BeNil())
+				Eventually(func() error {
+					return portEngine.CheckClockRole(portEngine.Ports[0], portEngine.Ports[1], portEngine.InitialRoles[0], portEngine.InitialRoles[1])
+				}, 120*time.Second, 1*time.Second).Should(BeNil())
 
 				By("Remove Grandmaster")
 				err := client.Client.PtpV1Interface.PtpConfigs(pkg.PtpLinuxDaemonNamespace).Delete(context.Background(), testconfig.GlobalConfig.DiscoveredGrandMasterPtpConfig.Name, metav1.DeleteOptions{})

--- a/test/pkg/metrics/metrics.go
+++ b/test/pkg/metrics/metrics.go
@@ -148,7 +148,7 @@ func CheckClockRole(roles []MetricRole, Ifs []string, nodeName *string) (err err
 			return fmt.Errorf("error strconv for roleString=%s, err:%s", roleString, err)
 		}
 		if MetricRole(roleInt) != roles[index] {
-			return fmt.Errorf(fmt.Sprintf("incorrect role, role expected=%d(%s), role observed=%d(%s)", roles[index], roles[index].String(), roleInt, MetricRole(roleInt).String()))
+			return fmt.Errorf(fmt.Sprintf("incorrect role for %s, role expected=%d(%s), role observed=%d(%s)", Ifs[index], roles[index], roles[index].String(), roleInt, MetricRole(roleInt).String()))
 		}
 	}
 	return nil


### PR DESCRIPTION
Adding retry to port role check to give more time to the port state to transition.
Also improving the logs to include interface names.