### PR TITLE
Move the haProfiles names check to dualnicbcha test mode.

### DIFF
--- a/test/conformance/serial/ptp.go
+++ b/test/conformance/serial/ptp.go
@@ -249,6 +249,10 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 
 		// Webhook validation test for underscore profile names
 		It("Should accept underscores in ptp-config profile names for HA profiles", func() {
+			if DesiredMode != testconfig.DualNICBoundaryClockHA {
+				Skip("Skipping as the test is only applicable for Dual NIC BC in HA mode (dualnicbcha)")
+			}
+
 			By("Creating a PtpConfig with underscore profile names in haProfiles")
 			err := testconfig.CreatePtpConfigWithUnderscoreProfileNames()
 			Expect(err).ToNot(HaveOccurred(), "webhook should accept underscores in profile names")


### PR DESCRIPTION
This is a quick and controversial workaround: this test case is failing in the CI of downstream releases <=4.15, due to the ptp admission webhook rejecting the ptpconfigs that are being created here:
```
Unexpected error:
    <*errors.StatusError | 0xc0008e1220>: 
    admission webhook "vptpconfig.kb.io" denied the request: profile.PtpSettings 'haProfiles' is not a configurable setting
```

Moving it under the [dualnicbcha mode](https://github.com/openshift/release/blob/ba081447c09adfe88e32fcbac996df6a3a9991a6/ci-operator/step-registry/telco5g/ptp/tests/telco5g-ptp-tests-commands.sh#L307) will help here, but we're somehow linking the upstream main branch test code to downstream versions... we should probably address this soon to avoid this kind of workarounds.