### PR TITLE
test: add MITM attack resilience test and refactor security secrets (CNF-19576)

### DIFF
--- a/test/pkg/consts.go
+++ b/test/pkg/consts.go
@@ -63,6 +63,11 @@ const (
 	RecoveryNetworkOutageDaemonSetNamespace     = "ptp-network-outage-recovery"
 	RecoveryNetworkOutageDaemonSetName          = "ptp-network-outage-recovery"
 	RecoveryNetworkOutageDaemonSetContainerName = "container-00"
+
+	// PTP Security sa_file paths for ptp4l configuration
+	SaFileSecurityConf     = "sa_file /etc/ptp-secret-mount/ptp-security-conf/ptp-security.conf"
+	SaFileMismatchConf     = "sa_file /etc/ptp-secret-mount/ptp-security-mismatch/ptp-security.conf"
+	SaFileMITMAttackerConf = "sa_file /etc/ptp-secret-mount/ptp-mitm-attacker-secret/ptp-security.conf"
 )
 
 const (


### PR DESCRIPTION
## Summary

Add a functional test for MITM (Man-in-the-Middle) attack resilience when TLV Authentication is enabled, and refactor security-related test infrastructure for better maintainability. [CNF-19576](https://issues.redhat.com/browse/CNF-19576)

---

## Files Changed

| File | Change |
|------|--------|
| `test/conformance/serial/ptp.go` | Added MITM attack test case; refactored existing security tests to use shared helpers |
| `test/pkg/testconfig/testconfig.go` | Added secret creation helpers (`CreateMITMAttackerSecret`, `CreateMismatchSecret`) and secret name constants |
| `test/pkg/consts.go` | Added `sa_file` path constants for PTP security configuration |

---

## Test Added

**"PTP rejects MITM attack with same Key ID but different secret"**

This test validates that PTP authentication correctly rejects tampered packets:
1. Verifies baseline sync is healthy with proper authentication
2. Creates an "attacker" secret using the same Key IDs (1, 2) but different secret values
3. Switches the GM to use the attacker secret (simulating a MITM injecting packets)
4. Asserts the slave **fails to sync** for 2 minutes due to ICV (Integrity Check Value) mismatch
5. Restores original configuration and verifies recovery

---

## Refactoring: Magic Values → Constants

Moved inline secret definitions and hardcoded `sa_file` paths to shared locations:

- **Secret names** → `testconfig.MITMAttackerSecretName`, `testconfig.MismatchSecretName`
- **Secret creation** → `testconfig.CreateMITMAttackerSecret()`, `testconfig.CreateMismatchSecret()`
- **sa_file paths** → `pkg.SaFileSecurityConf`, `pkg.SaFileMismatchConf`, `pkg.SaFileMITMAttackerConf`

This improves readability, reduces duplication, and makes future security tests easier to implement.

