### PR TITLE
Add clock type to hardwareconfig

### DIFF
--- a/api/v2alpha1/hardwareconfig_types.go
+++ b/api/v2alpha1/hardwareconfig_types.go
@@ -218,10 +218,11 @@ type Subsystem struct {
 	HardwareSpecificDefinitions string `json:"hardwareSpecificDefinitions,omitempty" yaml:"hardwareSpecificDefinitions,omitempty"`
 
 	// DPLL contains the DPLL configuration for this subsystem
-	DPLL DPLL `json:"dpll" yaml:"dpll"`
+	// When clockType is specified, this can be omitted and will be derived from ptpProfile and vendor defaults.
+	DPLL DPLL `json:"dpll,omitempty" yaml:"dpll,omitempty"`
 
 	// Ethernet defines one or more Ethernet subsystems associated with this synchronization subsystem
-	Ethernet []Ethernet `json:"ethernet" yaml:"ethernet"`
+	Ethernet []Ethernet `json:"ethernet,omitempty" yaml:"ethernet,omitempty"`
 }
 
 // HoldoverParameters defines the combination of the DPLL complex hardware parameters and the holdover specification threshold.
@@ -266,7 +267,8 @@ type DPLL struct {
 type Ethernet struct {
 	// Ports is a list of Ethernet port names associated with this Ethernet subsystem.
 	// The default port, or the port used to address the network adapter configuration through sysfs, is listed first.
-	Ports []string `json:"ports" yaml:"ports"`
+	// When clockType is specified, this can be omitted and will be derived from ptpconfig leading interfaces.
+	Ports []string `json:"ports,omitempty" yaml:"ports,omitempty"`
 }
 
 // PinConfig represents pin configuration for DPLL phase or frequency signals in a dictionary format
@@ -614,6 +616,11 @@ type HardwareConfigList struct {
 type HardwareProfile struct {
 	// Name is the unique identifier for this hardware profile
 	Name *string `json:"name" yaml:"name"`
+	// ClockType specifies the clock mode: "T-BC", "T-GM", or "APTS"
+	// When specified, behavior templates are loaded from vendor defaults based on
+	// each subsystem's hardwareSpecificDefinitions and resolved with user-provided overrides.
+	// If not specified, the behavior section must be explicitly provided in ClockChain.
+	ClockType *string `json:"clockType,omitempty" yaml:"clockType,omitempty"`
 
 	// ClockChain contains the complete clock chain configuration for this profile
 	ClockChain *ClockChain `json:"clockChain" yaml:"clockChain"`

--- a/api/v2alpha1/zz_generated.deepcopy.go
+++ b/api/v2alpha1/zz_generated.deepcopy.go
@@ -421,6 +421,11 @@ func (in *HardwareProfile) DeepCopyInto(out *HardwareProfile) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ClockType != nil {
+		in, out := &in.ClockType, &out.ClockType
+		*out = new(string)
+		**out = **in
+	}
 	if in.ClockChain != nil {
 		in, out := &in.ClockChain, &out.ClockChain
 		*out = new(ClockChain)

--- a/bundle/manifests/ptp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ptp-operator.clusterserviceversion.yaml
@@ -61,7 +61,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/openshift/origin-ptp-operator:4.21
-    createdAt: "2025-11-20T09:31:49Z"
+    createdAt: "2025-12-04T10:53:44Z"
     description: This software enables configuration of Precision Time Protocol(PTP)
       on Kubernetes. It detects hardware capable PTP devices on each node, and configures
       linuxptp processes such as ptp4l, phc2sys and timemaster.

--- a/bundle/manifests/ptp.openshift.io_hardwareconfigs.yaml
+++ b/bundle/manifests/ptp.openshift.io_hardwareconfigs.yaml
@@ -315,8 +315,9 @@ spec:
                             Each subsystem represents a cohesive unit that can operate independently or in coordination with other subsystems.
                           properties:
                             dpll:
-                              description: DPLL contains the DPLL configuration for
-                                this subsystem
+                              description: |-
+                                DPLL contains the DPLL configuration for this subsystem
+                                When clockType is specified, this can be omitted and will be derived from ptpProfile and vendor defaults.
                               properties:
                                 frequencyInputs:
                                   additionalProperties:
@@ -590,11 +591,10 @@ spec:
                                     description: |-
                                       Ports is a list of Ethernet port names associated with this Ethernet subsystem.
                                       The default port, or the port used to address the network adapter configuration through sysfs, is listed first.
+                                      When clockType is specified, this can be omitted and will be derived from ptpconfig leading interfaces.
                                     items:
                                       type: string
                                     type: array
-                                required:
-                                - ports
                                 type: object
                               type: array
                             hardwareSpecificDefinitions:
@@ -606,14 +606,19 @@ spec:
                                 this subsystem
                               type: string
                           required:
-                          - dpll
-                          - ethernet
                           - name
                           type: object
                         type: array
                     required:
                     - structure
                     type: object
+                  clockType:
+                    description: |-
+                      ClockType specifies the clock mode: "T-BC", "T-GM", or "APTS"
+                      When specified, behavior templates are loaded from vendor defaults based on
+                      each subsystem's hardwareSpecificDefinitions and resolved with user-provided overrides.
+                      If not specified, the behavior section must be explicitly provided in ClockChain.
+                    type: string
                   description:
                     description: Description provides optional context about this
                       hardware profile

--- a/config/crd/bases/ptp.openshift.io_hardwareconfigs.yaml
+++ b/config/crd/bases/ptp.openshift.io_hardwareconfigs.yaml
@@ -315,8 +315,9 @@ spec:
                             Each subsystem represents a cohesive unit that can operate independently or in coordination with other subsystems.
                           properties:
                             dpll:
-                              description: DPLL contains the DPLL configuration for
-                                this subsystem
+                              description: |-
+                                DPLL contains the DPLL configuration for this subsystem
+                                When clockType is specified, this can be omitted and will be derived from ptpProfile and vendor defaults.
                               properties:
                                 frequencyInputs:
                                   additionalProperties:
@@ -590,11 +591,10 @@ spec:
                                     description: |-
                                       Ports is a list of Ethernet port names associated with this Ethernet subsystem.
                                       The default port, or the port used to address the network adapter configuration through sysfs, is listed first.
+                                      When clockType is specified, this can be omitted and will be derived from ptpconfig leading interfaces.
                                     items:
                                       type: string
                                     type: array
-                                required:
-                                - ports
                                 type: object
                               type: array
                             hardwareSpecificDefinitions:
@@ -606,14 +606,19 @@ spec:
                                 this subsystem
                               type: string
                           required:
-                          - dpll
-                          - ethernet
                           - name
                           type: object
                         type: array
                     required:
                     - structure
                     type: object
+                  clockType:
+                    description: |-
+                      ClockType specifies the clock mode: "T-BC", "T-GM", or "APTS"
+                      When specified, behavior templates are loaded from vendor defaults based on
+                      each subsystem's hardwareSpecificDefinitions and resolved with user-provided overrides.
+                      If not specified, the behavior section must be explicitly provided in ClockChain.
+                    type: string
                   description:
                     description: Description provides optional context about this
                       hardware profile

--- a/manifests/stable/ptp-operator.clusterserviceversion.yaml
+++ b/manifests/stable/ptp-operator.clusterserviceversion.yaml
@@ -61,7 +61,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/openshift/origin-ptp-operator:4.21
-    createdAt: "2025-11-20T09:31:49Z"
+    createdAt: "2025-12-04T10:53:44Z"
     description: This software enables configuration of Precision Time Protocol(PTP)
       on Kubernetes. It detects hardware capable PTP devices on each node, and configures
       linuxptp processes such as ptp4l, phc2sys and timemaster.

--- a/manifests/stable/ptp.openshift.io_hardwareconfigs.yaml
+++ b/manifests/stable/ptp.openshift.io_hardwareconfigs.yaml
@@ -315,8 +315,9 @@ spec:
                             Each subsystem represents a cohesive unit that can operate independently or in coordination with other subsystems.
                           properties:
                             dpll:
-                              description: DPLL contains the DPLL configuration for
-                                this subsystem
+                              description: |-
+                                DPLL contains the DPLL configuration for this subsystem
+                                When clockType is specified, this can be omitted and will be derived from ptpProfile and vendor defaults.
                               properties:
                                 frequencyInputs:
                                   additionalProperties:
@@ -590,11 +591,10 @@ spec:
                                     description: |-
                                       Ports is a list of Ethernet port names associated with this Ethernet subsystem.
                                       The default port, or the port used to address the network adapter configuration through sysfs, is listed first.
+                                      When clockType is specified, this can be omitted and will be derived from ptpconfig leading interfaces.
                                     items:
                                       type: string
                                     type: array
-                                required:
-                                - ports
                                 type: object
                               type: array
                             hardwareSpecificDefinitions:
@@ -606,14 +606,19 @@ spec:
                                 this subsystem
                               type: string
                           required:
-                          - dpll
-                          - ethernet
                           - name
                           type: object
                         type: array
                     required:
                     - structure
                     type: object
+                  clockType:
+                    description: |-
+                      ClockType specifies the clock mode: "T-BC", "T-GM", or "APTS"
+                      When specified, behavior templates are loaded from vendor defaults based on
+                      each subsystem's hardwareSpecificDefinitions and resolved with user-provided overrides.
+                      If not specified, the behavior section must be explicitly provided in ClockChain.
+                    type: string
                   description:
                     description: Description provides optional context about this
                       hardware profile


### PR DESCRIPTION
This commit adds optional clock type to the hardwareconfig API and makes DPLL and Ethernet parts of the clock chain subsystem optional. This allows simplification of the user interface, where all the behavior details can be derived from ptpConfig and predefined hardware vendor details. For example, the T-BC hardware definition can be simplified as follows:
```
clockType: T-BC
clockChain:
      structure:
        - name: leader 
           # DPLL, sequences, labels, and Ports will be derived from ptpconfig 
           hardwareSpecificDefinitions: intel/e825 
 relatedPtpProfileName: 01-tbc-tr
```
The ability to override the defaults and configure flexible topologies will be preserved

/cc @josephdrichard @lack @nocturnalastro 