### PR TITLE
CI Bugfix:Update l2discovery-lib to v0.0.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/prometheus-operator/prometheus-operator/pkg/client v0.57.0
 	github.com/prometheus/common v0.44.0
 	github.com/redhat-cne/channel-pubsub v0.0.8
-	github.com/redhat-cne/l2discovery-lib v0.0.17
+	github.com/redhat-cne/l2discovery-lib v0.0.20
 	github.com/redhat-cne/privileged-daemonset v1.0.34
 	github.com/redhat-cne/ptp-listener-exports v0.0.7
 	github.com/redhat-cne/sdk-go v1.22.4

--- a/go.sum
+++ b/go.sum
@@ -473,8 +473,8 @@ github.com/prometheus/procfs v0.10.1/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPH
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/redhat-cne/channel-pubsub v0.0.8 h1:5UzwMev+pjIIfzHDyCsx8HlG4a/ahHpRO+EXMFDa7YQ=
 github.com/redhat-cne/channel-pubsub v0.0.8/go.mod h1:mzF6XIdwFXrQ0JmvVA4UtflirDIM+q9Dj/1YGevGnOU=
-github.com/redhat-cne/l2discovery-lib v0.0.17 h1:1fDmlcMKO4Qk2kRbRWcEf3R0KriaH3E+HgNRRsjEVLo=
-github.com/redhat-cne/l2discovery-lib v0.0.17/go.mod h1:Ig7vzdYn0xjt+4xVsgsPxpEBoEh5RgUH7YP0z9+DPF0=
+github.com/redhat-cne/l2discovery-lib v0.0.20 h1:L2LFuZIXWXXnbyf6PQYXKjGlwVd++aRgvBWQc2vuPGc=
+github.com/redhat-cne/l2discovery-lib v0.0.20/go.mod h1:ouxJZnHOUjQ77L6WqHFnnpGhmb3kOIGSyLobyCLnwzo=
 github.com/redhat-cne/privileged-daemonset v1.0.34 h1:wcffXvaz5PwvAZfq62WiMXi0N+gXFlEFXkK4CcdjshU=
 github.com/redhat-cne/privileged-daemonset v1.0.34/go.mod h1:poRO1Giq9rH4JD8/KLxRJobOARGxmPr8xAIwhSrZGRQ=
 github.com/redhat-cne/ptp-listener-exports v0.0.7 h1:OndW4kSKym5LK9bbEqJPE/LW/LGMDPw5IzXdmrGMRhI=

--- a/vendor/github.com/redhat-cne/l2discovery-lib/.golangci.yml
+++ b/vendor/github.com/redhat-cne/l2discovery-lib/.golangci.yml
@@ -1,50 +1,7 @@
-linters-settings:
-  dupl:
-    threshold: 100
-  funlen:
-    lines: 60
-    statements: 45
-  goconst:
-    min-len: 4
-    min-occurrences: 2
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-    disabled-checks:
-      - whyNoLint
-  gocyclo:
-    min-complexity: 20
-  mnd:
-    # do not include the "operation" and "assign"
-    checks:
-      - argument
-      - case
-      - condition
-      - return
-  govet:
-    settings:
-      printf:
-        funcs:
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
-  lll:
-    line-length: 250
-  nolintlint:
-    allow-unused: false # report any unused nolint directives
-    require-explanation: false # do not require an explanation for nolint directives
-    require-specific: true # require nolint directives to be specific about which linter is being skipped
-  exhaustive:
-    default-signifies-exhaustive: true
+version: "2"
+
 linters:
-  # please, do not use `enable-all`: it's deprecated and will be removed soon.
-  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
-  disable-all: true
+  default: none
   enable:
     - bodyclose
     - dogsled
@@ -54,76 +11,94 @@ linters:
     - goconst
     - gocritic
     - gocyclo
-    - gofmt
-    - goimports
-    - mnd
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - lll
     - misspell
+    - mnd
     - nolintlint
     - rowserrcheck
-    - staticcheck
-    - stylecheck
+    - staticcheck  # includes gosimple and stylecheck in v2
     - unconvert
     - unparam
     - whitespace
-  # do not enable:
-  # - asciicheck
-  # - depguard
-  # - dupl
-  # - gochecknoglobals
-  # - gochecknoinits
-  # - gocognit
-  # - godot
-  # - godox
-  # - goerr113
-  # - maligned
-  # - nakedret
-  # - nestif
-  # - noctx
-  # - prealloc
-  # - revive
-  # - exportloopref
-  # - structcheck
-  # - testpackage
-  # - wsl
-issues:
-  exclude-dirs:
-    - cmd/l2discovery
-  # Excluding configuration per-path, per-linter, per-text and per-source
-  exclude-rules:
-    # Ignore magic numbers, inline strings and function length in tests.
-    - path: _test\.go
-      linters:
-        - mnd
-        - goconst
-        - funlen
-    - path: config/config.go
-      linters:
-        - mnd
-    - path: _scaling.go
-      linters:
-        - gocritic
-    - path: hugepages.go
-      linters:
-        - mnd
-    - path: scheduling.go
-      linters:
-        - mnd
-    # Ignore line length for string assignments (do not try and wrap regex definitions)
-    - linters:
-        - lll
-      source: "^(.*= (\".*\"|`.*`))$"
-    # https://github.com/go-critic/go-critic/issues/926
-    - linters:
-        - gocritic
-      text: "unnecessaryDefer:"
-    # Ignore static strings in tests
+  exclusions:
+    paths:
+      - cmd/l2discovery
+    rules:
+      # Ignore magic numbers, inline strings and function length in tests.
+      - path: _test\.go
+        linters:
+          - mnd
+          - goconst
+          - funlen
+      - path: config/config.go
+        linters:
+          - mnd
+      - path: _scaling.go
+        linters:
+          - gocritic
+      - path: hugepages.go
+        linters:
+          - mnd
+      - path: scheduling.go
+        linters:
+          - mnd
+      # Ignore line length for string assignments (do not try and wrap regex definitions)
+      - linters:
+          - lll
+        source: "^(.*= (\".*\"|`.*`))$"
+      # https://github.com/go-critic/go-critic/issues/926
+      - linters:
+          - gocritic
+        text: "unnecessaryDefer:"
+  settings:
+    dupl:
+      threshold: 100
+    funlen:
+      lines: 60
+      statements: 45
+    goconst:
+      min-len: 4
+      min-occurrences: 2
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+      disabled-checks:
+        - whyNoLint
+    gocyclo:
+      min-complexity: 20
+    mnd:
+      # do not include the "operation" and "assign"
+      checks:
+        - argument
+        - case
+        - condition
+        - return
+    govet:
+      settings:
+        printf:
+          funcs:
+            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
+            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
+            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
+            - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
+    lll:
+      line-length: 250
+    nolintlint:
+      allow-unused: false # report any unused nolint directives
+      require-explanation: false # do not require an explanation for nolint directives
+      require-specific: true # require nolint directives to be specific about which linter is being skipped
+    exhaustive:
+      default-signifies-exhaustive: true
 
-
-# golangci.com configuration
-# https://github.com/golangci/golangci/wiki/Configuration
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/vendor/github.com/redhat-cne/l2discovery-lib/Makefile
+++ b/vendor/github.com/redhat-cne/l2discovery-lib/Makefile
@@ -1,4 +1,4 @@
-GOLANGCI_VERSION=v1.64.5
+GOLANGCI_VERSION=v2.8.0
 GO_PACKAGES=$(shell go list ./... | grep -v vendor)
 
 .PHONY: all clean test build build-l2discovery lint install-lint vet fmt image launch
@@ -14,9 +14,9 @@ fmt:
 lint:
 	golangci-lint run
 
-# Install golangci-lint	
+# Install golangci-lint v2
 install-lint:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin ${GOLANGCI_VERSION}
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${GOLANGCI_VERSION}
 
 vet:
 	go vet ${GO_PACKAGES}

--- a/vendor/github.com/redhat-cne/l2discovery-lib/pkg/graphsolver/graphsolver.go
+++ b/vendor/github.com/redhat-cne/l2discovery-lib/pkg/graphsolver/graphsolver.go
@@ -302,7 +302,7 @@ func SameLan2Wrapper(config exports.L2Info, if1, if2 int) bool {
 
 // Determines if 2 interfaces (ports) belong to the same NIC
 func SameNic(ifaceName1, ifaceName2 *exports.PtpIf) bool {
-	if ifaceName1.IfClusterIndex.NodeName != ifaceName2.IfClusterIndex.NodeName {
+	if ifaceName1.NodeName != ifaceName2.NodeName {
 		return false
 	}
 	return ifaceName1.IfPci.Device != "" && ifaceName1.IfPci.Device == ifaceName2.IfPci.Device
@@ -373,6 +373,7 @@ func applyStep(config exports.L2Info, step [][]int, combinations []int) bool {
 			negate = test[negationIdx] == Negative
 		}
 
+		//nolint:gosec // G602: slice indices are controlled by step definition and param count in test[1]
 		switch test[1] {
 		case int(NoParam):
 			stepResult = AlgoCode0[test[0]]()

--- a/vendor/github.com/redhat-cne/l2discovery-lib/pkg/pods/pods.go
+++ b/vendor/github.com/redhat-cne/l2discovery-lib/pkg/pods/pods.go
@@ -16,7 +16,9 @@ func GetLog(p *corev1.Pod, containerName string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer log.Close()
+	defer func() {
+		_ = log.Close()
+	}()
 
 	buf := new(bytes.Buffer)
 	_, err = io.Copy(buf, log)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -244,8 +244,8 @@ github.com/prometheus/procfs/internal/util
 # github.com/redhat-cne/channel-pubsub v0.0.8
 ## explicit; go 1.19
 github.com/redhat-cne/channel-pubsub
-# github.com/redhat-cne/l2discovery-lib v0.0.17
-## explicit; go 1.22
+# github.com/redhat-cne/l2discovery-lib v0.0.20
+## explicit; go 1.24
 github.com/redhat-cne/l2discovery-lib
 github.com/redhat-cne/l2discovery-lib/exports
 github.com/redhat-cne/l2discovery-lib/pkg/graphsolver


### PR DESCRIPTION
- Fix panic when JSON_REPORT missing in pod logs (bounds check)
- Add retry logic (3 attempts with 15s wait) for L2 discovery
- Migrate to golangci-lint v2.8.0 schema
- Fix lint errors (errcheck, simplified embedded field selectors)