### PR TITLE
fix: add sync gates to eliminate CI test race conditions

### DIFF
--- a/test/conformance/serial/ptp.go
+++ b/test/conformance/serial/ptp.go
@@ -907,11 +907,24 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 						}
 					})
 
+					// Wait for operator to reconcile the config map with the
+					// temp profile before restarting the daemon pod, so the new
+					// pod starts with the correct config on first boot.
+					err = ptphelper.WaitForConfigMapProfile(nodes.Items[0].Name, pkg.PtpTempPolicyName, 2*time.Minute)
+					Expect(err).NotTo(HaveOccurred(), "operator did not reconcile temp profile into configmap in time")
+
 					testPtpPod, err = ptphelper.GetPtpPodOnNode(nodes.Items[0].Name)
 					Expect(err).NotTo(HaveOccurred())
 
 					testPtpPod, err = ptphelper.ReplaceTestPod(&testPtpPod, time.Minute)
 					Expect(err).NotTo(HaveOccurred())
+				})
+
+				By("Waiting for daemon to load the temp profile", func() {
+					_, err := pods.GetPodLogsRegex(testPtpPod.Namespace,
+						testPtpPod.Name, pkg.PtpContainerName,
+						"Profile Name: "+pkg.PtpTempPolicyName, true, pkg.TimeoutIn3Minutes)
+					Expect(err).NotTo(HaveOccurred(), "daemon did not load temp profile in time")
 				})
 
 				By("Checking if Node has Profile and check sync", func() {

--- a/test/pkg/ptphelper/ptphelper.go
+++ b/test/pkg/ptphelper/ptphelper.go
@@ -384,6 +384,35 @@ func PtpDiscoveredInterfaceList(nodeName string) []string {
 	return ptpInterfaces
 }
 
+// WaitForConfigMapProfile polls the ptp-configmap until the given node's entry
+// contains the expected profile name (qualified or unqualified substring).
+// This ensures the operator has reconciled and the daemon will see the new
+// config when it starts or detects the change.
+func WaitForConfigMapProfile(nodeName, profileSubstring string, timeout time.Duration) error {
+	var lastErr error
+	Eventually(func() error {
+		cm, err := client.Client.CoreV1().ConfigMaps(pkg.PtpLinuxDaemonNamespace).Get(
+			context.Background(), "ptp-configmap", metav1.GetOptions{})
+		if err != nil {
+			lastErr = fmt.Errorf("could not get configmap: %v", err)
+			return lastErr
+		}
+		data, ok := cm.Data[nodeName]
+		if !ok {
+			lastErr = fmt.Errorf("node %s not found in configmap", nodeName)
+			return lastErr
+		}
+		if !strings.Contains(data, profileSubstring) {
+			lastErr = fmt.Errorf("profile %q not found in configmap for node %s", profileSubstring, nodeName)
+			return lastErr
+		}
+		return nil
+	}, timeout, 2*time.Second).Should(BeNil(),
+		fmt.Sprintf("timed out waiting for profile %q in configmap for node %s: %v",
+			profileSubstring, nodeName, lastErr))
+	return nil
+}
+
 func MutateProfile(profile *ptpv1.PtpConfig, profileName, nodeName string) *ptpv1.PtpConfig {
 	mutatedConfig := profile.DeepCopy()
 	priority := int64(0)


### PR DESCRIPTION
### This PR is mainly for testing whether we get more consistent tests passing and that we get rid of flaky fails.

Add synchronization gates and retry logic to the conformance test helpers to ensure tests wait for the full operator→configmap→daemon pipeline to complete before asserting on logs and metrics.

CI conformance tests are flaky because they proceed before the system has reached a consistent state. Log-based lookups fail when the daemon hasn't finished starting, and pod replacements race against operator reconciliation, causing non-deterministic failures that vary in location from run to run.

Tests now explicitly gate on each stage of the pipeline: the configmap reflecting the expected profile, the daemon logging that it loaded the profile, and the foreign master appearing in the log stream. This replaces the previous eager-fail behavior where a single transient log gap would abort the entire test before any retry logic could run.