### PR TITLE
Allow environment override of ImagePullPolicy

### DIFF
--- a/bindata/linuxptp/ptp-daemon.yaml
+++ b/bindata/linuxptp/ptp-daemon.yaml
@@ -35,7 +35,7 @@ spec:
         {{ if (eq .EnableEventPublisher true) }}
         - name: cloud-event-proxy
           image: {{ .SideCar }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{ .ImagePullPolicy }}
           args:
             - "--metrics-addr=127.0.0.1:9091"
             - "--store-path=/store"
@@ -93,7 +93,7 @@ spec:
           securityContext:
             privileged: true
           image: {{.Image}}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{.ImagePullPolicy}}
           command: [ "/bin/bash", "-c", "--" ]
           args:
           {{ $cmd := "/usr/local/bin/ptp --alsologtostderr -v 10" }}

--- a/controllers/ptpoperatorconfig_controller.go
+++ b/controllers/ptpoperatorconfig_controller.go
@@ -217,6 +217,10 @@ func (r *PtpOperatorConfigReconciler) syncLinuxptpDaemon(ctx context.Context, de
 
 	data := render.MakeRenderData()
 	data.Data["Image"] = os.Getenv("LINUXPTP_DAEMON_IMAGE")
+	data.Data["ImagePullPolicy"] = "IfNotPresent"
+	if overridePolicy, ok := os.LookupEnv("IMAGE_PULL_POLICY"); ok {
+		data.Data["ImagePullPolicy"] = overridePolicy
+	}
 	data.Data["Namespace"] = names.Namespace
 	data.Data["ReleaseVersion"] = os.Getenv("RELEASEVERSION")
 	data.Data["KubeRbacProxy"] = os.Getenv("KUBE_RBAC_PROXY_IMAGE")


### PR DESCRIPTION
This allows developers and QE to override the default ImagePullPolicy for both
the linuxtp-daemon and cloud-event-proxy pod images, by setting
IMAGE_PULL_POLICY in the ptp-operator environment.

Defaults to IfNotPresent if unset.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>
