### PR TITLE
Refactor TLS Adherence and only run deploy-ec2 on upstream

### DIFF
--- a/.github/workflows/aws-ci.yaml
+++ b/.github/workflows/aws-ci.yaml
@@ -11,6 +11,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   deploy-ec2:
+    if: github.repository == 'k8snetworkplumbingwg/ptp-operator'
     runs-on: ubuntu-latest
     timeout-minutes: 115
     steps:

--- a/controllers/tls_profile_test.go
+++ b/controllers/tls_profile_test.go
@@ -130,11 +130,7 @@ func TestTLSProfileTemplateRendering_LegacyAdherence(t *testing.T) {
 	// cipher suites that were in place before cluster TLS profile support.
 	data := makeTestRenderData()
 	data.Data["TLSMinVersion"] = ""
-	data.Data["TLSCipherSuites"] = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256," +
-		"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256," +
-		"TLS_RSA_WITH_AES_128_CBC_SHA256," +
-		"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256," +
-		"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
+	data.Data["TLSCipherSuites"] = legacyCipherSuites
 
 	objs, err := render.RenderTemplate("../bindata/linuxptp/ptp-daemon.yaml", data)
 	assert.NoError(t, err)
@@ -165,11 +161,7 @@ func TestTLSProfileTemplateRendering_LegacyAdherence(t *testing.T) {
 				"TLS min version should not be set in legacy adherence mode")
 		}
 		assert.Contains(t, rbacProxyArgs,
-			"--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,"+
-				"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,"+
-				"TLS_RSA_WITH_AES_128_CBC_SHA256,"+
-				"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,"+
-				"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256")
+			"--tls-cipher-suites="+legacyCipherSuites)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -336,17 +336,17 @@ func setupChecks(mgr ctrl.Manager, checker healthz.Checker) {
 func fetchTLSConfig(cfg *rest.Config) (configv1.TLSProfileSpec, configv1.TLSAdherencePolicy, error) {
 	s := runtime.NewScheme()
 	if err := configv1.Install(s); err != nil {
-		return configv1.TLSProfileSpec{}, "", fmt.Errorf("failed to add configv1 to scheme: %v", err)
+		return configv1.TLSProfileSpec{}, configv1.TLSAdherencePolicyNoOpinion, fmt.Errorf("failed to add configv1 to scheme: %v", err)
 	}
 	c, err := client.New(cfg, client.Options{Scheme: s})
 	if err != nil {
-		return configv1.TLSProfileSpec{}, "", fmt.Errorf("failed to create client: %v", err)
+		return configv1.TLSProfileSpec{}, configv1.TLSAdherencePolicyNoOpinion, fmt.Errorf("failed to create client: %v", err)
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	profileSpec, err := openshifttls.FetchAPIServerTLSProfile(ctx, c)
 	if err != nil {
-		return configv1.TLSProfileSpec{}, "", err
+		return configv1.TLSProfileSpec{}, configv1.TLSAdherencePolicyNoOpinion, err
 	}
 	adherencePolicy, err := openshifttls.FetchAPIServerTLSAdherencePolicy(ctx, c)
 	if err != nil {
@@ -356,7 +356,7 @@ func fetchTLSConfig(cfg *rest.Config) (configv1.TLSProfileSpec, configv1.TLSAdhe
 			setupLog.Info("APIServer CR not found for adherence policy, defaulting to legacy behavior")
 			return profileSpec, configv1.TLSAdherencePolicyNoOpinion, nil
 		}
-		return configv1.TLSProfileSpec{}, "", fmt.Errorf("failed to fetch TLS adherence policy: %v", err)
+		return configv1.TLSProfileSpec{}, configv1.TLSAdherencePolicyNoOpinion, fmt.Errorf("failed to fetch TLS adherence policy: %v", err)
 	}
 	return profileSpec, adherencePolicy, nil
 }


### PR DESCRIPTION
Refactor TLS Adherence
Also update the aws-ci.yaml to only run deploy-ec2 on upstream