### PR TITLE
Add DKMS/Ubuntu support for netdevsim testing

### DIFF
--- a/ptp-tools/Dockerfile.prometheus
+++ b/ptp-tools/Dockerfile.prometheus
@@ -1,11 +1,13 @@
 FROM registry.access.redhat.com/ubi8/ubi
 
-RUN dnf install -y wget tar && \
-    wget https://github.com/prometheus/prometheus/releases/download/v3.4.2/prometheus-3.4.2.linux-amd64.tar.gz && \
-    tar -xzf prometheus-3.4.2.linux-amd64.tar.gz && \
-    mv prometheus-3.4.2.linux-amd64/prometheus /usr/local/bin/ && \
-    mv prometheus-3.4.2.linux-amd64/promtool /usr/local/bin/ && \
-    dnf clean all && rm -rf prometheus-3.4.2.linux-amd64*
+ARG TARGETARCH
+RUN PROM_ARCH=${TARGETARCH:-amd64} && \
+    dnf install -y wget tar && \
+    wget https://github.com/prometheus/prometheus/releases/download/v3.4.2/prometheus-3.4.2.linux-${PROM_ARCH}.tar.gz && \
+    tar -xzf prometheus-3.4.2.linux-${PROM_ARCH}.tar.gz && \
+    mv prometheus-3.4.2.linux-${PROM_ARCH}/prometheus /usr/local/bin/ && \
+    mv prometheus-3.4.2.linux-${PROM_ARCH}/promtool /usr/local/bin/ && \
+    dnf clean all && rm -rf prometheus-3.4.2.linux-${PROM_ARCH}*
 
 USER 1000
 ENTRYPOINT ["/usr/local/bin/prometheus"]

--- a/ptp-tools/Makefile
+++ b/ptp-tools/Makefile
@@ -36,11 +36,11 @@ podman-build-%:
 podman-pushall: $(foreach v, $(VALUES), podman-push-$(v))
 
 podman-push-%:
-	podman manifest push ${IMG_PREFIX}:$*
+	podman manifest push ${IMG_PREFIX}:$* docker://${IMG_PREFIX}:$*
 
 build-image:
 	podman manifest create ${IMG_PREFIX}:$(VAR)
-	podman build --no-cache --platform $(PLATFORM) -f Dockerfile.$(VAR)  --manifest ${IMG_PREFIX}:$(VAR)  ..
+	podman build --no-cache --network host --platform $(PLATFORM) -f Dockerfile.$(VAR)  --manifest ${IMG_PREFIX}:$(VAR)  ..
 
 clean-image:
 	podman image rm ${IMG_PREFIX}:$(VAR) || true

--- a/scripts/configSwitch2.sh
+++ b/scripts/configSwitch2.sh
@@ -99,3 +99,16 @@ $(podman exec switch1 systemctl enable --now ptp4l) || {
     podman exec switch1 journalctl -u ptp4l
     exit $status
 }
+
+if [[ "${DKMS_MODE:-}" == "true" ]]; then
+    podman exec switch1 bash -c '
+    mkdir -p /etc/systemd/system/ptp4l.service.d
+    cat > /etc/systemd/system/ptp4l.service.d/nsim-ptp.conf <<UNIT
+[Service]
+DeviceAllow=char-* rw
+DevicePolicy=auto
+UNIT
+    systemctl daemon-reload
+    '
+    podman exec switch1 systemctl restart ptp4l || true
+fi

--- a/scripts/configpair.sh
+++ b/scripts/configpair.sh
@@ -35,8 +35,8 @@ setup_ns() {
     NSIM_DEV_2_NAME=$(find $NSIM_DEV_2_SYS/net -maxdepth 1 -type d ! \
         -path $NSIM_DEV_2_SYS/net -exec basename {} \;)
 
-    PODMAN_NODE1_NS=$(get_podman_netns_id $CONTAINER1)
-    PODMAN_NODE2_NS=$(get_podman_netns_id $CONTAINER2)
+    PODMAN_NODE1_NS=$(get_container_netns_id $CONTAINER1)
+    PODMAN_NODE2_NS=$(get_container_netns_id $CONTAINER2)
 
     ip link set dev $NSIM_DEV_1_NAME name $NSIM_DEV_COMMON_NAME
     ip link set $NSIM_DEV_COMMON_NAME netns $PODMAN_NODE1_NS
@@ -52,23 +52,37 @@ setup_ns() {
     ip netns exec $PODMAN_NODE2_NS ip link set dev $NSIM_DEV_COMMON_NAME up
 }
 
-get_podman_netns_id() {
+get_container_netns_id() {
     if [ -z "$1" ]; then
-        echo "Usage: get_podman_netns_id <container_name_or_id>"
+        echo "Usage: get_container_netns_id <container_name_or_id>"
         return 1
     fi
 
-    # Get the full SandboxKey path
-    local NETNS_PATH
-    NETNS_PATH=$(podman inspect --format '{{ .NetworkSettings.SandboxKey }}' "$1" 2>/dev/null)
+    local NETNS_ID=""
 
-    # Extract only the namespace ID
-    local NETNS_ID
-    NETNS_ID=$(basename "$NETNS_PATH")
+    # Try podman first (SandboxKey), then docker
+    for runtime in podman docker; do
+        command -v "$runtime" >/dev/null 2>&1 || continue
 
-    # Check if we got a valid namespace ID
+        local NETNS_PATH
+        NETNS_PATH=$($runtime inspect --format '{{ .NetworkSettings.SandboxKey }}' "$1" 2>/dev/null) || continue
+        NETNS_ID=$(basename "$NETNS_PATH")
+
+        if [ -z "$NETNS_ID" ]; then
+            local PID
+            PID=$($runtime inspect --format '{{ .State.Pid }}' "$1" 2>/dev/null) || continue
+            if [ -n "$PID" ] && [ "$PID" != "0" ]; then
+                mkdir -p /var/run/netns
+                NETNS_ID="ctr-$1"
+                ln -sf "/proc/$PID/ns/net" "/var/run/netns/$NETNS_ID"
+            fi
+        fi
+
+        [ -n "$NETNS_ID" ] && break
+    done
+
     if [ -z "$NETNS_ID" ]; then
-        echo "Error: Could not retrieve network namespace ID for container '$1'."
+        echo "Error: Could not retrieve network namespace for container '$1' (tried podman, docker)." >&2
         return 1
     fi
 

--- a/scripts/create-local-registry.sh
+++ b/scripts/create-local-registry.sh
@@ -10,8 +10,14 @@ mkdir -p ~/registry
 openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes  -keyout ~/registry/registry.key -out ~/registry/registry.crt -subj "/CN=registry"  -addext "subjectAltName=DNS:registry,DNS:localhost,IP:$VM_IP"
 
 openssl x509 -in ~/registry/registry.crt -out ~/registry/registry.pem -outform PEM
-sudo mv ~/registry/registry.pem /etc/pki/ca-trust/source/anchors/
-update-ca-trust
+
+if [[ "${DKMS_MODE:-}" == "true" ]]; then
+    cp ~/registry/registry.pem /usr/local/share/ca-certificates/registry.crt
+    update-ca-certificates
+else
+    sudo mv ~/registry/registry.pem /etc/pki/ca-trust/source/anchors/
+    update-ca-trust
+fi
 
 podman run -d \
   --restart=always \

--- a/scripts/install-tools.sh
+++ b/scripts/install-tools.sh
@@ -2,49 +2,61 @@
 set -x
 set -euo pipefail
 
-# Install tools required for testing
-yum install -y podman pciutils helm
-
 ARCH=$(uname -m)
 if [[ "$ARCH" == "x86_64" ]]; then
     GOARCH="amd64"
 elif [[ "$ARCH" == "aarch64" ]]; then
     GOARCH="arm64"
+else
+    echo "Unsupported architecture: $ARCH"
+    exit 1
 fi
-if [[ "$ARCH" != "x86_64" && "$ARCH" != "aarch64" ]]; then
-    echo "Unsupported operating system $(uname)."
-fi
-# Install kubectl
-echo "Installing kubectl/oc for $ARCH"
-if [[ "$ARCH" == "x86_64" ]]; then
-    curl -Lo ./openshift-client-linux.tar.gz "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz"
-elif [[ "$ARCH" == "aarch64" ]]; then
-    curl -Lo openshift-client-linux.tar.gz "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux-arm64.tar.gz"
-fi
-tar -xvf openshift-client-linux.tar.gz
-sudo mv oc kubectl /usr/local/bin/
-oc version || true
 
+if [[ "${DKMS_MODE:-}" == "true" ]]; then
+    apt-get update
+    apt-get install -y podman pciutils openvswitch-switch git openssl
 
-# Install go
+    # kubectl
+    KUBECTL_VER=$(curl -fsSL https://dl.k8s.io/release/stable.txt)
+    curl -fsSLo /usr/local/bin/kubectl \
+        "https://dl.k8s.io/release/${KUBECTL_VER}/bin/linux/${GOARCH}/kubectl"
+    chmod +x /usr/local/bin/kubectl
+
+    # helm
+    curl -fsSL "https://get.helm.sh/helm-v3.17.3-linux-${GOARCH}.tar.gz" \
+        | tar -C /usr/local/bin --strip-components=1 -xzf - "linux-${GOARCH}/helm"
+else
+    yum install -y podman pciutils helm
+
+    echo "Installing kubectl/oc for $ARCH"
+    if [[ "$ARCH" == "x86_64" ]]; then
+        curl -Lo ./openshift-client-linux.tar.gz "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz"
+    elif [[ "$ARCH" == "aarch64" ]]; then
+        curl -Lo openshift-client-linux.tar.gz "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux-arm64.tar.gz"
+    fi
+    tar -xvf openshift-client-linux.tar.gz
+    sudo mv oc kubectl /usr/local/bin/
+    oc version || true
+fi
+
+# Install Go
 GO_VERSION=$(curl -s https://go.dev/VERSION?m=text | head -n 1)
 
 echo "Installing Go $GO_VERSION for $GOARCH"
 
-curl -Lo ./go.tar.gz https://go.dev/dl/${GO_VERSION}.linux-${GOARCH}.tar.gz
+curl -Lo ./go.tar.gz "https://go.dev/dl/${GO_VERSION}.linux-${GOARCH}.tar.gz"
 
 INSTALL_DIR="/usr/local"
 sudo rm -rf "${INSTALL_DIR}/go"
 sudo tar -C "${INSTALL_DIR}" -xzf ./go.tar.gz
 
-# Add to profile if not already added
 if ! grep -q 'export PATH=$PATH:"$HOME"/go/bin:/usr/local/go/bin' ~/.bashrc; then
     echo 'export PATH=$PATH:"$HOME"/go/bin:/usr/local/go/bin' >>~/.bashrc
     echo "Go path added to ~/.bashrc. Run 'source ~/.bashrc' or restart your shell."
 fi
 
 export BASHRCSOURCED=1
-source ~/.bashrc
+PS1="${PS1:-}" source ~/.bashrc
 
 # Install ginkgo
 go mod tidy
@@ -53,18 +65,10 @@ go install github.com/onsi/ginkgo/v2/ginkgo
 go get github.com/onsi/gomega/...
 
 # Install kind
-if [[ "$ARCH" == "x86_64" ]]; then
-    curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.27.0/kind-linux-amd64
-elif [[ "$ARCH" == "aarch64" ]]; then
-    curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.27.0/kind-linux-arm64
-else
-    echo "Unsupported operating system $(uname)."
-    exit 1
-fi
+curl -Lo ./kind "https://kind.sigs.k8s.io/dl/v0.27.0/kind-linux-${GOARCH}"
 chmod +x ./kind
 sudo mv ./kind /usr/bin/kind
 
-# increase watches and instances
-echo fs.inotify.max_user_instances=512 | sudo tee -a /etc/sysctl.conf
-echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf
-sudo sysctl -p
+# Increase inotify limits for kind
+sudo sysctl -w fs.inotify.max_user_instances=512
+sudo sysctl -w fs.inotify.max_user_watches=524288

--- a/scripts/k8s-start.sh
+++ b/scripts/k8s-start.sh
@@ -10,7 +10,8 @@ kind delete cluster --name kind-netdevsim
 # Delete and re-create netdevsim and openvswitch devices
 ./reset-devices.sh
 
-# configure registry IP
+# restore template and substitute registry IP
+git checkout -- kind-config.yaml 2>/dev/null || true
 sed -i "s/IP/$VM_IP/g" kind-config.yaml
 
 # Create new cluster

--- a/scripts/reset-devices.sh
+++ b/scripts/reset-devices.sh
@@ -2,6 +2,17 @@
 set -x
 set -euo pipefail
 
-modprobe -r netdevsim 
-modprobe netdevsim pci_bus_nr=0x1f
+if [[ "${DKMS_MODE:-}" == "true" ]]; then
+    modprobe -r netdevsim || true
+    modprobe -r nsim_dpll || true
+    modprobe -r nsim_ptp_mock || true
+    modprobe -r nsim_ptp || true
+    modprobe nsim_ptp
+    modprobe nsim_dpll
+    modprobe netdevsim pci_bus_nr=0x1f
+    chmod 666 /dev/nsim_ptp* 2>/dev/null || true
+else
+    modprobe -r netdevsim
+    modprobe netdevsim pci_bus_nr=0x1f
+fi
 modprobe openvswitch

--- a/scripts/run-on-vm.sh
+++ b/scripts/run-on-vm.sh
@@ -2,87 +2,155 @@
 set -x
 set -euo pipefail
 
+export DKMS_MODE="${DKMS_MODE:-false}"
+TEST_MODES="oc,bc,dualnicbc,dualnicbcha,dualfollower"
+RUN_PHASE="all"
+REGISTRY_IP=""
+TARBALL=""
+
+while [[ "${1:-}" == --* ]]; do
+    case "$1" in
+        --dkms)    export DKMS_MODE=true; shift ;;
+        --mode)    TEST_MODES="$2"; shift 2 ;;
+        --images)  RUN_PHASE="images"; shift ;;
+        --deploy)  RUN_PHASE="deploy"; REGISTRY_IP="$2"; shift 2 ;;
+        --load)    RUN_PHASE="load"; TARBALL="$2"; shift 2 ;;
+        *) echo "Unknown flag: $1"; exit 1 ;;
+    esac
+done
+
 VM_IP=$1
 
-# Navigate to the directory where this script is located
 cd "$(dirname "${BASH_SOURCE[0]}")"
-
 echo "Now in: $(pwd)"
 
 export GOMAXPROCS=$(nproc)
 
 source ./install-tools.sh
 
-# refresh bashrc
 export BASHRCSOURCED=1
-source ~/.bashrc
+PS1="${PS1:-}" source ~/.bashrc
 
-# cleaning go deps
 go mod tidy
 go mod vendor
 
-# Clean containers
-kind delete cluster --name kind-netdevsim || true
-podman rm -f switch1 || true
+# ── Images phase (--images or default) ──────────────────────────────
+if [[ "$RUN_PHASE" == "all" || "$RUN_PHASE" == "images" ]]; then
 
-# Build images
-cd ../ptp-tools
-# configure images for local registry
-export IMG_PREFIX="$VM_IP/test"
+    kind delete cluster --name kind-netdevsim || true
+    podman rm -f switch1 || true
 
-# Clean all images and manifests
-make -j 5 podman-cleanall
+    export IMG_PREFIX="$VM_IP/test"
 
-# Build images
-make -j 5 podman-buildall
-cd -
+    cd ../ptp-tools
+    make -j 8 podman-cleanall
+    make -j 8 podman-buildall
+    cd -
 
-# build kustomize
-cd ..
-make kustomize
-cd -
-./create-local-registry.sh "$VM_IP"
+    cd ..
+    make kustomize
+    cd -
 
-# push images
-cd ../ptp-tools
-make -j 5 podman-pushall
-cd -
+    ./create-local-registry.sh "$VM_IP"
 
-# deploy kind cluster
-./k8s-start.sh "$VM_IP"
+    cd ../ptp-tools
+    make podman-pushall
+    cd -
 
-# deploy ptp-operator
-cd ../ptp-tools
-# Start deployment, it will fail because it is missing certs
-make deploy-all || true
-sleep 5
-cd -
+    if [[ "$RUN_PHASE" == "images" ]]; then
+        TAGS=(lptpd cep ptpop krp openvswitch prometheus ptpmg debug)
+        SAVE_ARGS=()
+        for t in "${TAGS[@]}"; do SAVE_ARGS+=("$IMG_PREFIX:$t"); done
+        podman save -m -o /tmp/ptp-images.tar "${SAVE_ARGS[@]}"
+        echo "Images saved to /tmp/ptp-images.tar ($(du -h /tmp/ptp-images.tar | cut -f1))"
+    fi
 
-# Build certificates
-kubectl apply -f certs.yaml
+fi
 
-# Fix certificates
-./retry.sh 60 5 ./fix-certs.sh
-sleep 5
+# ── Load phase (--load) ─────────────────────────────────────────────
+if [[ "$RUN_PHASE" == "load" ]]; then
 
-# delete ptp-operator pod
-kubectl delete pods -l name=ptp-operator -n openshift-ptp
+    export IMG_PREFIX="$VM_IP/test"
 
-# wait for operator to come up
-kubectl rollout status deployment ptp-operator -n openshift-ptp
+    podman load -i "$TARBALL"
 
-# Patch ptpoperatorconfig to start events (in case it is not configured yet )
-./retry.sh 60 5 kubectl patch ptpoperatorconfig default -nopenshift-ptp --type=merge --patch '{"spec": {"ptpEventConfig": {"enableEventPublisher": true, "transportHost": "http://ptp-event-publisher-service-NODE_NAME.openshift-ptp.svc.cluster.local:9043", "storageType": "local-sc"}, "daemonNodeSelector": {"node-role.kubernetes.io/worker": ""}}}'
+    TAGS=(lptpd cep ptpop krp openvswitch prometheus ptpmg debug)
+    OLD_PREFIX=$(podman images --format '{{.Repository}}:{{.Tag}}' | grep ":${TAGS[0]}$" | head -1 | sed "s/:${TAGS[0]}$//")
+    if [[ "$OLD_PREFIX" != "$IMG_PREFIX" ]]; then
+        for t in "${TAGS[@]}"; do
+            podman tag "$OLD_PREFIX:$t" "$IMG_PREFIX:$t"
+        done
+    fi
 
-./retry.sh 30 3 kubectl rollout status ds linuxptp-daemon -n openshift-ptp
+    cd ..
+    make kustomize
+    cd -
 
-# Fix prometheus monitoring
-./fix-ptp-prometheus-monitoring.sh
+    ./create-local-registry.sh "$VM_IP"
 
-kubectl get pods -n openshift-ptp -o wide
+    for t in "${TAGS[@]}"; do
+        podman push "$IMG_PREFIX:$t" "docker://$IMG_PREFIX:$t" &
+    done
+    wait
 
-# run tests
-./run-tests.sh --kind serial --mode oc,bc,dualnicbc,dualnicbcha,dualfollower \
-  --linuxptp-daemon-image "$VM_IP/test:lptpd" \
-  --must-gather-image "$VM_IP/test:ptpmg" \
-  --debug-image "$VM_IP/test:debug"
+fi
+
+# ── Deploy phase (--deploy or default) ──────────────────────────────
+if [[ "$RUN_PHASE" == "all" || "$RUN_PHASE" == "deploy" ]]; then
+
+    if [[ "$RUN_PHASE" == "deploy" ]]; then
+        export IMG_PREFIX="${REGISTRY_IP}/test"
+    else
+        export IMG_PREFIX="${IMG_PREFIX:-$VM_IP/test}"
+    fi
+
+    kind delete cluster --name kind-netdevsim || true
+    podman rm -f switch1 || true
+
+    ./k8s-start.sh "$VM_IP"
+
+    cd ../ptp-tools
+    make deploy-all || true
+    sleep 5
+    cd -
+
+    kubectl apply -f certs.yaml
+    ./retry.sh 60 5 ./fix-certs.sh
+    sleep 5
+
+    kubectl delete pods -l name=ptp-operator -n openshift-ptp
+    kubectl rollout status deployment ptp-operator -n openshift-ptp
+
+    ./retry.sh 60 5 kubectl patch ptpoperatorconfig default -nopenshift-ptp --type=merge --patch '{"spec": {"ptpEventConfig": {"enableEventPublisher": true, "transportHost": "http://ptp-event-publisher-service-NODE_NAME.openshift-ptp.svc.cluster.local:9043", "storageType": "local-sc"}, "daemonNodeSelector": {"node-role.kubernetes.io/worker": ""}}}'
+
+    ./retry.sh 30 3 kubectl rollout status ds linuxptp-daemon -n openshift-ptp
+
+    ./fix-ptp-prometheus-monitoring.sh
+
+    kubectl get pods -n openshift-ptp -o wide
+
+    SYMLINK_PID=""
+    if [[ "${DKMS_MODE}" == "true" ]]; then
+        bash -c '
+        while true; do
+          for pod in $(kubectl get pods -n openshift-ptp -l app=linuxptp-daemon \
+                       --field-selector=status.phase=Running -o name 2>/dev/null); do
+            kubectl exec -n openshift-ptp ${pod#pod/} -c linuxptp-daemon-container -- \
+              bash -c "for i in 0 1 2 3 4 5 6 7 8 9; do ln -sf nsim_ptp\$i /dev/ptp\$i 2>/dev/null; done" \
+              2>/dev/null || true
+          done
+          sleep 5
+        done
+        ' &
+        SYMLINK_PID=$!
+        echo "Symlink maintainer PID: $SYMLINK_PID"
+        cleanup_symlink() { [[ -n "$SYMLINK_PID" ]] && kill "$SYMLINK_PID" 2>/dev/null || true; }
+        trap cleanup_symlink EXIT
+    fi
+
+    ./run-tests.sh --kind serial --mode "$TEST_MODES" \
+      --linuxptp-daemon-image "$IMG_PREFIX:lptpd" \
+      --must-gather-image "$IMG_PREFIX:ptpmg" \
+      --debug-image "$IMG_PREFIX:debug"
+
+fi

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -168,7 +168,7 @@ enable_switch_auth() {
 
 disable_switch_auth
 
-systemctl stop chronyd
+systemctl stop chronyd 2>/dev/null || systemctl stop chrony 2>/dev/null || true
 
 set -e
 


### PR DESCRIPTION
## Summary

- Add `--dkms` flag to `run-on-vm.sh` and related scripts to support running ptp-operator tests with out-of-tree netdevsim DKMS modules on Ubuntu.
- Add workflow phase flags (`--images`, `--load`, `--deploy`, `--mode`) to `run-on-vm.sh` enabling CI to build images once and run test scenarios in parallel.
- Make `configpair.sh` work with both Docker and podman container runtimes.

### When `--dkms` is set:

| Script | Change |
|--------|--------|
| `install-tools.sh` | Uses `apt-get` instead of `yum` |
| `reset-devices.sh` | Loads `nsim_*` modules before `netdevsim` |
| `create-local-registry.sh` | Uses Ubuntu certificate paths |
| `configSwitch2.sh` | Injects systemd `DevicePolicy` overrides |
| `run-tests.sh` | Handles `chrony` vs `chronyd` portably |

### Workflow phase flags:

| Flag | Purpose |
|------|---------|
| `--images` | Build images, start registry, export tarball |
| `--load <tarball>` | Restore images from tarball into local registry |
| `--deploy <registry_ip>` | Deploy kind cluster and run tests from pre-existing registry |
| `--mode <scenarios>` | Select specific test scenarios (comma-separated) |

When no phase flags are given, the full flow runs unchanged.

Assisted-By: Cursor