### PR TITLE
test: add webhook underscore validation and eventConfig update tests for ptpoperatorconfig

### DIFF
--- a/test/conformance/serial/ptp.go
+++ b/test/conformance/serial/ptp.go
@@ -246,6 +246,76 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 			logrus.Infof("successfully acquired lease %s/%s", pkg.PtpLinuxDaemonNamespace, pkg.PtpOperatorLeaseID)
 		})
 
+		// Webhook validation test for underscore profile names
+		It("Should accept underscores in ptp-config profile names for HA profiles", func() {
+			By("Creating a PtpConfig with underscore profile names in haProfiles")
+			err := testconfig.CreatePtpConfigWithUnderscoreProfileNames()
+			Expect(err).ToNot(HaveOccurred(), "webhook should accept underscores in profile names")
+			logrus.Infof("Successfully created PtpConfig with underscore profile names: test_profile_bc1, test_profile_bc2")
+
+			By("Verifying the PtpConfig was created with correct haProfiles")
+			ptpConfig, err := client.Client.PtpConfigs(pkg.PtpLinuxDaemonNamespace).Get(context.Background(), pkg.PtpUnderscoreTestPolicyName, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(ptpConfig.Spec.Profile)).To(BeNumerically(">", 0), "no profiles found in PtpConfig")
+
+			haProfiles, exists := ptpConfig.Spec.Profile[0].PtpSettings["haProfiles"]
+			Expect(exists).To(BeTrue(), "haProfiles setting should exist")
+			Expect(haProfiles).To(ContainSubstring("test_profile_bc1"), "haProfiles should contain underscore profile name")
+			Expect(haProfiles).To(ContainSubstring("test_profile_bc2"), "haProfiles should contain underscore profile name")
+			logrus.Infof("Verified haProfiles contains underscore names: %s", haProfiles)
+
+			// cleaning up the test PtpConfig
+			err = testconfig.DeletePtpConfigWithUnderscoreProfileNames()
+			Expect(err).ToNot(HaveOccurred(), "failed to delete test PtpConfig")
+			logrus.Infof("Successfully deleted test PtpConfig")
+		})
+
+		// PtpOperatorConfig eventConfig test
+		It("Should be able to update and read ptpoperatorconfig eventConfig.EnableEventPublisher", func() {
+			By("Getting the current PtpOperatorConfig")
+			ptpOperatorConfig, err := client.Client.PtpV1Interface.PtpOperatorConfigs(pkg.PtpLinuxDaemonNamespace).Get(context.Background(), pkg.PtpConfigOperatorName, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			// Store original value to restore later
+			var originalEnableEventPublisher bool
+			if ptpOperatorConfig.Spec.EventConfig != nil {
+				originalEnableEventPublisher = ptpOperatorConfig.Spec.EventConfig.EnableEventPublisher
+			}
+			logrus.Infof("Original EnableEventPublisher value: %v", originalEnableEventPublisher)
+
+			By("Setting EnableEventPublisher to true")
+			if ptpOperatorConfig.Spec.EventConfig == nil {
+				ptpOperatorConfig.Spec.EventConfig = &ptpv1.PtpEventConfig{}
+			}
+			ptpOperatorConfig.Spec.EventConfig.EnableEventPublisher = true
+			_, err = client.Client.PtpOperatorConfigs(pkg.PtpLinuxDaemonNamespace).Update(context.Background(), ptpOperatorConfig, metav1.UpdateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Reading back and verifying EnableEventPublisher is true")
+			ptpOperatorConfig, err = client.Client.PtpV1Interface.PtpOperatorConfigs(pkg.PtpLinuxDaemonNamespace).Get(context.Background(), pkg.PtpConfigOperatorName, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ptpOperatorConfig.Spec.EventConfig).ToNot(BeNil(), "EventConfig should not be nil")
+			Expect(ptpOperatorConfig.Spec.EventConfig.EnableEventPublisher).To(BeTrue(), "EnableEventPublisher should be true")
+			logrus.Infof("Verified EnableEventPublisher is set to true")
+
+			By("Setting EnableEventPublisher to false")
+			ptpOperatorConfig.Spec.EventConfig.EnableEventPublisher = false
+			_, err = client.Client.PtpOperatorConfigs(pkg.PtpLinuxDaemonNamespace).Update(context.Background(), ptpOperatorConfig, metav1.UpdateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Reading back and verifying EnableEventPublisher is false")
+			ptpOperatorConfig, err = client.Client.PtpV1Interface.PtpOperatorConfigs(pkg.PtpLinuxDaemonNamespace).Get(context.Background(), pkg.PtpConfigOperatorName, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ptpOperatorConfig.Spec.EventConfig.EnableEventPublisher).To(BeFalse(), "EnableEventPublisher should be false")
+			logrus.Infof("Verified EnableEventPublisher is set to false")
+
+			By("Restoring original EnableEventPublisher value")
+			ptpOperatorConfig.Spec.EventConfig.EnableEventPublisher = originalEnableEventPublisher
+			_, err = client.Client.PtpOperatorConfigs(pkg.PtpLinuxDaemonNamespace).Update(context.Background(), ptpOperatorConfig, metav1.UpdateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			logrus.Infof("Restored EnableEventPublisher to original value: %v", originalEnableEventPublisher)
+		})
+
 	})
 
 	Describe("PTP e2e tests", func() {

--- a/test/pkg/consts.go
+++ b/test/pkg/consts.go
@@ -34,6 +34,7 @@ const (
 	PtpSlave2PolicyName         = "test-slave2"
 	PtpDualNicBCHAPolicyName    = "test-dual-nic-bc-ha"
 	PtpTempPolicyName           = "temp"
+	PtpUnderscoreTestPolicyName = "test-underscore-profile"
 
 	// node labels
 	PtpGrandmasterNodeLabel    = "ptp/test-grandmaster"


### PR DESCRIPTION
## Overview

This PR adds two functional tests for the PTP Operator: one validates that the admission webhook correctly accepts underscores in PtpConfig profile names (specifically for HA profiles), and another verifies the ability to update and read the `eventConfig.EnableEventPublisher` field in PtpOperatorConfig. These tests ensure proper validation behavior and API functionality. [CNF-16774](https://issues.redhat.com/browse/CNF-16774)

---

## Files Changed

| File Changed | Explanation |
| :--- | :--- |
| `test/conformance/serial/ptp.go` | Added two test cases: webhook underscore validation and eventConfig update verification |
| `test/pkg/testconfig/testconfig.go` | Added `CreatePtpConfigWithUnderscoreProfileNames()` and `DeletePtpConfigWithUnderscoreProfileNames()` helper functions |
| `test/pkg/consts.go` | Added `PtpUnderscoreTestPolicyName` constant |

---

## Technical Implementation

### Testing
- **New test:** `"Should accept underscores in ptp-config profile names for HA profiles"`
  - Creates a PtpConfig with underscore profile names (`test_profile_bc1`, `test_profile_bc2`)
  - Verifies webhook accepts the configuration
  - Validates haProfiles setting contains underscore names
  - Cleans up test resources

- **New test:** `"Should be able to update and read ptpoperatorconfig eventConfig.EnableEventPublisher"`
  - Gets current PtpOperatorConfig and stores original value
  - Sets `EnableEventPublisher` to `true`, reads back and verifies
  - Sets `EnableEventPublisher` to `false`, reads back and verifies
  - Restores original value

### Infrastructure
- **Helper added to `testconfig.go`:**
  - `CreatePtpConfigWithUnderscoreProfileNames()` — creates PtpConfig with underscore names in haProfiles
  - `DeletePtpConfigWithUnderscoreProfileNames()` — cleanup function

- **Constant added to `consts.go`:**
  - `PtpUnderscoreTestPolicyName` — test policy name for underscore validation

---

## Checklist

- [x] New test cases added for webhook validation
- [x] New test case added for eventConfig API verification
- [x] Helper functions added for test setup/teardown
- [x] Constants extracted for reusability
- [x] No breaking changes to public APIs