### PR TITLE
chore: Update privileged-daemonset dependency to v1.0.35

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/prometheus/common v0.66.1
 	github.com/redhat-cne/channel-pubsub v0.0.8
 	github.com/redhat-cne/l2discovery-lib v0.1.1
-	github.com/redhat-cne/privileged-daemonset v1.0.34
+	github.com/redhat-cne/privileged-daemonset v1.0.35
 	github.com/redhat-cne/ptp-listener-exports v0.0.7
 	github.com/redhat-cne/sdk-go v1.22.4
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -497,8 +497,8 @@ github.com/redhat-cne/channel-pubsub v0.0.8 h1:5UzwMev+pjIIfzHDyCsx8HlG4a/ahHpRO
 github.com/redhat-cne/channel-pubsub v0.0.8/go.mod h1:mzF6XIdwFXrQ0JmvVA4UtflirDIM+q9Dj/1YGevGnOU=
 github.com/redhat-cne/l2discovery-lib v0.1.1 h1:wicVcqruOfVxU3wlIUQ1f2Ju2E6eAMG6wraZMg6hmng=
 github.com/redhat-cne/l2discovery-lib v0.1.1/go.mod h1:EjkRseUYnjUByFSzCSnMQ/DeQ8FkcRfHF1OIUxX/RCA=
-github.com/redhat-cne/privileged-daemonset v1.0.34 h1:wcffXvaz5PwvAZfq62WiMXi0N+gXFlEFXkK4CcdjshU=
-github.com/redhat-cne/privileged-daemonset v1.0.34/go.mod h1:poRO1Giq9rH4JD8/KLxRJobOARGxmPr8xAIwhSrZGRQ=
+github.com/redhat-cne/privileged-daemonset v1.0.35 h1:zfJyrK5bp7STIs1s9niKPTo36h69f4kSxfd6DnGq6oU=
+github.com/redhat-cne/privileged-daemonset v1.0.35/go.mod h1:poRO1Giq9rH4JD8/KLxRJobOARGxmPr8xAIwhSrZGRQ=
 github.com/redhat-cne/ptp-listener-exports v0.0.7 h1:OndW4kSKym5LK9bbEqJPE/LW/LGMDPw5IzXdmrGMRhI=
 github.com/redhat-cne/ptp-listener-exports v0.0.7/go.mod h1:oDdWZOsl2wP1WUECbyLvva0ld/JOvWzNWLJOSCOlOAI=
 github.com/redhat-cne/sdk-go v1.22.4 h1:blyFVvP6MwY7y0jLBW8CnDayaZjbbJ9BsIhWMMHujxQ=

--- a/vendor/github.com/redhat-cne/privileged-daemonset/main.go
+++ b/vendor/github.com/redhat-cne/privileged-daemonset/main.go
@@ -3,6 +3,7 @@ package privilegeddaemonset
 import (
 	"context"
 	"fmt"
+	"log"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -262,10 +263,41 @@ func WaitDaemonsetReady(namespace, name string, timeout time.Duration) error {
 	}
 
 	if !isReady {
+		logStuckPods(namespace, name)
 		return fmt.Errorf("daemonset %q (ns %q) could not be deployed (timed out)", name, namespace)
 	}
 
 	return nil
+}
+
+// logStuckPods logs pod states when a daemonset wait times out to aid debugging.
+func logStuckPods(namespace, dsName string) {
+	podList, err := daemonsetClient.K8sClient.CoreV1().Pods(namespace).List(
+		context.Background(), metav1.ListOptions{LabelSelector: "name=" + dsName})
+	if err != nil {
+		log.Printf("failed to list pods for stuck daemonset %s/%s: %v", namespace, dsName, err)
+		return
+	}
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		phase := pod.Status.Phase
+		var containerState string
+		if len(pod.Status.ContainerStatuses) > 0 {
+			cs := pod.Status.ContainerStatuses[0]
+			switch {
+			case cs.State.Waiting != nil:
+				containerState = "Waiting/" + cs.State.Waiting.Reason
+			case cs.State.Running != nil:
+				containerState = "Running"
+			case cs.State.Terminated != nil:
+				containerState = "Terminated/" + cs.State.Terminated.Reason
+			}
+		} else {
+			containerState = "no-container-status"
+		}
+		log.Printf("stuck daemonset %s/%s: pod %s on node %s: phase=%s container=%s",
+			namespace, dsName, pod.Name, pod.Spec.NodeName, phase, containerState)
+	}
 }
 
 func isDaemonSetReady(status *appsv1.DaemonSetStatus) bool {
@@ -403,7 +435,6 @@ func namespaceCreate(namespace string) error {
 }
 
 func DeleteNamespaceIfPresent(namespace string) (err error) {
-	// delete namespace if present
 	if !namespaceIsPresent(namespace) {
 		return nil
 	}
@@ -411,11 +442,49 @@ func DeleteNamespaceIfPresent(namespace string) (err error) {
 	if err != nil {
 		return fmt.Errorf("could not delete namespace %q, err: %v", namespace, err)
 	}
-	// wait for the namespace to be deleted
 	err = namespaceWaitForDeletion(namespace, namespaceDeleteTimeout)
-	if err != nil {
-		return fmt.Errorf("failed waiting for namespace %q to be deleted, err: %v", namespace, err)
+	if err == nil {
+		return nil
 	}
 
+	// Namespace is stuck — likely due to pods that never started (e.g. CRI-O
+	// image-pull hang) which stay Terminating indefinitely.  Force-delete
+	// every remaining pod and wait again.
+	log.Printf("namespace %q still terminating after %v, force-deleting stuck pods", namespace, namespaceDeleteTimeout)
+	forceErr := forceDeletePodsInNamespace(namespace)
+	if forceErr != nil {
+		log.Printf("error force-deleting pods in namespace %q: %v", namespace, forceErr)
+	}
+
+	err = namespaceWaitForDeletion(namespace, namespaceDeleteTimeout)
+	if err != nil {
+		return fmt.Errorf("namespace %q still not deleted after force-deleting pods: %v", namespace, err)
+	}
 	return nil
+}
+
+// forceDeletePodsInNamespace force-deletes all pods in the given namespace
+// using a zero grace period. This unblocks namespace deletion when pods are
+// stuck in Terminating/ContainerCreating due to runtime issues (e.g. CRI-O
+// image pull hang).
+func forceDeletePodsInNamespace(namespace string) error {
+	podList, err := daemonsetClient.K8sClient.CoreV1().Pods(namespace).List(
+		context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("listing pods in %q: %w", namespace, err)
+	}
+	gracePeriod := int64(0)
+	deleteOpts := metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod}
+	var lastErr error
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		log.Printf("force-deleting pod %s/%s (phase=%s, node=%s)",
+			namespace, pod.Name, pod.Status.Phase, pod.Spec.NodeName)
+		if err := daemonsetClient.K8sClient.CoreV1().Pods(namespace).Delete(
+			context.Background(), pod.Name, deleteOpts); err != nil && !k8serrors.IsNotFound(err) {
+			log.Printf("failed to force-delete pod %s/%s: %v", namespace, pod.Name, err)
+			lastErr = err
+		}
+	}
+	return lastErr
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -251,7 +251,7 @@ github.com/redhat-cne/l2discovery-lib/exports
 github.com/redhat-cne/l2discovery-lib/pkg/graphsolver
 github.com/redhat-cne/l2discovery-lib/pkg/l2client
 github.com/redhat-cne/l2discovery-lib/pkg/pods
-# github.com/redhat-cne/privileged-daemonset v1.0.34
+# github.com/redhat-cne/privileged-daemonset v1.0.35
 ## explicit; go 1.22
 github.com/redhat-cne/privileged-daemonset
 # github.com/redhat-cne/ptp-listener-exports v0.0.7


### PR DESCRIPTION
## Summary

- Bumps `github.com/redhat-cne/privileged-daemonset` from v1.0.34 to v1.0.35
- v1.0.35 fixes a recurring CI issue where the `ptp-network-outage-recovery` namespace gets stuck in `Terminating` state, causing reboot discovery and clock sync tests to fail (see [nightly-4.22 job #2055189046187003904](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.22-e2e-telco5g-ptp/2055189046187003904))
- The new version adds force-deletion of stuck pods when namespace deletion times out, and logs pod states when a DaemonSet wait times out to aid debugging

## Changes in privileged-daemonset v1.0.35

1. **Force-delete stuck pods during namespace cleanup** — When `DeleteNamespaceIfPresent` times out waiting for namespace deletion, it now force-deletes all remaining pods (zero grace period) and retries. This unblocks namespace teardown when pods are stuck in Terminating/ContainerCreating due to runtime issues (e.g. CRI-O image pull hang).
2. **Log stuck pod details on DaemonSet timeout** — When `WaitDaemonsetReady` times out, it now logs the state of each pod (phase, container state, node) to help diagnose deployment failures.

Assisted-By: Cursor