### PR TITLE
contain full hardware info for nodeptpdevice

### DIFF
--- a/api/v1/nodeptpdevice_types.go
+++ b/api/v1/nodeptpdevice_types.go
@@ -58,11 +58,11 @@ type PtpDevice struct {
 type HardwareInfo struct {
 	// PCI Information - Device location and identification on the PCI bus
 
-	// PCIAddress is the PCI bus address (e.g., "0000:01:00.0")
+	// PCIAddress is the PCI bus address
 	// +optional
 	PCIAddress string `json:"pciAddress,omitempty"`
 
-	// VendorID is the PCI vendor identifier (e.g., "8086" for Intel)
+	// VendorID is the PCI vendor identifier
 	// +optional
 	VendorID string `json:"vendorID,omitempty"`
 
@@ -88,7 +88,25 @@ type HardwareInfo struct {
 	// +optional
 	DriverVersion string `json:"driverVersion,omitempty"`
 
+	// Link Status Information
+
+	// LinkStatus indicates whether the link is up ("up") or down ("down")
+	// +optional
+	LinkStatus string `json:"linkStatus,omitempty"`
+
+	// LinkSpeed is the negotiated link speed
+	// +optional
+	LinkSpeed string `json:"linkSpeed,omitempty"`
+
+	// FEC is the Forward Error Correction mode in use
+	// +optional
+	FEC string `json:"fec,omitempty"`
+
 	// VPD (Vital Product Data) - Manufacturing and product information
+
+	// VPDIdentifierString is the device identifier string from VPD
+	// +optional
+	VPDIdentifierString string `json:"vpdIdentifierString,omitempty"`
 
 	// VPDPartNumber is the manufacturer's part number from VPD
 	// +optional
@@ -102,9 +120,18 @@ type HardwareInfo struct {
 	// +optional
 	VPDManufacturerID string `json:"vpdManufacturerID,omitempty"`
 
-	// VPDProductName is the product name from VPD
+	// VPDProductName is the product name from VPD (V0 field)
 	// +optional
 	VPDProductName string `json:"vpdProductName,omitempty"`
+
+	// VPDVendorSpecific1 is vendor-specific data from VPD (V1 field).
+	// Often contains detailed product identification useful for hardware fingerprinting.
+	// +optional
+	VPDVendorSpecific1 string `json:"vpdVendorSpecific1,omitempty"`
+
+	// VPDVendorSpecific2 is vendor-specific data from VPD (V2 field)
+	// +optional
+	VPDVendorSpecific2 string `json:"vpdVendorSpecific2,omitempty"`
 }
 
 type HwConfig struct {

--- a/bundle/manifests/ptp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ptp-operator.clusterserviceversion.yaml
@@ -61,7 +61,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/openshift/origin-ptp-operator:4.22
-    createdAt: "2026-01-20T12:52:18Z"
+    createdAt: "2026-03-03T14:39:41Z"
     description: This software enables configuration of Precision Time Protocol(PTP)
       on Kubernetes. It detects hardware capable PTP devices on each node, and configures
       linuxptp processes such as ptp4l, phc2sys and timemaster.

--- a/bundle/manifests/ptp.openshift.io_nodeptpdevices.yaml
+++ b/bundle/manifests/ptp.openshift.io_nodeptpdevices.yaml
@@ -63,12 +63,23 @@ spec:
                           description: DriverVersion is the version of the kernel
                             driver in use
                           type: string
+                        fec:
+                          description: FEC is the Forward Error Correction mode in
+                            use
+                          type: string
                         firmwareVersion:
                           description: FirmwareVersion is the version of the device
                             firmware
                           type: string
+                        linkSpeed:
+                          description: LinkSpeed is the negotiated link speed
+                          type: string
+                        linkStatus:
+                          description: LinkStatus indicates whether the link is up
+                            ("up") or down ("down")
+                          type: string
                         pciAddress:
-                          description: PCIAddress is the PCI bus address (e.g., "0000:01:00.0")
+                          description: PCIAddress is the PCI bus address
                           type: string
                         subsystemDeviceID:
                           description: SubsystemDeviceID is the PCI subsystem device
@@ -79,8 +90,11 @@ spec:
                             identifier
                           type: string
                         vendorID:
-                          description: VendorID is the PCI vendor identifier (e.g.,
-                            "8086" for Intel)
+                          description: VendorID is the PCI vendor identifier
+                          type: string
+                        vpdIdentifierString:
+                          description: VPDIdentifierString is the device identifier
+                            string from VPD
                           type: string
                         vpdManufacturerID:
                           description: VPDManufacturerID is the manufacturer identifier
@@ -92,10 +106,20 @@ spec:
                           type: string
                         vpdProductName:
                           description: VPDProductName is the product name from VPD
+                            (V0 field)
                           type: string
                         vpdSerialNumber:
                           description: VPDSerialNumber is the unique serial number
                             from VPD
+                          type: string
+                        vpdVendorSpecific1:
+                          description: |-
+                            VPDVendorSpecific1 is vendor-specific data from VPD (V1 field).
+                            Often contains detailed product identification useful for hardware fingerprinting.
+                          type: string
+                        vpdVendorSpecific2:
+                          description: VPDVendorSpecific2 is vendor-specific data
+                            from VPD (V2 field)
                           type: string
                       type: object
                     name:

--- a/config/crd/bases/ptp.openshift.io_nodeptpdevices.yaml
+++ b/config/crd/bases/ptp.openshift.io_nodeptpdevices.yaml
@@ -63,12 +63,23 @@ spec:
                           description: DriverVersion is the version of the kernel
                             driver in use
                           type: string
+                        fec:
+                          description: FEC is the Forward Error Correction mode in
+                            use
+                          type: string
                         firmwareVersion:
                           description: FirmwareVersion is the version of the device
                             firmware
                           type: string
+                        linkSpeed:
+                          description: LinkSpeed is the negotiated link speed
+                          type: string
+                        linkStatus:
+                          description: LinkStatus indicates whether the link is up
+                            ("up") or down ("down")
+                          type: string
                         pciAddress:
-                          description: PCIAddress is the PCI bus address (e.g., "0000:01:00.0")
+                          description: PCIAddress is the PCI bus address
                           type: string
                         subsystemDeviceID:
                           description: SubsystemDeviceID is the PCI subsystem device
@@ -79,8 +90,11 @@ spec:
                             identifier
                           type: string
                         vendorID:
-                          description: VendorID is the PCI vendor identifier (e.g.,
-                            "8086" for Intel)
+                          description: VendorID is the PCI vendor identifier
+                          type: string
+                        vpdIdentifierString:
+                          description: VPDIdentifierString is the device identifier
+                            string from VPD
                           type: string
                         vpdManufacturerID:
                           description: VPDManufacturerID is the manufacturer identifier
@@ -92,10 +106,20 @@ spec:
                           type: string
                         vpdProductName:
                           description: VPDProductName is the product name from VPD
+                            (V0 field)
                           type: string
                         vpdSerialNumber:
                           description: VPDSerialNumber is the unique serial number
                             from VPD
+                          type: string
+                        vpdVendorSpecific1:
+                          description: |-
+                            VPDVendorSpecific1 is vendor-specific data from VPD (V1 field).
+                            Often contains detailed product identification useful for hardware fingerprinting.
+                          type: string
+                        vpdVendorSpecific2:
+                          description: VPDVendorSpecific2 is vendor-specific data
+                            from VPD (V2 field)
                           type: string
                       type: object
                     name:

--- a/manifests/stable/ptp-operator.clusterserviceversion.yaml
+++ b/manifests/stable/ptp-operator.clusterserviceversion.yaml
@@ -61,7 +61,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/openshift/origin-ptp-operator:4.22
-    createdAt: "2026-01-20T12:52:18Z"
+    createdAt: "2026-03-03T14:39:41Z"
     description: This software enables configuration of Precision Time Protocol(PTP)
       on Kubernetes. It detects hardware capable PTP devices on each node, and configures
       linuxptp processes such as ptp4l, phc2sys and timemaster.

--- a/manifests/stable/ptp.openshift.io_nodeptpdevices.yaml
+++ b/manifests/stable/ptp.openshift.io_nodeptpdevices.yaml
@@ -63,12 +63,23 @@ spec:
                           description: DriverVersion is the version of the kernel
                             driver in use
                           type: string
+                        fec:
+                          description: FEC is the Forward Error Correction mode in
+                            use
+                          type: string
                         firmwareVersion:
                           description: FirmwareVersion is the version of the device
                             firmware
                           type: string
+                        linkSpeed:
+                          description: LinkSpeed is the negotiated link speed
+                          type: string
+                        linkStatus:
+                          description: LinkStatus indicates whether the link is up
+                            ("up") or down ("down")
+                          type: string
                         pciAddress:
-                          description: PCIAddress is the PCI bus address (e.g., "0000:01:00.0")
+                          description: PCIAddress is the PCI bus address
                           type: string
                         subsystemDeviceID:
                           description: SubsystemDeviceID is the PCI subsystem device
@@ -79,8 +90,11 @@ spec:
                             identifier
                           type: string
                         vendorID:
-                          description: VendorID is the PCI vendor identifier (e.g.,
-                            "8086" for Intel)
+                          description: VendorID is the PCI vendor identifier
+                          type: string
+                        vpdIdentifierString:
+                          description: VPDIdentifierString is the device identifier
+                            string from VPD
                           type: string
                         vpdManufacturerID:
                           description: VPDManufacturerID is the manufacturer identifier
@@ -92,10 +106,20 @@ spec:
                           type: string
                         vpdProductName:
                           description: VPDProductName is the product name from VPD
+                            (V0 field)
                           type: string
                         vpdSerialNumber:
                           description: VPDSerialNumber is the unique serial number
                             from VPD
+                          type: string
+                        vpdVendorSpecific1:
+                          description: |-
+                            VPDVendorSpecific1 is vendor-specific data from VPD (V1 field).
+                            Often contains detailed product identification useful for hardware fingerprinting.
+                          type: string
+                        vpdVendorSpecific2:
+                          description: VPDVendorSpecific2 is vendor-specific data
+                            from VPD (V2 field)
                           type: string
                       type: object
                     name:


### PR DESCRIPTION
This fixes reverted [PR#170 ](https://github.com/k8snetworkplumbingwg/ptp-operator/pull/170)

contains full hardware info in the nodeptpdevice. 
Addressing [PR#143](https://github.com/k8snetworkplumbingwg/linuxptp-daemon/pull/143)