### PR TITLE
CNF-21768: Add TLS adherence support

### DIFF
--- a/bindata/linuxptp/ptp-daemon.yaml
+++ b/bindata/linuxptp/ptp-daemon.yaml
@@ -73,7 +73,9 @@ spec:
             - --logtostderr
             - --secure-listen-address=:8443
             - --tls-cipher-suites={{.TLSCipherSuites}}
+            {{- if .TLSMinVersion}}
             - --tls-min-version={{.TLSMinVersion}}
+            {{- end}}
             - --upstream=http://127.0.0.1:9091/
             - --tls-private-key-file=/etc/metrics/tls.key
             - --tls-cert-file=/etc/metrics/tls.crt
@@ -168,6 +170,8 @@ spec:
       tlsConfig:
         caFile: "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt"
         serverName: "ptp-monitor-service.{{.Namespace}}.svc"
+        certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+        keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
   jobLabel: app
   namespaceSelector:
     matchNames:

--- a/bindata/linuxptp/ptp-daemon.yaml
+++ b/bindata/linuxptp/ptp-daemon.yaml
@@ -72,7 +72,9 @@ spec:
           args:
             - --logtostderr
             - --secure-listen-address=:8443
+            {{- if .TLSCipherSuites}}
             - --tls-cipher-suites={{.TLSCipherSuites}}
+            {{- end}}
             {{- if .TLSMinVersion}}
             - --tls-min-version={{.TLSMinVersion}}
             {{- end}}

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -16,6 +16,8 @@ spec:
       tlsConfig:
         caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
         serverName: ptp-operator-metrics-service.openshift-ptp.svc
+        certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+        keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/controllers/ptpoperatorconfig_controller.go
+++ b/controllers/ptpoperatorconfig_controller.go
@@ -53,9 +53,10 @@ import (
 // PtpOperatorConfigReconciler reconciles a PtpOperatorConfig object
 type PtpOperatorConfigReconciler struct {
 	client.Client
-	Log            logr.Logger
-	Scheme         *runtime.Scheme
-	TLSProfileSpec configv1.TLSProfileSpec
+	Log                logr.Logger
+	Scheme             *runtime.Scheme
+	TLSProfileSpec     configv1.TLSProfileSpec
+	TLSAdherencePolicy configv1.TLSAdherencePolicy
 }
 
 const (
@@ -273,10 +274,7 @@ func (r *PtpOperatorConfigReconciler) syncLinuxptpDaemon(ctx context.Context, de
 		glog.Infof("ptp operator enabled plugins: %s", enabledPlugins)
 	}
 
-	// Pass TLS profile settings for kube-rbac-proxy
-	ianaCiphers := libgocrypto.OpenSSLToIANACipherSuites(r.TLSProfileSpec.Ciphers)
-	data.Data["TLSMinVersion"] = string(r.TLSProfileSpec.MinTLSVersion)
-	data.Data["TLSCipherSuites"] = strings.Join(ianaCiphers, ",")
+	r.setTLSTemplateData(&data)
 
 	objs, err = render.RenderTemplate(filepath.Join(names.ManifestDir, "linuxptp/ptp-daemon.yaml"), &data)
 	if err != nil {
@@ -428,6 +426,25 @@ func (r *PtpOperatorConfigReconciler) syncNodePtpDevice(ctx context.Context, nod
 		}
 	}
 	return nil
+}
+
+// setTLSTemplateData populates TLS settings for the kube-rbac-proxy container
+// in the daemon DaemonSet template. In Strict adherence mode, the cluster-wide
+// TLS profile from the APIServer CR is used. In Legacy mode, the hardcoded
+// cipher suites from before cluster TLS profile support (PR #189) are used.
+func (r *PtpOperatorConfigReconciler) setTLSTemplateData(data *render.RenderData) {
+	if libgocrypto.ShouldHonorClusterTLSProfile(r.TLSAdherencePolicy) {
+		ianaCiphers := libgocrypto.OpenSSLToIANACipherSuites(r.TLSProfileSpec.Ciphers)
+		data.Data["TLSMinVersion"] = string(r.TLSProfileSpec.MinTLSVersion)
+		data.Data["TLSCipherSuites"] = strings.Join(ianaCiphers, ",")
+	} else {
+		data.Data["TLSMinVersion"] = ""
+		data.Data["TLSCipherSuites"] = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256," +
+			"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256," +
+			"TLS_RSA_WITH_AES_128_CBC_SHA256," +
+			"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256," +
+			"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
+	}
 }
 
 func (r *PtpOperatorConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/controllers/ptpoperatorconfig_controller.go
+++ b/controllers/ptpoperatorconfig_controller.go
@@ -53,10 +53,11 @@ import (
 // PtpOperatorConfigReconciler reconciles a PtpOperatorConfig object
 type PtpOperatorConfigReconciler struct {
 	client.Client
-	Log                logr.Logger
-	Scheme             *runtime.Scheme
-	TLSProfileSpec     configv1.TLSProfileSpec
-	TLSAdherencePolicy configv1.TLSAdherencePolicy
+	Log    logr.Logger
+	Scheme *runtime.Scheme
+	// TLSProfileSpec is the cluster-wide TLS profile to apply to kube-rbac-proxy.
+	// When nil, legacy hardcoded cipher suites are used (pre-TLS adherence behavior).
+	TLSProfileSpec *configv1.TLSProfileSpec
 }
 
 const (
@@ -428,22 +429,26 @@ func (r *PtpOperatorConfigReconciler) syncNodePtpDevice(ctx context.Context, nod
 	return nil
 }
 
+// legacyCipherSuites are the hardcoded cipher suites used by kube-rbac-proxy
+// before cluster TLS profile support was added (PR #189).
+const legacyCipherSuites = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256," +
+	"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256," +
+	"TLS_RSA_WITH_AES_128_CBC_SHA256," +
+	"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256," +
+	"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
+
 // setTLSTemplateData populates TLS settings for the kube-rbac-proxy container
-// in the daemon DaemonSet template. In Strict adherence mode, the cluster-wide
-// TLS profile from the APIServer CR is used. In Legacy mode, the hardcoded
-// cipher suites from before cluster TLS profile support (PR #189) are used.
+// in the daemon DaemonSet template. When TLSProfileSpec is set (strict adherence),
+// the cluster-wide TLS profile is used. When nil (legacy), the hardcoded cipher
+// suites from before cluster TLS profile support (PR #189) are used.
 func (r *PtpOperatorConfigReconciler) setTLSTemplateData(data *render.RenderData) {
-	if libgocrypto.ShouldHonorClusterTLSProfile(r.TLSAdherencePolicy) {
+	if r.TLSProfileSpec != nil {
 		ianaCiphers := libgocrypto.OpenSSLToIANACipherSuites(r.TLSProfileSpec.Ciphers)
 		data.Data["TLSMinVersion"] = string(r.TLSProfileSpec.MinTLSVersion)
 		data.Data["TLSCipherSuites"] = strings.Join(ianaCiphers, ",")
 	} else {
 		data.Data["TLSMinVersion"] = ""
-		data.Data["TLSCipherSuites"] = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256," +
-			"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256," +
-			"TLS_RSA_WITH_AES_128_CBC_SHA256," +
-			"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256," +
-			"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
+		data.Data["TLSCipherSuites"] = legacyCipherSuites
 	}
 }
 

--- a/controllers/tls_profile_test.go
+++ b/controllers/tls_profile_test.go
@@ -61,14 +61,8 @@ func TestTLSProfileTemplateData(t *testing.T) {
 	}
 }
 
-func TestTLSProfileTemplateRendering(t *testing.T) {
-	profile := *configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
-	ianaCiphers := libgocrypto.OpenSSLToIANACipherSuites(profile.Ciphers)
-
+func makeTestRenderData() *render.RenderData {
 	data := render.MakeRenderData()
-	data.Data["TLSMinVersion"] = string(profile.MinTLSVersion)
-	data.Data["TLSCipherSuites"] = strings.Join(ianaCiphers, ",")
-	// Set all required template variables
 	data.Data["Image"] = "test-image"
 	data.Data["ImagePullPolicy"] = "IfNotPresent"
 	data.Data["Namespace"] = "openshift-ptp"
@@ -80,8 +74,18 @@ func TestTLSProfileTemplateRendering(t *testing.T) {
 	data.Data["EnabledPlugins"] = "e810"
 	data.Data["StorageType"] = "emptyDir"
 	data.Data["EventApiVersion"] = "2.0"
+	return &data
+}
 
-	objs, err := render.RenderTemplate("../bindata/linuxptp/ptp-daemon.yaml", &data)
+func TestTLSProfileTemplateRendering(t *testing.T) {
+	profile := *configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+	ianaCiphers := libgocrypto.OpenSSLToIANACipherSuites(profile.Ciphers)
+
+	data := makeTestRenderData()
+	data.Data["TLSMinVersion"] = string(profile.MinTLSVersion)
+	data.Data["TLSCipherSuites"] = strings.Join(ianaCiphers, ",")
+
+	objs, err := render.RenderTemplate("../bindata/linuxptp/ptp-daemon.yaml", data)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, objs)
 
@@ -119,6 +123,54 @@ func TestTLSProfileTemplateRendering(t *testing.T) {
 		assert.Contains(t, rbacProxyArgs, expectedMinVersion)
 	}
 	assert.True(t, dsFound, "DaemonSet not found in rendered objects")
+}
+
+func TestTLSProfileTemplateRendering_LegacyAdherence(t *testing.T) {
+	// When TLS adherence is legacy, kube-rbac-proxy should use the hardcoded
+	// cipher suites that were in place before cluster TLS profile support.
+	data := makeTestRenderData()
+	data.Data["TLSMinVersion"] = ""
+	data.Data["TLSCipherSuites"] = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256," +
+		"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256," +
+		"TLS_RSA_WITH_AES_128_CBC_SHA256," +
+		"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256," +
+		"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
+
+	objs, err := render.RenderTemplate("../bindata/linuxptp/ptp-daemon.yaml", data)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, objs)
+
+	for _, obj := range objs {
+		if obj.GetKind() != "DaemonSet" {
+			continue
+		}
+		containers, found, err := unstructuredContainers(obj.Object)
+		assert.NoError(t, err)
+		assert.True(t, found)
+
+		var rbacProxyArgs []string
+		for _, c := range containers {
+			container := c.(map[string]interface{})
+			if container["name"] == "kube-rbac-proxy" {
+				args := container["args"].([]interface{})
+				for _, a := range args {
+					rbacProxyArgs = append(rbacProxyArgs, a.(string))
+				}
+				break
+			}
+		}
+
+		for _, arg := range rbacProxyArgs {
+			assert.NotContains(t, arg, "--tls-min-version",
+				"TLS min version should not be set in legacy adherence mode")
+		}
+		assert.Contains(t, rbacProxyArgs,
+			"--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,"+
+				"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,"+
+				"TLS_RSA_WITH_AES_128_CBC_SHA256,"+
+				"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,"+
+				"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256")
+	}
 }
 
 func unstructuredContainers(obj map[string]interface{}) ([]interface{}, bool, error) {

--- a/controllers/tls_watcher_test.go
+++ b/controllers/tls_watcher_test.go
@@ -11,17 +11,10 @@ import (
 	"github.com/k8snetworkplumbingwg/ptp-operator/pkg/render"
 )
 
-const legacyCipherSuites = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256," +
-	"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256," +
-	"TLS_RSA_WITH_AES_128_CBC_SHA256," +
-	"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256," +
-	"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
-
-func TestSetTLSTemplateData_StrictMode(t *testing.T) {
+func TestSetTLSTemplateData_WithProfile(t *testing.T) {
 	profile := *configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
 	r := &PtpOperatorConfigReconciler{
-		TLSProfileSpec:     profile,
-		TLSAdherencePolicy: configv1.TLSAdherencePolicyStrictAllComponents,
+		TLSProfileSpec: &profile,
 	}
 	data := render.MakeRenderData()
 	r.setTLSTemplateData(&data)
@@ -31,37 +24,23 @@ func TestSetTLSTemplateData_StrictMode(t *testing.T) {
 	assert.Equal(t, expectedCiphers, data.Data["TLSCipherSuites"])
 }
 
-func TestSetTLSTemplateData_LegacyMode(t *testing.T) {
+func TestSetTLSTemplateData_NilProfileUsesLegacy(t *testing.T) {
 	r := &PtpOperatorConfigReconciler{
-		TLSAdherencePolicy: configv1.TLSAdherencePolicyLegacyAdheringComponentsOnly,
+		TLSProfileSpec: nil,
 	}
 	data := render.MakeRenderData()
 	r.setTLSTemplateData(&data)
 
 	assert.Equal(t, "", data.Data["TLSMinVersion"],
-		"TLSMinVersion should be empty in legacy mode")
+		"TLSMinVersion should be empty when TLSProfileSpec is nil")
 	assert.Equal(t, legacyCipherSuites, data.Data["TLSCipherSuites"],
-		"TLSCipherSuites should use hardcoded legacy ciphers")
+		"TLSCipherSuites should use hardcoded legacy ciphers when TLSProfileSpec is nil")
 }
 
-func TestSetTLSTemplateData_NoOpinionDefaultsToLegacy(t *testing.T) {
-	r := &PtpOperatorConfigReconciler{
-		TLSAdherencePolicy: configv1.TLSAdherencePolicyNoOpinion,
-	}
-	data := render.MakeRenderData()
-	r.setTLSTemplateData(&data)
-
-	assert.Equal(t, "", data.Data["TLSMinVersion"],
-		"TLSMinVersion should be empty when adherence is unset")
-	assert.Equal(t, legacyCipherSuites, data.Data["TLSCipherSuites"],
-		"TLSCipherSuites should use hardcoded legacy ciphers when adherence is unset")
-}
-
-func TestSetTLSTemplateData_StrictModernProfile(t *testing.T) {
+func TestSetTLSTemplateData_ModernProfile(t *testing.T) {
 	profile := *configv1.TLSProfiles[configv1.TLSProfileModernType]
 	r := &PtpOperatorConfigReconciler{
-		TLSProfileSpec:     profile,
-		TLSAdherencePolicy: configv1.TLSAdherencePolicyStrictAllComponents,
+		TLSProfileSpec: &profile,
 	}
 	data := render.MakeRenderData()
 	r.setTLSTemplateData(&data)

--- a/controllers/tls_watcher_test.go
+++ b/controllers/tls_watcher_test.go
@@ -1,0 +1,71 @@
+package controllers
+
+import (
+	"strings"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	libgocrypto "github.com/openshift/library-go/pkg/crypto"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/k8snetworkplumbingwg/ptp-operator/pkg/render"
+)
+
+const legacyCipherSuites = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256," +
+	"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256," +
+	"TLS_RSA_WITH_AES_128_CBC_SHA256," +
+	"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256," +
+	"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
+
+func TestSetTLSTemplateData_StrictMode(t *testing.T) {
+	profile := *configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+	r := &PtpOperatorConfigReconciler{
+		TLSProfileSpec:     profile,
+		TLSAdherencePolicy: configv1.TLSAdherencePolicyStrictAllComponents,
+	}
+	data := render.MakeRenderData()
+	r.setTLSTemplateData(&data)
+
+	expectedCiphers := strings.Join(libgocrypto.OpenSSLToIANACipherSuites(profile.Ciphers), ",")
+	assert.Equal(t, string(profile.MinTLSVersion), data.Data["TLSMinVersion"])
+	assert.Equal(t, expectedCiphers, data.Data["TLSCipherSuites"])
+}
+
+func TestSetTLSTemplateData_LegacyMode(t *testing.T) {
+	r := &PtpOperatorConfigReconciler{
+		TLSAdherencePolicy: configv1.TLSAdherencePolicyLegacyAdheringComponentsOnly,
+	}
+	data := render.MakeRenderData()
+	r.setTLSTemplateData(&data)
+
+	assert.Equal(t, "", data.Data["TLSMinVersion"],
+		"TLSMinVersion should be empty in legacy mode")
+	assert.Equal(t, legacyCipherSuites, data.Data["TLSCipherSuites"],
+		"TLSCipherSuites should use hardcoded legacy ciphers")
+}
+
+func TestSetTLSTemplateData_NoOpinionDefaultsToLegacy(t *testing.T) {
+	r := &PtpOperatorConfigReconciler{
+		TLSAdherencePolicy: configv1.TLSAdherencePolicyNoOpinion,
+	}
+	data := render.MakeRenderData()
+	r.setTLSTemplateData(&data)
+
+	assert.Equal(t, "", data.Data["TLSMinVersion"],
+		"TLSMinVersion should be empty when adherence is unset")
+	assert.Equal(t, legacyCipherSuites, data.Data["TLSCipherSuites"],
+		"TLSCipherSuites should use hardcoded legacy ciphers when adherence is unset")
+}
+
+func TestSetTLSTemplateData_StrictModernProfile(t *testing.T) {
+	profile := *configv1.TLSProfiles[configv1.TLSProfileModernType]
+	r := &PtpOperatorConfigReconciler{
+		TLSProfileSpec:     profile,
+		TLSAdherencePolicy: configv1.TLSAdherencePolicyStrictAllComponents,
+	}
+	data := render.MakeRenderData()
+	r.setTLSTemplateData(&data)
+
+	assert.Equal(t, "VersionTLS13", data.Data["TLSMinVersion"])
+	// TLS 1.3 ciphers are not configurable in Go, so cipher list may be empty
+}

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	openshifttls "github.com/openshift/controller-runtime-common/pkg/tls"
+	libgocrypto "github.com/openshift/library-go/pkg/crypto"
 
 	"github.com/k8snetworkplumbingwg/ptp-operator/pkg/names"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -86,18 +87,31 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 	le := leaderelection.GetLeaderElectionConfig(restConfig, enableLeaderElection)
 
-	// Fetch the TLS security profile from the APIServer CR.
+	// Fetch the TLS security profile and adherence policy from the APIServer CR.
 	// Defaults to the Intermediate profile if the CR is not accessible.
-	tlsProfileSpec, err := fetchTLSProfile(restConfig)
+	tlsProfileSpec, tlsAdherencePolicy, err := fetchTLSConfig(restConfig)
 	isOpenShiftCluster := err == nil
 	if !isOpenShiftCluster {
-		setupLog.Info("unable to fetch TLS profile from APIServer CR, using Intermediate profile", "error", err)
+		setupLog.Info("unable to fetch TLS config from APIServer CR, using Intermediate profile", "error", err)
 		tlsProfileSpec, _ = openshifttls.GetTLSProfileSpec(nil)
 	}
-	setupLog.Info("TLS security profile resolved", "minTLSVersion", tlsProfileSpec.MinTLSVersion, "ciphers", tlsProfileSpec.Ciphers)
-	tlsOption, unsupportedCiphers := openshifttls.NewTLSConfigFromProfile(tlsProfileSpec)
-	if len(unsupportedCiphers) > 0 {
-		setupLog.Info("some ciphers from the TLS profile are not supported", "unsupportedCiphers", unsupportedCiphers)
+	honorClusterTLS := libgocrypto.ShouldHonorClusterTLSProfile(tlsAdherencePolicy)
+	setupLog.Info("TLS security profile resolved",
+		"minTLSVersion", tlsProfileSpec.MinTLSVersion,
+		"ciphers", tlsProfileSpec.Ciphers,
+		"tlsAdherence", tlsAdherencePolicy,
+		"honorClusterTLSProfile", honorClusterTLS)
+
+	var tlsOption func(*tls.Config)
+	if honorClusterTLS {
+		var unsupportedCiphers []string
+		tlsOption, unsupportedCiphers = openshifttls.NewTLSConfigFromProfile(tlsProfileSpec)
+		if len(unsupportedCiphers) > 0 {
+			setupLog.Info("some ciphers from the TLS profile are not supported", "unsupportedCiphers", unsupportedCiphers)
+		}
+	} else {
+		setupLog.Info("TLS adherence is legacy, using default TLS configuration")
+		tlsOption = func(*tls.Config) {} // no-op: use Go defaults
 	}
 	disableHTTP2 := func(c *tls.Config) {
 		if !enableHTTP2 {
@@ -171,10 +185,11 @@ func main() {
 	}
 
 	if err = (&controllers.PtpOperatorConfigReconciler{
-		Client:         mgr.GetClient(),
-		Log:            ctrl.Log.WithName("controllers").WithName("PtpOperatorConfig"),
-		Scheme:         mgr.GetScheme(),
-		TLSProfileSpec: tlsProfileSpec,
+		Client:             mgr.GetClient(),
+		Log:                ctrl.Log.WithName("controllers").WithName("PtpOperatorConfig"),
+		Scheme:             mgr.GetScheme(),
+		TLSProfileSpec:     tlsProfileSpec,
+		TLSAdherencePolicy: tlsAdherencePolicy,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "PtpOperatorConfig")
 		os.Exit(1)
@@ -206,12 +221,19 @@ func main() {
 
 	if isOpenShiftCluster {
 		if err = (&openshifttls.SecurityProfileWatcher{
-			Client:                mgr.GetClient(),
-			InitialTLSProfileSpec: tlsProfileSpec,
+			Client:                    mgr.GetClient(),
+			InitialTLSProfileSpec:     tlsProfileSpec,
+			InitialTLSAdherencePolicy: tlsAdherencePolicy,
 			OnProfileChange: func(ctx context.Context, oldProfile, newProfile configv1.TLSProfileSpec) {
 				setupLog.Info("TLS security profile changed, initiating graceful shutdown",
 					"oldMinTLSVersion", oldProfile.MinTLSVersion,
 					"newMinTLSVersion", newProfile.MinTLSVersion)
+				cancel()
+			},
+			OnAdherencePolicyChange: func(ctx context.Context, oldPolicy, newPolicy configv1.TLSAdherencePolicy) {
+				setupLog.Info("TLS adherence policy changed, initiating graceful shutdown",
+					"oldPolicy", oldPolicy,
+					"newPolicy", newPolicy)
 				cancel()
 			},
 		}).SetupWithManager(mgr); err != nil {
@@ -308,18 +330,29 @@ func setupChecks(mgr ctrl.Manager, checker healthz.Checker) {
 	}
 }
 
-// fetchTLSProfile creates a temporary client to read the APIServer TLS profile at startup,
-// before the manager's cache is available.
-func fetchTLSProfile(cfg *rest.Config) (configv1.TLSProfileSpec, error) {
+// fetchTLSConfig creates a temporary client to read the APIServer TLS profile
+// and adherence policy at startup, before the manager's cache is available.
+func fetchTLSConfig(cfg *rest.Config) (configv1.TLSProfileSpec, configv1.TLSAdherencePolicy, error) {
 	s := runtime.NewScheme()
 	if err := configv1.Install(s); err != nil {
-		return configv1.TLSProfileSpec{}, fmt.Errorf("failed to add configv1 to scheme: %v", err)
+		return configv1.TLSProfileSpec{}, "", fmt.Errorf("failed to add configv1 to scheme: %v", err)
 	}
 	c, err := client.New(cfg, client.Options{Scheme: s})
 	if err != nil {
-		return configv1.TLSProfileSpec{}, fmt.Errorf("failed to create client: %v", err)
+		return configv1.TLSProfileSpec{}, "", fmt.Errorf("failed to create client: %v", err)
 	}
-	return openshifttls.FetchAPIServerTLSProfile(context.TODO(), c)
+	profileSpec, err := openshifttls.FetchAPIServerTLSProfile(context.TODO(), c)
+	if err != nil {
+		return configv1.TLSProfileSpec{}, "", err
+	}
+	adherencePolicy, err := openshifttls.FetchAPIServerTLSAdherencePolicy(context.TODO(), c)
+	if err != nil {
+		// Adherence policy fetch may fail on older clusters without the field.
+		// Default to no opinion (legacy behavior).
+		setupLog.Info("unable to fetch TLS adherence policy, defaulting to legacy behavior", "error", err)
+		adherencePolicy = configv1.TLSAdherencePolicyNoOpinion
+	}
+	return profileSpec, adherencePolicy, nil
 }
 
 // waitForWebhookServer waits until the webhook server is ready.

--- a/main.go
+++ b/main.go
@@ -103,7 +103,9 @@ func main() {
 		"honorClusterTLSProfile", honorClusterTLS)
 
 	var tlsOption func(*tls.Config)
+	var tlsProfileSpecPtr *configv1.TLSProfileSpec
 	if honorClusterTLS {
+		tlsProfileSpecPtr = &tlsProfileSpec
 		var unsupportedCiphers []string
 		tlsOption, unsupportedCiphers = openshifttls.NewTLSConfigFromProfile(tlsProfileSpec)
 		if len(unsupportedCiphers) > 0 {
@@ -185,11 +187,10 @@ func main() {
 	}
 
 	if err = (&controllers.PtpOperatorConfigReconciler{
-		Client:             mgr.GetClient(),
-		Log:                ctrl.Log.WithName("controllers").WithName("PtpOperatorConfig"),
-		Scheme:             mgr.GetScheme(),
-		TLSProfileSpec:     tlsProfileSpec,
-		TLSAdherencePolicy: tlsAdherencePolicy,
+		Client:         mgr.GetClient(),
+		Log:            ctrl.Log.WithName("controllers").WithName("PtpOperatorConfig"),
+		Scheme:         mgr.GetScheme(),
+		TLSProfileSpec: tlsProfileSpecPtr,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "PtpOperatorConfig")
 		os.Exit(1)
@@ -341,16 +342,21 @@ func fetchTLSConfig(cfg *rest.Config) (configv1.TLSProfileSpec, configv1.TLSAdhe
 	if err != nil {
 		return configv1.TLSProfileSpec{}, "", fmt.Errorf("failed to create client: %v", err)
 	}
-	profileSpec, err := openshifttls.FetchAPIServerTLSProfile(context.TODO(), c)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	profileSpec, err := openshifttls.FetchAPIServerTLSProfile(ctx, c)
 	if err != nil {
 		return configv1.TLSProfileSpec{}, "", err
 	}
-	adherencePolicy, err := openshifttls.FetchAPIServerTLSAdherencePolicy(context.TODO(), c)
+	adherencePolicy, err := openshifttls.FetchAPIServerTLSAdherencePolicy(ctx, c)
 	if err != nil {
-		// Adherence policy fetch may fail on older clusters without the field.
-		// Default to no opinion (legacy behavior).
-		setupLog.Info("unable to fetch TLS adherence policy, defaulting to legacy behavior", "error", err)
-		adherencePolicy = configv1.TLSAdherencePolicyNoOpinion
+		if errors.IsNotFound(err) {
+			// APIServer object not found — should not happen since we just
+			// fetched the TLS profile from it. Default to legacy behavior.
+			setupLog.Info("APIServer CR not found for adherence policy, defaulting to legacy behavior")
+			return profileSpec, configv1.TLSAdherencePolicyNoOpinion, nil
+		}
+		return configv1.TLSProfileSpec{}, "", fmt.Errorf("failed to fetch TLS adherence policy: %v", err)
 	}
 	return profileSpec, adherencePolicy, nil
 }


### PR DESCRIPTION
Read the tlsAdherence policy from the APIServer CR and use ShouldHonorClusterTLSProfile to conditionally apply the cluster TLS profile. In Legacy mode (default), Go TLS defaults are used. In Strict mode, the cluster-wide TLS profile is enforced on the operator's webhook/metrics servers and on the daemon's kube-rbac-proxy.

The SecurityProfileWatcher now also monitors adherence policy changes and triggers a graceful restart when the policy changes.