### PR TITLE
PTP CI: test PTP Operator lease acquisition

### DIFF
--- a/test/pkg/consts.go
+++ b/test/pkg/consts.go
@@ -16,6 +16,7 @@ const (
 	PtpOperatorDeploymentName      = "ptp-operator"
 	PtPOperatorPodsLabel           = "name=ptp-operator"
 	PtpDaemonsetName               = "linuxptp-daemon"
+	PtpOperatorLeaseID             = "ptp.openshift.io"
 
 	PtpResourcesGroupVersionPrefix  = "ptp.openshift.io/v"
 	PtpResourcesNameOperatorConfigs = "ptpoperatorconfigs"
@@ -46,6 +47,7 @@ const (
 	Timeout10Seconds           = 10 * time.Second
 	Timeout1Seconds            = 1 * time.Second
 	TimeoutInterval2Seconds    = 2 * time.Second
+	TimeoutInterval5Seconds    = 5 * time.Second
 
 	MasterOffsetLowerBound  = -100
 	MasterOffsetHigherBound = 100


### PR DESCRIPTION
Add e2e test to verify ptp-operator re-acquires leader election lease within 5 minutes after pod deletion. This validates operator high-availability and recovery behavior.