### PR TITLE
add coverage gate to block PRs with decreasing coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,42 @@
+name: "Coverage Quality Gate"
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  coverage:
+    if: "!contains(github.event.pull_request.labels.*.name, 'skip-coverage')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Generate Coverage
+        run: |
+          go test $(go list ./... | grep -v '/test/') -coverprofile=coverage.raw.out
+          grep -vE "zz_generated|mock_|/test/|vendor/|/bin/" coverage.raw.out > coverage.out
+
+      - name: Generate Base Coverage
+        if: github.event_name == 'pull_request'
+        run: |
+          git checkout ${{ github.event.pull_request.base.sha }}
+          go test $(go list ./... | grep -v '/test/') -coverprofile=coverage.raw.out
+          grep -vE "zz_generated|mock_|/test/|vendor/|/bin/" coverage.raw.out > coverage.out
+          go run github.com/vladopajic/go-test-coverage/v2@v2.17.1 -p coverage.out --breakdown-file-name base-coverage.json
+          git checkout ${{ github.sha }}
+
+      - name: Check Coverage Regressions
+        if: github.event_name == 'pull_request'
+        uses: vladopajic/go-test-coverage@v2
+        with:
+          profile: coverage.out
+          base-breakdown-file: base-coverage.json
+          diff-threshold: 0

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,24 +19,10 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Coverage Gate
+        if: github.event_name == 'pull_request'
+        run: make coverage-gate BASE_REF=${{ github.event.pull_request.base.sha }}
+
       - name: Generate Coverage
-        run: |
-          go test $(go list ./... | grep -v '/test/') -coverprofile=coverage.raw.out
-          grep -vE "zz_generated|mock_|/test/|vendor/|/bin/" coverage.raw.out > coverage.out
-
-      - name: Generate Base Coverage
-        if: github.event_name == 'pull_request'
-        run: |
-          git checkout ${{ github.event.pull_request.base.sha }}
-          go test $(go list ./... | grep -v '/test/') -coverprofile=coverage.raw.out
-          grep -vE "zz_generated|mock_|/test/|vendor/|/bin/" coverage.raw.out > coverage.out
-          go run github.com/vladopajic/go-test-coverage/v2@v2.17.1 -p coverage.out --breakdown-file-name base-coverage.json
-          git checkout ${{ github.sha }}
-
-      - name: Check Coverage Regressions
-        if: github.event_name == 'pull_request'
-        uses: vladopajic/go-test-coverage@v2
-        with:
-          profile: coverage.out
-          base-breakdown-file: base-coverage.json
-          diff-threshold: 0
+        if: github.event_name == 'push'
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -127,11 +127,13 @@ fmt-code: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
-#ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
-#test: manifests generate fmt vet ## Run tests.
-#	mkdir -p ${ENVTEST_ASSETS_DIR}
-#	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
-#	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./... -coverprofile cover.out
+.PHONY: test
+test: ## Run unit tests with coverage
+	./hack/unit-test.sh
+
+.PHONY: coverage-gate
+coverage-gate: ## Compare coverage against a base ref (default: main)
+	./hack/coverage-gate.sh $(BASE_REF)
 
 ##@ Build
 

--- a/README.md
+++ b/README.md
@@ -69,18 +69,18 @@ metadata:
 ```
 ## PtpConfig
 
-`PtpConfig` CRD is used to define linuxptp configurations and to which node these 
-linuxptp configurations shall be applied. 
-The Spec of CR has two major sections. 
+`PtpConfig` CRD is used to define linuxptp configurations and to which node these
+linuxptp configurations shall be applied.
+The Spec of CR has two major sections.
 The first section `profile` contains `interface`, `ptp4lOpts`, `phc2sysOpts` and `ptp4lConf` options,
 the second `recommend` defines profile selection logic.
 ```
  PTP operator supports T-BC and Ordinary clock which can be configured via ptpConfig
 ```
 ### ptpConfig to set up ordinary clock using single interface
-``` 
-NOTE: following ptp4l/phc2sys opts required when events are enabled 
-    ptp4lOpts: "-2 -s --summary_interval -4" 
+```
+NOTE: following ptp4l/phc2sys opts required when events are enabled
+    ptp4lOpts: "-2 -s --summary_interval -4"
     phc2sysOpts: "-a -r -m -n 24 -N 8 -R 16"
 ```
 ```
@@ -102,9 +102,9 @@ spec:
     - nodeLabel: "node-role.kubernetes.io/worker"
 ```
 ### ptpConfig to set up boundary clock using multiple interface
-``` 
-NOTE: following ptp4l/phc2sys opts required when events are enabled 
-    ptp4lOpts: "-2 --summary_interval -4" 
+```
+NOTE: following ptp4l/phc2sys opts required when events are enabled
+    ptp4lOpts: "-2 --summary_interval -4"
     phc2sysOpts: "-a -r -m -n 24 -N 8 -R 16"
 ```
 ```
@@ -143,7 +143,7 @@ spec:
   - name: "profile1"
     ...
     ...
-    ......   
+    ......
     ptpClockThreshold:
       holdOverTimeout: 24 # in secs
       maxOffsetThreshold: 100 #in nano secs
@@ -153,7 +153,7 @@ spec:
     priority: 4
     match:
     - nodeLabel: "node-role.kubernetes.io/worker"
-    
+
 ```
 ### ptpConfig to filter 'master offset' and 'delay   filtered' logs
 ```
@@ -167,7 +167,7 @@ spec:
   - name: "profile1"
     ...
     ...
-    ......   
+    ......
     ptpSettings:
       stdoutFilter: "^.*delay   filtered.*$"
       logReduce: "true"
@@ -176,7 +176,7 @@ spec:
     priority: 4
     match:
     - nodeLabel: "node-role.kubernetes.io/worker"
-    
+
 ```
 ### ptpConfig to filter 'master offset' logs and report periodic summary every 5 seconds
 ```
@@ -190,7 +190,7 @@ spec:
   - name: "profile1"
     ...
     ...
-    ......   
+    ......
     ptpSettings:
       logReduce: "enhanced 5s 100"
   recommend:
@@ -198,7 +198,7 @@ spec:
     priority: 4
     match:
     - nodeLabel: "node-role.kubernetes.io/worker"
-    
+
 ```
 ### ptpConfig to configure as WPC NIC as GM
 ```
@@ -212,7 +212,7 @@ spec:
   - name: "profile1"
     ...
     ...
-    ......   
+    ......
     plugins:
       e810:
         enableDefaultConfig: true
@@ -245,7 +245,7 @@ spec:
      network_option 2
      extended_tlv 1
      recover_time 60
-     clock_id 
+     clock_id
      module_name ice
 
      [enp59s0f0np0]
@@ -262,7 +262,7 @@ spec:
     priority: 4
     match:
     - nodeLabel: "node-role.kubernetes.io/worker"
-    
+
 ```
 
 In above examples, `profile1` will be applied by `linuxptp-daemon` to nodes labeled with `node-role.kubernetes.io/worker`.
@@ -270,7 +270,7 @@ In above examples, `profile1` will be applied by `linuxptp-daemon` to nodes labe
 `xxx-ptpconfig` CR is created with `PtpConfig` kind. `spec.profile` defines profile named `profile1` which contains `interface (enp134s0f0)` to run ptp4l process on, `ptp4lOpts (-s -2)` sysconfig options to run ptp4l process with and `phc2sysOpts (-a -r)` to run phc2sys process with. `spec.recommend` defines `priority` (lower numbers mean higher priority, 0 is the highest priority) and `match` rules of profile `profile1`. `priority` is useful when there are multiple `PtpConfig` CRs defined, linuxptp daemon applies `match` rules against node labels and names from high priority to low priority in order. If any of `nodeLabel` or `nodeName` on a specific node matches with the node label or name where daemon runs, it applies profile on that node.
 
 #### Automatic leap second file management
-The T-GM system depends on having the most recent leap second information. This data comes in a file that shows the difference in seconds between Coordinated Universal Time (UTC) and International Atomic Time (TAI). This file is regularly updated by the International Earth Rotation and Reference Systems Service (IERS). 
+The T-GM system depends on having the most recent leap second information. This data comes in a file that shows the difference in seconds between Coordinated Universal Time (UTC) and International Atomic Time (TAI). This file is regularly updated by the International Earth Rotation and Reference Systems Service (IERS).
 The latest leap seconds file can be downloaded from https://hpiers.obspm.fr/iers/bul/bulc/ntp/leap-seconds.list.
 While the PTP operator container image includes the latest leap second information at build time, the system can automatically update the leap second file using announcements received through GPS to ensure it stays current.
 
@@ -313,6 +313,30 @@ Requirements:
 Two ptp4l configurations must exist with the phc2sysOPts field set to an empty string.
 The names of these ptp4l configurations will be used and listed under the ptpSettings/haProfiles key in the phc2sys-only enabled ptpConfig.
 
+
+## Test Coverage
+
+Run `make coverage-gate` to compare test coverage of your branch against the upstream main branch. The script auto-detects the upstream remote and its tracking branch.
+
+```sh
+$ make coverage-gate
+
+Base coverage (up-main): 16.2%
+Current coverage:            16.2%
+Difference:                  0%
+✅ Coverage unchanged.
+```
+
+You can also compare against a specific branch:
+
+```sh
+$ BASE_REF=release-4.20 make coverage-gate
+
+Base coverage (release-4.20): 10.3%
+Current coverage:            16.2%
+Difference:                  5.9%
+🎉 Coverage increased by 5.9%, good job!
+```
 
 ## Quick Start
 

--- a/hack/coverage-gate.sh
+++ b/hack/coverage-gate.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Compare test coverage of the current branch against a base ref.
+# Usage: hack/coverage-gate.sh [base-ref]
+# When base-ref is omitted, auto-detects the local branch tracking
+# the upstream k8snetworkplumbingwg remote's default branch.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+resolve_base_ref() {
+  if [ -n "$1" ]; then
+    echo "$1"
+    return
+  fi
+
+  # Find the remote pointing to k8snetworkplumbingwg
+  UPSTREAM_REMOTE=$(git remote -v | grep 'k8snetworkplumbingwg/.*fetch' | awk '{print $1}' | head -1)
+  if [ -z "${UPSTREAM_REMOTE}" ]; then
+    echo "main"
+    return
+  fi
+
+  git fetch "${UPSTREAM_REMOTE}" --quiet
+
+  # Find the default branch of the upstream remote
+  UPSTREAM_HEAD=$(git remote show "${UPSTREAM_REMOTE}" | sed -n '/HEAD branch/s/.*: //p')
+  UPSTREAM_REF="${UPSTREAM_REMOTE}/${UPSTREAM_HEAD}"
+
+  # Find or create a local branch tracking this remote branch
+  LOCAL_BRANCH=$(git branch --list --format='%(refname:short) %(upstream:short)' | grep " ${UPSTREAM_REF}$" | awk '{print $1}' | head -1)
+  if [ -z "${LOCAL_BRANCH}" ]; then
+    LOCAL_BRANCH="up-${UPSTREAM_HEAD}"
+    echo "==> Creating tracking branch '${LOCAL_BRANCH}' for '${UPSTREAM_REF}'..." >&2
+    git branch "${LOCAL_BRANCH}" "${UPSTREAM_REF}" --quiet
+    git branch --set-upstream-to="${UPSTREAM_REF}" "${LOCAL_BRANCH}" --quiet >/dev/null
+  fi
+
+  # Update tracking branch to latest without checkout
+  git branch -f "${LOCAL_BRANCH}" "${UPSTREAM_REF}" --quiet
+
+  echo "${LOCAL_BRANCH}"
+}
+
+BASE_REF=$(resolve_base_ref "$1")
+
+echo "==> Running tests on current branch..."
+"${SCRIPT_DIR}/unit-test.sh"
+CURRENT_COV=$(go tool cover -func=coverage.out | grep ^total | awk '{print $3}' | tr -d '%')
+
+echo "==> Running tests on base ref '${BASE_REF}'..."
+CURRENT_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || git rev-parse HEAD)
+TMPTEST=$(mktemp)
+cp "${SCRIPT_DIR}/unit-test.sh" "${TMPTEST}"
+STASHED=false
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  git stash --quiet
+  STASHED=true
+fi
+git checkout "${BASE_REF}" --quiet
+bash "${TMPTEST}"
+rm -f "${TMPTEST}"
+BASE_COV=$(go tool cover -func=coverage.out | grep ^total | awk '{print $3}' | tr -d '%')
+git checkout "${CURRENT_BRANCH}" --quiet
+if [ "${STASHED}" = true ]; then
+  git stash pop --quiet
+fi
+
+DIFF=$(echo "${CURRENT_COV} - ${BASE_COV}" | bc)
+echo ""
+echo "Base coverage (${BASE_REF}): ${BASE_COV}%"
+echo "Current coverage:            ${CURRENT_COV}%"
+echo "Difference:                  ${DIFF}%"
+
+if (( $(echo "${DIFF} < 0" | bc -l) )); then
+  echo "❌ FAIL: Coverage decreased by ${DIFF}%"
+  exit 1
+elif (( $(echo "${DIFF} > 0" | bc -l) )); then
+  echo "🎉 Coverage increased by ${DIFF}%, good job!"
+else
+  echo "✅ Coverage unchanged."
+fi

--- a/hack/unit-test.sh
+++ b/hack/unit-test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Run unit tests and generate filtered coverage profile.
+set -e
+go test $(go list ./... | grep -v '/test/') -coverprofile=coverage.raw.out
+grep -vE "zz_generated|mock_|/test/|vendor/|/bin/" coverage.raw.out > coverage.out


### PR DESCRIPTION
Introduces a GitHub Action to enforce unit test coverage.

- Generates coverage profile for all packages, excluding e2e tests.
- Filters out auto-generated code (zz_generated, mocks, etc.) and the
  top-level /test directory to ensure metrics reflect core logic.
- On PRs, generates baseline coverage from the base branch and
  blocks if coverage decreases relative to that baseline.
- Supports skip-coverage label to bypass the check when needed.