### PR TITLE
Fix for dual follower test flakiness

### DIFF
--- a/test/pkg/ptptesthelper/ptptesthelper.go
+++ b/test/pkg/ptptesthelper/ptptesthelper.go
@@ -542,7 +542,7 @@ func (p *PortEngine) RolesInOnly(roles []metrics.MetricRole) (err error) {
 	if len(roles) != len(p.InitialRoles) {
 		return fmt.Errorf("len(InitialRoles) != len(roles)")
 	}
-	sortedInitialRoles := p.InitialRoles
+	sortedInitialRoles := slices.Clone(p.InitialRoles)
 	slices.Sort(sortedInitialRoles)
 	slices.Sort(roles)
 


### PR DESCRIPTION
    Fix corruption of initial port table. The inital values were sorted by mistake. Instead make a copy of the table first