### PR TITLE
CI: Increased the upstream CI tests timeout 115 minutes

### DIFF
--- a/.github/workflows/aws-ci.yaml
+++ b/.github/workflows/aws-ci.yaml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   deploy-ec2:
     runs-on: ubuntu-latest
-    timeout-minutes: 55
+    timeout-minutes: 115
     steps:
       - name: Remove ok-to-test label if new commit
         uses: actions/github-script@v7


### PR DESCRIPTION
Test added recently lead to timeout in CI because they took more than 55 minutes to run. This PR extends the timeout to 115 minutes to match the new 2h OIDC timeout.