### PR TITLE
Set tls-profiles feature annotation to true in CSV

### DIFF
--- a/bundle/manifests/ptp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ptp-operator.clusterserviceversion.yaml
@@ -71,7 +71,7 @@ metadata:
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/proxy-aware: "false"
-    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/tls-profiles: "true"
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"

--- a/config/manifests/bases/ptp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ptp-operator.clusterserviceversion.yaml
@@ -66,7 +66,7 @@ metadata:
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/proxy-aware: "false"
-    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/tls-profiles: "true"
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"

--- a/manifests/stable/ptp-operator.clusterserviceversion.yaml
+++ b/manifests/stable/ptp-operator.clusterserviceversion.yaml
@@ -71,7 +71,7 @@ metadata:
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/proxy-aware: "false"
-    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/tls-profiles: "true"
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"


### PR DESCRIPTION
The operator now honors the cluster-wide TLS security profile from the APIServer CR, so declare this capability via the OLM feature annotation.