### PR TITLE
CNF-22878: Fix VerifyNICClockClass to handle missing config label on OCP < 4.18

### DIFF
--- a/test/conformance/serial/ptp.go
+++ b/test/conformance/serial/ptp.go
@@ -1111,21 +1111,21 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 
 				// Step 1: verify initial locked state via PMC, metrics, and events
 				By("Step 1: Verifying NIC reports clockClass 6 (initial locked state)")
-				ptptesthelper.VerifyNICClockClass(fullConfig, nic1, locked)
+				ptptesthelper.VerifyNICClockClass(fullConfig, nic1, locked, false)
 				verifyClockClassViaEvent(evCtx, locked)
 
 				// Step 2: cut upstream sync by bringing slave interface down
 				By(fmt.Sprintf("Step 2: Locking NIC-1 PTP source (bringing down %s)", nic1.SlaveIf))
 				portEngine.TurnOffAndWaitFaulty(nic1.SlaveIf, nodeName)
 				// Clock should transition to freerun (248) without its time source
-				ptptesthelper.VerifyNICClockClass(fullConfig, nic1, freerun)
+				ptptesthelper.VerifyNICClockClass(fullConfig, nic1, freerun, false)
 				verifyClockClassViaEvent(evCtx, freerun)
 
 				// Step 3: restore upstream sync by bringing slave interface back up
 				By(fmt.Sprintf("Step 3: Unlocking NIC-1 PTP source (bringing up %s)", nic1.SlaveIf))
 				portEngine.TurnOnAndWaitSlave(nic1.SlaveIf, nodeName)
 				// Clock should recover to locked (6)
-				ptptesthelper.VerifyNICClockClass(fullConfig, nic1, locked)
+				ptptesthelper.VerifyNICClockClass(fullConfig, nic1, locked, false)
 				verifyClockClassViaEvent(evCtx, locked)
 			})
 
@@ -1169,8 +1169,8 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 
 				// Step 1: all NICs should report clockClass 6 (locked)
 				By("Step 1: Verifying all NICs report clockClass 6 (initial locked state)")
-				ptptesthelper.VerifyNICClockClass(fullConfig, nic1, locked)
-				ptptesthelper.VerifyNICClockClass(fullConfig, nic2, locked)
+				ptptesthelper.VerifyNICClockClass(fullConfig, nic1, locked, true)
+				ptptesthelper.VerifyNICClockClass(fullConfig, nic2, locked, true)
 				verifyClockClassViaEvent(evCtx, locked)
 
 				// Step 2: lock NIC-2's PTP source
@@ -1179,8 +1179,8 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 
 				// Step 3: NIC-1 still locked, NIC-2 now freerun
 				By("Step 3: Verifying NIC-1=6, NIC-2=248")
-				ptptesthelper.VerifyNICClockClass(fullConfig, nic1, locked)
-				ptptesthelper.VerifyNICClockClass(fullConfig, nic2, freerun)
+				ptptesthelper.VerifyNICClockClass(fullConfig, nic1, locked, true)
+				ptptesthelper.VerifyNICClockClass(fullConfig, nic2, freerun, true)
 				verifyClockClassViaEvent(evCtx, freerun)
 
 				// Step 4: swap — lock NIC-1, unlock NIC-2
@@ -1190,8 +1190,8 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 
 				// Step 5: NIC-1 now freerun, NIC-2 recovered to locked
 				By("Step 5: Verifying NIC-1=248, NIC-2=6")
-				ptptesthelper.VerifyNICClockClass(fullConfig, nic1, freerun)
-				ptptesthelper.VerifyNICClockClass(fullConfig, nic2, locked)
+				ptptesthelper.VerifyNICClockClass(fullConfig, nic1, freerun, true)
+				ptptesthelper.VerifyNICClockClass(fullConfig, nic2, locked, true)
 				verifyClockClassViaEvent(evCtx, freerun)
 			})
 		})

--- a/test/pkg/ptptesthelper/ptptesthelper.go
+++ b/test/pkg/ptptesthelper/ptptesthelper.go
@@ -749,11 +749,54 @@ func VerifyPerConfigClockClassWithMetrics(fullConfig testconfig.TestConfig, conf
 		fmt.Sprintf("Expected metrics clock class %d for config %s", expectedClass, configName))
 }
 
-// VerifyNICClockClass checks the expected clock class for a NIC via PMC
-// and per-config Prometheus metrics.
-func VerifyNICClockClass(fullConfig testconfig.TestConfig, nic NICInfo, expectedClass int) {
+// nodeClockClassRe matches openshift_ptp_clock_class without the config label (4.16/4.17).
+var nodeClockClassRe = regexp.MustCompile(`^openshift_ptp_clock_class\{node="([^"]+)",process="ptp4l"\}\s+(\d+)`)
+
+// getNodeClockClassFromMetrics returns the clock class from the node-level metric
+// (without config label, used on OCP < 4.18).
+func getNodeClockClassFromMetrics(fullConfig testconfig.TestConfig) (int, error) {
+	buf, _, err := pods.ExecCommand(client.Client, true, fullConfig.DiscoveredClockUnderTestPod,
+		pkg.PtpContainerName, []string{"curl", pkg.MetricsEndPoint})
+	if err != nil {
+		return -1, fmt.Errorf("error getting metrics: %v", err)
+	}
+	scanner := bufio.NewScanner(strings.NewReader(buf.String()))
+	for scanner.Scan() {
+		matches := nodeClockClassRe.FindStringSubmatch(scanner.Text())
+		if len(matches) >= 3 {
+			return strconv.Atoi(matches[2])
+		}
+	}
+	return -1, fmt.Errorf("openshift_ptp_clock_class metric not found")
+}
+
+// verifyNodeClockClassWithMetrics polls the node-level clock class metric (no config label)
+// until the expected value is seen. Used on OCP < 4.18 for single NIC.
+func verifyNodeClockClassWithMetrics(fullConfig testconfig.TestConfig, expectedClass int) {
+	Eventually(func() int {
+		cc, err := getNodeClockClassFromMetrics(fullConfig)
+		if err != nil {
+			fmt.Fprintf(GinkgoWriter, "Node-level clock class metric error: %v\n", err)
+			return -1
+		}
+		fmt.Fprintf(GinkgoWriter, "Node-level clock class metric: %d (expected %d)\n", cc, expectedClass)
+		return cc
+	}, pkg.TimeoutIn5Minutes, 5*time.Second).Should(Equal(expectedClass),
+		fmt.Sprintf("Expected node-level clock class metric %d", expectedClass))
+}
+
+// VerifyNICClockClass checks the expected clock class for a NIC via PMC and metrics.
+// isDualNIC controls the metric check on OCP < 4.18:
+//   - On OCP >= 4.18: always verifies via per-config metric (config label available).
+//   - On OCP < 4.18, single NIC: verifies via node-level metric (no config label).
+//   - On OCP < 4.18, dual NIC: metrics skipped (single metric can't distinguish NICs).
+func VerifyNICClockClass(fullConfig testconfig.TestConfig, nic NICInfo, expectedClass int, isDualNIC bool) {
 	VerifyClockClassViaPMC(fullConfig, nic.ConfigFile, expectedClass)
-	VerifyPerConfigClockClassWithMetrics(fullConfig, nic.ConfigName, expectedClass)
+	if ptphelper.IsPTPOperatorVersionAtLeast("4.18") {
+		VerifyPerConfigClockClassWithMetrics(fullConfig, nic.ConfigName, expectedClass)
+	} else if !isDualNIC {
+		verifyNodeClockClassWithMetrics(fullConfig, expectedClass)
+	}
 }
 
 // TurnOffAndWaitFaulty brings the interface down and polls until its clock role


### PR DESCRIPTION
## Summary

- **Fixes version-dependent CI failures** where `VerifyNICClockClass` timed out waiting for the `openshift_ptp_clock_class{config=...}` per-config Prometheus metric on OCP 4.16/4.17. The `config` label was only added to this metric in `cloud-event-proxy` starting from OCP 4.18.
- **Adds version-aware metric verification** using `IsPTPOperatorVersionAtLeast("4.18")`:
  - **OCP >= 4.18**: PMC + per-config metric (with `config` label)
  - **OCP < 4.18, single NIC**: PMC + node-level metric (without `config` label)
  - **OCP < 4.18, dual NIC**: PMC only (a single node-level metric cannot distinguish between two NICs)
- **Passes `isDualNIC` parameter** to `VerifyNICClockClass` from `ptp.go` so the helper knows which verification path to take.

## Root Cause

On OCP 4.16/4.17, `cloud-event-proxy` registers `openshift_ptp_clock_class` with only `node` and `process` labels (no `config` label). The existing `perConfigClockClassRe` regex expects `config="..."`, so it never matched, causing 5-minute timeouts on every call to `VerifyPerConfigClockClassWithMetrics`.

## Changes

| File | Change |
|------|--------|
| `test/pkg/ptptesthelper/ptptesthelper.go` | Added `nodeClockClassRe`, `getNodeClockClassFromMetrics`, `verifyNodeClockClassWithMetrics`; refactored `VerifyNICClockClass` to be version- and NIC-aware |
| `test/conformance/serial/ptp.go` | Pass `isDualNIC` (`false` for single NIC, `true` for dual NIC) to all `VerifyNICClockClass` calls |

## Linked Issues

- [CNF-22878](https://redhat.atlassian.net/browse/CNF-22878)
