### PR TITLE
ci: fix check-changes to fetch PR head for fork PRs

### DIFF
--- a/.github/workflows/aws-ci.yaml
+++ b/.github/workflows/aws-ci.yaml
@@ -18,6 +18,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Fetch PR head
+        run: git fetch origin +refs/pull/${{ github.event.pull_request.number }}/head:refs/remotes/origin/pr-head
       - name: Check for production code changes
         id: filter
         run: |


### PR DESCRIPTION
## Summary

- Fix `check-changes` job in `aws-ci.yaml` to fetch the PR head ref before running `git diff`.
- With `pull_request_target`, `actions/checkout` only checks out the base branch. The PR head SHA from a fork is missing, causing `git diff` to fail silently and `has-code-changes` to always be `false`, which skips the `deploy-ec2` job for all fork PRs.

## Test plan

- [ ] Open a fork PR with test-only file changes and verify `check-changes` outputs `has-code-changes=true`
- [ ] Confirm `deploy-ec2` is no longer skipped (pending `ok-to-test` label)