### PR TITLE
Update CI to use new Netdevsim image

### DIFF
--- a/.github/workflows/aws-ci.yaml
+++ b/.github/workflows/aws-ci.yaml
@@ -60,7 +60,7 @@ jobs:
         id: launch
         run: |
           INSTANCE_ID=$(aws ec2 run-instances \
-            --image-id ami-0f7270e9a0e492eac \
+            --image-id ami-03f4e4724537a687c \
             --subnet-id subnet-04ee218fe8f32cad5 \
             --instance-type m6a.xlarge \
             --security-group-ids sg-05e700edc2ed0a2d5 \

--- a/scripts/configpair.sh
+++ b/scripts/configpair.sh
@@ -12,8 +12,8 @@ CONTAINER2=$7
 PCI1=$8
 PCI2=$9
 
-NSIM_DEV_1_SYS=/sys/bus/netdevsim/devices/netdevsim$NSIM_DEV_1_ID
-NSIM_DEV_2_SYS=/sys/bus/netdevsim/devices/netdevsim$NSIM_DEV_2_ID
+NSIM_DEV_1_SYS=/sys/bus/pci/devices/$PCI1
+NSIM_DEV_2_SYS=/sys/bus/pci/devices/$PCI2
 
 NSIM_DEV_SYS_NEW=/sys/bus/netdevsim/new_device
 NSIM_DEV_SYS_DEL=/sys/bus/netdevsim/del_device

--- a/scripts/install-tools.sh
+++ b/scripts/install-tools.sh
@@ -2,6 +2,9 @@
 set -x
 set -euo pipefail
 
+# Install tools required for testing
+yum install -y podman pciutils helm
+
 ARCH=$(uname -m)
 if [[ "$ARCH" == "x86_64" ]]; then
     GOARCH="amd64"

--- a/scripts/reset-devices.sh
+++ b/scripts/reset-devices.sh
@@ -3,6 +3,5 @@ set -x
 set -euo pipefail
 
 modprobe -r netdevsim 
-modprobe -r openvswitch 
-modprobe netdevsim 
+modprobe netdevsim pci_bus_nr=0x1f
 modprobe openvswitch

--- a/scripts/run-on-vm.sh
+++ b/scripts/run-on-vm.sh
@@ -11,9 +11,6 @@ echo "Now in: $(pwd)"
 
 export GOMAXPROCS=$(nproc)
 
-# disable firewall
-systemctl disable firewalld --now
-
 source ./install-tools.sh
 
 # refresh bashrc
@@ -26,13 +23,17 @@ go mod vendor
 
 # Clean containers
 kind delete cluster --name kind-netdevsim || true
-podman rm switch1 || true
+podman rm -f switch1 || true
 
 # Build images
 cd ../ptp-tools
 # configure images for local registry
 export IMG_PREFIX="$VM_IP/test"
 
+# Clean all images and manifests
+make -j 5 podman-cleanall
+
+# Build images
 make -j 5 podman-buildall
 cd -
 


### PR DESCRIPTION
This PR updates the Upstream CI to use the new Netdevsim image. Since it modifies github workflow, it cannot be tested here but passed successfully here: https://github.com/k8snetworkplumbingwg/ptp-operator/actions/runs/18756655518

Highlights:
Detect platform architecture (x86_64/aarch64) and set PCI prefix accordingly
Use 0000:1F prefix for x86_64, 0001:1F for aarch64 Replace hardcoded PCI addresses with dynamic PCI_PREFIX variable Update all network device pairs to use architecture-specific addressing Add installation of podman, pciutils, helm in install-tools.sh Configure netdevsim with pci_bus_nr=0x1f parameter in reset-devices.sh Add image cleanup step before building in run-on-vm.sh Force remove switch1 container to prevent conflicts"

Fix PCI address format and update AWS AMI in test scripts Update AWS EC2 AMI ID in GitHub workflow
Change PCI address format from colon to dot notation (01:0 -> 01.0) Update configpair.sh to use PCI bus device paths instead of netdevsim paths Apply PCI format fixes across all network device pairs in configSwitch2.sh

Assisted-by: Cursor AI Editor