### PR TITLE
Add development time QoL improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ test/conformance/parallel/linuxptp-daemon-*
 .env
 catalog/*
 catalog.Dockerfile
+# Backup files created during build
+*.bak
+config/manager/env.yaml.bak


### PR DESCRIPTION
This commit adds several improvements for development time overrides:
- allow custom kubeconfig for `install`, `deploy`, `uninstall` and `undeploy` targets
- allow specifying architecture as a build parameter
- allow overrides of operator images in CSVs and templates

[CNF-21023](https://issues.redhat.com/browse/CNF-21023)

