### PR TITLE
Fix test timeout and incorrect log pattern in event API v2 tests

### DIFF
--- a/test/conformance/serial/ptp.go
+++ b/test/conformance/serial/ptp.go
@@ -1173,21 +1173,21 @@ spp 0
 
 					logrus.Infof("Checking cloud-event-proxy logs on pod %s (node: %s)", pod.Name, pod.Spec.NodeName)
 
-					// Search for REST API config v2.0 in pod logs (literal text search)
+					// Search for "starting v2 rest api server at port" in pod logs (literal text search)
 					matches, err := pods.GetPodLogsRegex(
 						pod.Namespace,
 						pod.Name,
 						pkg.EventProxyContainerName,
-						`REST API config: version=2.0`,
+						`starting v2 rest api server at port`,
 						true,
 						30*time.Second,
 					)
 					Expect(err).NotTo(HaveOccurred(),
 						fmt.Sprintf("Failed to get logs from pod %s", pod.Name))
 					Expect(matches).NotTo(BeEmpty(),
-						fmt.Sprintf("No 'REST API config: version=2.0' found in cloud-event-proxy logs on pod %s", pod.Name))
+						fmt.Sprintf("No 'starting v2 rest api server at port' found in cloud-event-proxy logs on pod %s", pod.Name))
 
-					logrus.Infof("Pod %s: found REST API config v2.0 in logs", pod.Name)
+					logrus.Infof("Pod %s: found 'starting v2 rest api server at port' in logs", pod.Name)
 				}
 			})
 
@@ -1239,16 +1239,16 @@ spp 0
 						pod.Namespace,
 						pod.Name,
 						pkg.EventProxyContainerName,
-						`REST API config: version=2.0`,
+						`starting v2 rest api server at port`,
 						true,
 						30*time.Second,
 					)
 					Expect(err).NotTo(HaveOccurred(),
 						fmt.Sprintf("Failed to get logs from pod %s", pod.Name))
 					Expect(matches).NotTo(BeEmpty(),
-						fmt.Sprintf("No 'REST API config: version=2.0' found in cloud-event-proxy logs on pod %s", pod.Name))
+						fmt.Sprintf("No 'starting v2 rest api server at port' found in cloud-event-proxy logs on pod %s", pod.Name))
 
-					logrus.Infof("Pod %s: found REST API config v2.0 in logs", pod.Name)
+					logrus.Infof("Pod %s: found 'starting v2 rest api server at port' in logs", pod.Name)
 				}
 			})
 			// Verify invalid apiVersion values are rejected and pods are not restarted

--- a/test/pkg/pods/pods.go
+++ b/test/pkg/pods/pods.go
@@ -189,7 +189,10 @@ func GetPodLogsRegexSince(namespace string, podName string, containerName, regex
 
 	podLogRequest := testclient.Client.CoreV1().Pods(namespace).GetLogs(podName, &podLogOptions)
 
-	stream, err := podLogRequest.Stream(context.TODO())
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	stream, err := podLogRequest.Stream(ctx)
 	if err != nil {
 		return matches, fmt.Errorf("failed to open log streamn for %s/%s container=%s, err=%s", namespace, podName, containerName, err)
 	}
@@ -221,7 +224,10 @@ func GetPodLogsRegex(namespace string, podName string, containerName, regex stri
 
 	podLogRequest := testclient.Client.CoreV1().Pods(namespace).GetLogs(podName, &podLogOptions)
 
-	stream, err := podLogRequest.Stream(context.TODO())
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	stream, err := podLogRequest.Stream(ctx)
 	if err != nil {
 		return matches, fmt.Errorf("failed to open log streamn for %s/%s container=%s, err=%s", namespace, podName, containerName, err)
 	}


### PR DESCRIPTION
This PR is fixing this CI blocker: [CNF-21166](https://issues.redhat.com/browse/CNF-21166)

Two issues were identified:

1. **Blocking read without context timeout**: `GetPodLogsRegex` and `GetPodLogsRegexSince` used `context.TODO()` when opening the log stream. When no new logs were produced and the pattern wasn't found, `stream.Read()` blocked indefinitely, ignoring the timeout parameter.

2. **Incorrect log pattern**: The test searched for `REST API config: version=2.0` which doesn't exist in 4.18 or earlier releases.

This PR solves those 2 issues.

### Solution

1. **Added context with timeout** to `GetPodLogsRegex` and `GetPodLogsRegexSince` in `test/pkg/pods/pods.go`:
      This ensures the stream is cancelled after the timeout, causing `Read()` to return with `context deadline exceeded` instead of blocking forever.

2. **Updated search pattern** in `test/conformance/serial/ptp.go` from:
   - `REST API config: version=2.0`
   
   to:
   - `starting v2 rest api server at port`
   
   This message exists in all releases that support v2.

Tested and verified the timeout fix works correctly - function now returns within the specified timeout period when the pattern is not found.