### PR TITLE
Add nil guards in TurnAllPortsUp/Down to prevent cascading panics

### DIFF
--- a/test/pkg/ptptesthelper/ptptesthelper.go
+++ b/test/pkg/ptptesthelper/ptptesthelper.go
@@ -524,6 +524,10 @@ func (p *PortEngine) TurnPortUp(port string) error {
 }
 
 func (p *PortEngine) TurnAllPortsDown(skippedInterfaces map[string]bool) error {
+	if p.ClockPod == nil {
+		logrus.Warnf("TurnAllPortsDown: ClockPod is nil, skipping (PortEngine was not initialized)")
+		return nil
+	}
 	for _, port := range p.Ports {
 		if skippedInterfaces[port] {
 			logrus.Infof("Skipping interface: %s (in skip list)", port)
@@ -541,6 +545,10 @@ func (p *PortEngine) TurnAllPortsDown(skippedInterfaces map[string]bool) error {
 }
 
 func (p *PortEngine) TurnAllPortsUp() error {
+	if p.ClockPod == nil {
+		logrus.Warnf("TurnAllPortsUp: ClockPod is nil, skipping (PortEngine was not initialized)")
+		return nil
+	}
 	for _, port := range p.Ports {
 		stdout, stderr, err := pods.ExecCommand(client.Client, true, p.ClockPod, pkg.RecoveryNetworkOutageDaemonSetContainerName,
 			[]string{"ip", "link", "set", port, "up"})


### PR DESCRIPTION
## Summary

- When `PortEngine.Initialize` fails (e.g. privileged DaemonSet creation times out), `ClockPod` remains nil. The `AfterEach` cleanup then calls `TurnAllPortsUp()` which panics on nil `ClockPod`, cascading the panic into every subsequent test — resulting in **36 test panics** across all modes.
- Add nil guards in `TurnAllPortsUp` and `TurnAllPortsDown` so cleanup is safely skipped when `PortEngine` was not initialized, preventing a single setup failure from taking down the entire test suite.

**Note**: The `CreatePtpTestPrivilegedDaemonSet` fix (retry with `Eventually` + nil/empty checks) was already addressed in PR #211. This PR adds the missing safety net in the cleanup path.

**Observed in**: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.21-e2e-telco5g-ptp/2047465867783966720

## Test plan

- [ ] Verify that `AfterEach` cleanup does not panic when `PortEngine` was not initialized (nil `ClockPod`)
- [ ] Verify normal test execution is not affected when `PortEngine` is properly initialized
