### PR TITLE
Use environment override of ImagePullPolicy, in CI instead of sed.

### DIFF
--- a/bindata/linuxptp/ptp-daemon.yaml
+++ b/bindata/linuxptp/ptp-daemon.yaml
@@ -68,7 +68,7 @@ spec:
         {{ end }}
         - name: kube-rbac-proxy
           image: {{.KubeRbacProxy}}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{.ImagePullPolicy}}
           args:
             - --logtostderr
             - --secure-listen-address=:8443

--- a/ptp-tools/Makefile
+++ b/ptp-tools/Makefile
@@ -30,7 +30,6 @@ podman-buildall: $(foreach v, $(VALUES), podman-build-$(v))
 
 podman-build-%:
 	@echo "Platform: $(PLATFORM)"
-	sed -i 's/IfNotPresent/Always/g' ../bindata/linuxptp/ptp-daemon.yaml
 	$(MAKE) clean-image VAR=$*;
 	$(MAKE) build-image VAR=$*
 

--- a/ptp-tools/scripts/customize-env.sh
+++ b/ptp-tools/scripts/customize-env.sh
@@ -13,6 +13,7 @@ spec:
     spec:
       containers:
         - name: ptp-operator
+          imagePullPolicy: Always
           env:
             - name: OPERATOR_NAME
               value: "ptp-operator"
@@ -24,6 +25,6 @@ spec:
               value: "$IMG_PREFIX:krp"
             - name: SIDECAR_EVENT_IMAGE
               value: "$IMG_PREFIX:cep"
+            - name: IMAGE_PULL_POLICY
+              value: "Always"
 EOF
-
-sed -i 's/IfNotPresent/Always/g' $ENV_PATH/manager.yaml


### PR DESCRIPTION
PR below prevents CI script to replace image pull policy. Using new method instead. See:
https://github.com/k8snetworkplumbingwg/ptp-operator/pull/132