### PR TITLE
Fix flaky clockClass tests: prevent NetworkManager from auto-recovering downed interfaces

### DIFF
--- a/test/pkg/ptptesthelper/ptptesthelper.go
+++ b/test/pkg/ptptesthelper/ptptesthelper.go
@@ -799,9 +799,12 @@ func VerifyNICClockClass(fullConfig testconfig.TestConfig, nic NICInfo, expected
 	}
 }
 
-// TurnOffAndWaitFaulty brings the interface down and polls until its clock role
-// becomes FAULTY, failing the test on timeout.
+// TurnOffAndWaitFaulty disables NetworkManager management on the interface,
+// brings it down, and polls until its clock role becomes FAULTY. Disabling NM
+// prevents it from auto-recovering the link while the test expects it to stay down.
 func (p *PortEngine) TurnOffAndWaitFaulty(iface, nodeName string) {
+	p.nmSetManaged(iface, false)
+	DeferCleanup(p.nmSetManaged, iface, true)
 	err := p.TurnPortDown(iface)
 	Expect(err).NotTo(HaveOccurred())
 	Eventually(func() error {
@@ -811,14 +814,32 @@ func (p *PortEngine) TurnOffAndWaitFaulty(iface, nodeName string) {
 		iface+" should be FAULTY")
 }
 
-// TurnOnAndWaitSlave brings the interface up and polls until its clock role
-// recovers to SLAVE, failing the test on timeout.
+// TurnOnAndWaitSlave brings the interface up, re-enables NetworkManager
+// management, and polls until its clock role recovers to SLAVE.
 func (p *PortEngine) TurnOnAndWaitSlave(iface, nodeName string) {
 	err := p.TurnPortUp(iface)
 	Expect(err).NotTo(HaveOccurred())
+	p.nmSetManaged(iface, true)
 	Eventually(func() error {
 		return metrics.CheckClockRole([]metrics.MetricRole{metrics.MetricRoleSlave},
 			[]string{iface}, &nodeName)
 	}, pkg.TimeoutIn5Minutes, 5*time.Second).Should(BeNil(),
 		iface+" should recover to SLAVE")
+}
+
+// nmSetManaged tells NetworkManager to start or stop managing an interface.
+// This prevents NM from auto-recovering a link that the test brought down.
+// Silently ignored when nmcli is not available (e.g. Kind clusters).
+func (p *PortEngine) nmSetManaged(port string, managed bool) {
+	val := "no"
+	if managed {
+		val = "yes"
+	}
+	stdout, _, err := pods.ExecCommand(client.Client, true, p.ClockPod, pkg.RecoveryNetworkOutageDaemonSetContainerName,
+		[]string{"chroot", "/host", "nmcli", "device", "set", port, "managed", val})
+	if err != nil {
+		logrus.Debugf("nmcli not available for %s (expected on Kind): %v", port, err)
+		return
+	}
+	logrus.Infof("NM set managed=%s for %s: output: %s", val, port, stdout.String())
 }


### PR DESCRIPTION
## Summary

- **Root cause**: During clockClass verification tests (`bc-serial` and `dualnicbcha-serial`), the test brings a slave interface down (`ip link set <iface> down`) to simulate PTP source loss and then verifies the NIC transitions to `clockClass 248` (FREERUN). However, NetworkManager—running on every RHCOS node—detects the admin-down interface and **automatically brings it back up within 4–7 seconds**. This causes the NIC to re-sync with its upstream GM and return to `clockClass 6` before the test can verify `clockClass 248`, resulting in intermittent test failures.
- **Evidence from CI logs**: Analysis of `cloud-event-proxy` logs confirmed the interface bounce:
  - **Failing run** (OCP 4.21, Apr 16): `ens2f1` bounced back in **4.1 seconds** — the test polled at 5.7s and found `clockClass 6` instead of `248`.
  - **Passing run** (OCP 4.21, Apr 15): `ens2f1` bounced back in **6.8 seconds** — the test finished verification just in time before NM recovered the link.
- **Fix**: Before bringing an interface down, tell NetworkManager to stop managing it (`nmcli device set <iface> managed no`). After bringing it back up, re-enable management (`managed yes`). This is done in `TurnOffAndWaitFaulty` and `TurnOnAndWaitSlave` via a new `nmSetManaged` helper. The primitive `TurnPortDown`/`TurnPortUp` functions remain unchanged.
- The `nmcli` call is silently ignored when unavailable (e.g. Kind clusters), so this change is safe for all environments.
- This makes the test more faithful to real-world behavior: a physical cable pull (what customers experience) does not auto-recover, so disabling NM management on a test-downed interface is the correct simulation.

## Test plan

- [ ] `bc-serial`: Verify clockClass transitions to 248 on single NIC boundary clock when slave interface is brought down
- [ ] `dualnicbcha-serial`: Verify clockClass transitions to 248 on NIC-1 while NIC-2 recovers to 6 in dual NIC boundary clock scenario
- [ ] Verify that other tests using `TurnPortDown`/`TurnPortUp` directly are not affected (these functions are unchanged)
- [ ] Verify graceful handling when `nmcli` is not available (Kind clusters)