### PR TITLE
Skip force-update of tracking branch when checked out

### DIFF
--- a/hack/coverage-gate.sh
+++ b/hack/coverage-gate.sh
@@ -35,10 +35,11 @@ resolve_base_ref() {
     git branch --set-upstream-to="${UPSTREAM_REF}" "${LOCAL_BRANCH}" --quiet >/dev/null
   fi
 
-  # Update tracking branch to latest (skip if currently checked out)
-  CURRENT=$(git symbolic-ref --short HEAD 2>/dev/null || true)
-  if [ "${LOCAL_BRANCH}" != "${CURRENT}" ]; then
-    git branch -f "${LOCAL_BRANCH}" "${UPSTREAM_REF}" --quiet 2>/dev/null || true
+  # Update tracking branch to latest. If it's checked out (here or elsewhere),
+  # return the upstream ref directly to avoid checkout conflicts.
+  if ! git branch -f "${LOCAL_BRANCH}" "${UPSTREAM_REF}" --quiet 2>/dev/null; then
+    echo "${UPSTREAM_REF}"
+    return
   fi
 
   echo "${LOCAL_BRANCH}"


### PR DESCRIPTION
coverage-gate.sh tried to force-update the base tracking branch even when it was currently checked out or used by a worktree, causing a fatal error from git.