### PR TITLE
Lowering the overall timeout to 55 minutes from 60 

### DIFF
--- a/.github/workflows/aws-ci.yaml
+++ b/.github/workflows/aws-ci.yaml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   deploy-ec2:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 55
     steps:
       - name: Remove ok-to-test label if new commit
         uses: actions/github-script@v7


### PR DESCRIPTION
This is to leave a 5 minutes buffer to clean up the VM in case we time out (the aws token duration is 60 mins). Otherwise, in this case, VM are left dangling.