### PR TITLE
Set phc2sysOpts to nil when all slave RT clock updates are disabled 

### DIFF
--- a/test/pkg/testconfig/testconfig.go
+++ b/test/pkg/testconfig/testconfig.go
@@ -1590,6 +1590,10 @@ func createPtpConfigPhc2SysHA(policyName string, nodeName string, haProfiles []s
 	}
 
 	phc2sysOpts := phc2sysDualNicBCHA
+	testParameters, errTestParam := ptptestconfig.GetPtpTestConfig()
+	if errTestParam == nil && testParameters.GlobalConfig.DisableAllSlaveRTUpdate {
+		phc2sysOpts = strings.Join(strings.Fields(strings.ReplaceAll(phc2sysOpts, "-r", "")), " ")
+	}
 	ptp4lOpts := "" // no ptp4l options
 
 	ptpProfile := ptpv1.PtpProfile{
@@ -2061,8 +2065,9 @@ func createConfig(profileName string, ifaceName, ptp4lOpts *string, ptp4lConfig 
 	thresholds.HoldOverTimeout = int64(testParameters.GlobalConfig.HoldOverTimeout)
 
 	if testParameters.GlobalConfig.DisableAllSlaveRTUpdate && nodeLabel != pkg.PtpGrandmasterNodeLabel && phc2sysOpts != nil {
-		temp := "-v"
-		phc2sysOpts = &temp
+		noRT := strings.ReplaceAll(*phc2sysOpts, "-r", "")
+		noRT = strings.Join(strings.Fields(noRT), " ")
+		phc2sysOpts = &noRT
 	}
 
 	ptpProfile := ptpv1.PtpProfile{Name: &profileName, Interface: ifaceName, Phc2sysOpts: phc2sysOpts, Ptp4lOpts: ptp4lOpts, PtpSchedulingPolicy: &ptpSchedulingPolicy, PtpSchedulingPriority: ptpSchedulingPriority,


### PR DESCRIPTION
Improving disabling phc2sys updates for netdevsim simulation by passing a nil configuration instead of "-v" to print version and quit. Improves reliability of test: "PTP ClockSync Can provide a profile with higher priority"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated configuration handling so related timing settings no longer force a hardcoded fallback when a specific update mode is disabled.
  * Improved support for high-availability setups by adjusting command options more safely and consistently.
  * Preserved existing option values while removing an incompatible flag, reducing unexpected behavior in non-grandmaster node configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->