### PR TITLE
Updates Go version in `ptp-tools/Dockerfile.krp` from 1.24.3 to 1.24.11.

### DIFF
--- a/ptp-tools/Dockerfile.krp
+++ b/ptp-tools/Dockerfile.krp
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.24.3 AS builder
+FROM docker.io/golang:1.24.11 AS builder
 WORKDIR /go/src/github.com/brancz/kube-rbac-proxy
 RUN git clone https://github.com/openshift/kube-rbac-proxy.git /go/src/github.com/brancz/kube-rbac-proxy
 ENV GO111MODULE=on


### PR DESCRIPTION
The `deploy-ec2` CI job fails when building `kube-rbac-proxy` from source. The upstream `openshift/kube-rbac-proxy` main branch now requires Go 1.24.11, but `Dockerfile.krp` was using `golang:1.24.3`, causing the build to fail with:
`go: go.mod requires go >= 1.24.11 (running go 1.24.3; GOTOOLCHAIN=local)`

After the 4.22 version bump (#166), PRs based on the new main branch started failing the `deploy-ec2` CI check. Investigation revealed that `openshift/kube-rbac-proxy` release-4.22 branch requires Go 1.24.11, while the 4.21 branch only required Go 1.23.6.

Update `ptp-tools/Dockerfile.krp` to use `golang:1.24.11` to match the upstream requirement.