### PR TITLE
CNF-22218: Clean and organize test CI output

### DIFF
--- a/ptp-tools/Makefile
+++ b/ptp-tools/Makefile
@@ -27,6 +27,10 @@ SAVE_DIR ?= /tmp/ptp-images
 
 VALUES = lptpd cep ptpop krp openvswitch prometheus ptpmg debug
 
+.PHONY: print-values
+print-values:
+	@printf '%s\n' $(VALUES)
+
 podman-buildall: $(foreach v, $(VALUES), podman-build-$(v))
 
 podman-build-%:
@@ -80,4 +84,6 @@ deploy-all:
 	cd ../config/manager && $(KUSTOMIZE) edit set image controller=${IMG_PREFIX}:ptpop
 	$(KUSTOMIZE) build ../config/default | kubectl apply -f -
 	$(KUSTOMIZE) build ../config/custom | kubectl apply -f -
+	# Operator creates default asynchronously; ensure it exists before patch.
+	kubectl apply -n openshift-ptp -f ../config/samples/ptp_v1_ptpoperatorconfig.yaml
 	kubectl patch ptpoperatorconfig default -nopenshift-ptp --type=merge --patch '{"spec": {"ptpEventConfig": {"enableEventPublisher": true, "transportHost": "http://ptp-event-publisher-service-NODE_NAME.openshift-ptp.svc.cluster.local:9043", "storageType": "local-sc"}, "daemonNodeSelector": {"node-role.kubernetes.io/worker": ""}}}'

--- a/scripts/ginkgo-headline-rewrite.sh
+++ b/scripts/ginkgo-headline-rewrite.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# Pipe Ginkgo -v output through this script to add START / DONE lines around each spec.
+#
+# Assumes reporter SilenceSkips=true: omits end-of-spec skip reports in DidRun only.
+# At -v, Ginkgo still prints "[SKIPPED] in [It|BeforeEach|…] - file:line @ …" via
+# EmitFailure while the spec runs; that line is suppressed here but still sets SKIPPED.
+# Pending specs print "P [PENDING]"; that line is suppressed (status via infer_status_update).
+#
+# Ginkgo --- delimiters are suppressed; we print one after each "■ DONE" line.
+# "▶ START" is printed only from release_queued_start (after "■ DONE" + delimiter).
+# If the next spec headline arrives before the current spec finishes, queue it and wait.
+
+set -euo pipefail
+
+SPEC_DONE_SEP='------------------------------'
+
+strip_ansi() {
+	LC_ALL=C printf '%s' "$1" | LC_ALL=C sed -E $'s/\033\[[0-9;]*[A-Za-z]//g'
+}
+
+to_lower() {
+	LC_ALL=C tr '[:upper:]' '[:lower:]' <<<"$1"
+}
+
+is_delimiter_line() {
+	local p="$1"
+	p="${p//$'\r'/}"
+	p="${p#"${p%%[![:space:]]*}"}"
+	p="${p%"${p##*[![:space:]]}"}"
+	[[ ${#p} -ge 20 ]] || return 1
+	[[ "$p" == *---* ]] || return 1
+	[[ "$p" =~ ^[-[:space:]]+$ ]]
+}
+
+is_headline_line() {
+	local plain="$1"
+	local pl
+	pl="$(to_lower "$plain")"
+	if [[ "$pl" =~ \[serial\][[:space:]]+(passed|skipped|failed|pending)[[:space:]]*$ ]]; then
+		return 1
+	fi
+	if [[ "$pl" =~ \[parallel\][[:space:]]+(passed|skipped|failed|pending)[[:space:]]*$ ]]; then
+		return 1
+	fi
+	[[ "$pl" == *"[serial]"* || "$pl" == *"[parallel]"* ]] || return 1
+	if [[ "$plain" =~ ^[[:space:]] ]]; then
+		return 0
+	fi
+	case "$plain" in
+	\[*) return 0 ;;
+	esac
+	return 1
+}
+
+is_ginkgo_emit_skip_line() {
+	local plain="$1"
+	[[ "$plain" =~ ^[[:space:]]*\[SKIPPED\][[:space:]]+in[[:space:]]+\[[^]]+\][[:space:]]*- ]]
+}
+
+is_ginkgo_emit_pending_line() {
+	local plain="$1"
+	[[ "$plain" =~ ^[[:space:]]*P[[:space:]]+\[PENDING\] ]]
+}
+
+infer_status_update() {
+	local plain="$1"
+	if [[ "$plain" == *'[FAILED]'* || "$plain" == *'FAIL!'* || "$plain" == *'--- FAIL:'* || "$plain" == *[Pp][Aa][Nn][Ii][Cc]:* ]]; then
+		echo FAILED
+		return
+	fi
+	if [[ "$plain" == *'[PENDING]'* || "$plain" == *' PENDING'* ]]; then
+		echo PENDING
+		return
+	fi
+	if [[ "$plain" == *'[SKIPPED]'* || "$plain" == *' SKIPPED'* ]]; then
+		echo SKIPPED
+		return
+	fi
+	if [[ "$plain" =~ ^[[:space:]]*•[[:space:]]+\[[0-9] ]]; then
+		echo PASSED
+		return
+	fi
+	echo ""
+}
+
+status_rank() {
+	case "$1" in
+	FAILED) echo 4 ;;
+	PENDING) echo 3 ;;
+	SKIPPED) echo 2 ;;
+	PASSED) echo 1 ;;
+	*) echo 0 ;;
+	esac
+}
+
+status_colored() {
+	local word="$1"
+	if [[ -n "${NO_COLOR:-}" ]]; then
+		printf '%s' "$word"
+		return
+	fi
+	case "$word" in
+	PASSED) printf '\033[32m%s\033[0m' "$word" ;;
+	FAILED) printf '\033[31m%s\033[0m' "$word" ;;
+	PENDING) printf '\033[33m%s\033[0m' "$word" ;;
+	SKIPPED) printf '\033[34m%s\033[0m' "$word" ;;
+	*) printf '%s' "$word" ;;
+	esac
+}
+
+print_spec_start() {
+	local name="$1"
+	printf '▶ START  %s\n' "$name"
+}
+
+release_queued_start() {
+	if [[ -z "$queued_headline" ]]; then
+		return
+	fi
+	spec_name="$queued_headline"
+	queued_headline=""
+	have_spec=true
+	status=""
+	print_spec_start "$spec_name"
+}
+
+print_spec_done() {
+	local name="$1"
+	local st="$2"
+	printf '■ DONE   %s  ' "$name"
+	status_colored "$st"
+	printf '\n'
+	printf '%s\n' "${SPEC_DONE_SEP}"
+	release_queued_start
+}
+
+flush_spec_done() {
+	if [[ "$have_spec" != true || -z "$status" ]]; then
+		return 1
+	fi
+	local will_start_next=false
+	[[ -n "$queued_headline" ]] && will_start_next=true
+	print_spec_done "$spec_name" "$status"
+	if [[ "$will_start_next" != true ]]; then
+		have_spec=false
+		spec_name=""
+		status=""
+	fi
+	return 0
+}
+
+have_spec=false
+spec_name=""
+status=""
+queued_headline=""
+
+while IFS= read -r line || [[ -n "${line}" ]]; do
+	plain="$(strip_ansi "$line")"
+	plain="${plain%$'\r'}"
+
+	if is_delimiter_line "$plain"; then
+		continue
+	fi
+
+	if is_headline_line "$plain"; then
+		if [[ "$have_spec" == true && -z "$status" ]]; then
+			queued_headline="$plain"
+			continue
+		fi
+		flush_spec_done || true
+		queued_headline="$plain"
+		if [[ "$have_spec" != true ]]; then
+			release_queued_start
+		fi
+		continue
+	fi
+
+	if [[ "$have_spec" == true ]]; then
+		upd="$(infer_status_update "$plain")"
+		if [[ -n "$upd" ]]; then
+			if [[ -z "$status" ]] || (($(status_rank "$upd") > $(status_rank "$status"))); then
+				status="$upd"
+			fi
+			if [[ -n "$queued_headline" ]]; then
+				flush_spec_done || true
+			fi
+		fi
+	fi
+
+	if is_ginkgo_emit_skip_line "$plain" || is_ginkgo_emit_pending_line "$plain"; then
+		continue
+	fi
+	printf '%s\n' "$line"
+done
+
+flush_spec_done || true

--- a/scripts/run-on-vm.sh
+++ b/scripts/run-on-vm.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -x
 set -euo pipefail
 
 export DKMS_MODE="${DKMS_MODE:-false}"
@@ -19,28 +18,267 @@ while [[ "${1:-}" == --* ]]; do
     esac
 done
 
-VM_IP=$1
+# Save full run output under /tmp/ptp-operator (timestamped file; also shown on the terminal).
+mkdir -p /tmp/ptp-operator
+RUN_ON_VM_LOG="/tmp/ptp-operator/run-on-vm-$(date +%Y%m%d-%H%M%S).log"
+: >"${RUN_ON_VM_LOG}"
+exec > >(tee -a "${RUN_ON_VM_LOG}") 2>&1
 
+VM_IP=$1
+echo "run-on-vm: logging to ${RUN_ON_VM_LOG}"
+
+COLOR_STEP='\033[1;36m'
+COLOR_ERR='\033[1;31m'
+COLOR_OK='\033[1;32m'
+COLOR_GRAY='\033[90m'
+COLOR_RESET='\033[0m'
+
+RUN_ON_VM_STEP_HDR="${COLOR_STEP}STEP:${COLOR_RESET}"
+RUN_ON_VM_STEP_CHILD_INDENT='  '
+# run_quiet_with_log_dump_on_failure only prints on failure
+RUN_ON_VM_PHASE_FAIL_PREFIX="${COLOR_ERR}FAIL "
+RUN_ON_VM_PHASE_LOG_BEGIN_PREFIX="${COLOR_ERR}---- BEGIN "
+RUN_ON_VM_PHASE_LOG_END_PREFIX="${COLOR_ERR}---- END "
+
+# Same clock layout as Ginkgo's default GINKGO_TIME_FORMAT ("01/02/06 15:04:05.999", see onsi/ginkgo/v2/types).
+log_ts() { date '+%m/%d/%y %H:%M:%S.%3N'; }
+
+# Echo with indent only.
+log_ind() { echo -e "${RUN_ON_VM_STEP_CHILD_INDENT}$*"; }
+
+# Log the command, run it, print stdout/stderr with indent on each line.
+run_ind() {
+  local _rc
+  "$@" 2>&1 | sed "s/^/${RUN_ON_VM_STEP_CHILD_INDENT}/"
+  _rc=${PIPESTATUS[0]}
+  return "${_rc}"
+}
+
+step() { echo -e "${COLOR_STEP}STEP:${COLOR_RESET} $* ${COLOR_GRAY}@ $(log_ts)${COLOR_RESET}"; }
+
+PTP_TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../ptp-tools" && pwd)"
+_ptp_tool_images=()
+
+# Populate _ptp_tool_images from ptp-tools/Makefile VALUES via `make print-values`.
+read_ptp_tool_images() {
+  local _img
+  _ptp_tool_images=()
+  while IFS= read -r _img; do
+    [[ -n "${_img}" ]] && _ptp_tool_images+=("${_img}")
+  done < <(make -C "${PTP_TOOLS_DIR}" -s print-values)
+  if ((${#_ptp_tool_images[@]} == 0)); then
+    echo "No image values from ${PTP_TOOLS_DIR}/Makefile (target print-values)" >&2
+    return 1
+  fi
+}
+
+# Run with stdout/stderr captured; no output on success, On failure, print the command log.
+run_quiet_with_log_dump_on_failure() {
+  local log_tag="$1"
+  shift
+
+  local log_file
+  log_file="$(mktemp "/tmp/ptp-operator/${log_tag// /_}.XXXXXX.log")"
+
+  local rc
+  if "$@" >"${log_file}" 2>&1 </dev/null; then
+    rc=0
+  else
+    rc=$?
+  fi
+
+  if [[ "${rc}" -eq 0 ]]; then
+    rm -f "${log_file}"
+    return 0
+  fi
+
+  echo -e "${COLOR_ERR}FAIL ${log_tag}:${COLOR_RESET} (exit code ${rc}) ${COLOR_GRAY}@ $(log_ts)${COLOR_RESET}"
+  echo -e "${COLOR_ERR}---- BEGIN ${log_tag} LOG ----${COLOR_RESET} ${COLOR_GRAY}@ $(log_ts)${COLOR_RESET}"
+  cat "${log_file}"
+  echo -e "${COLOR_ERR}---- END ${log_tag} LOG ----${COLOR_RESET} ${COLOR_GRAY}@ $(log_ts)${COLOR_RESET}"
+  rm -f "${log_file}"
+  return "${rc}"
+}
+
+declare -A STEP_ROWS_DONE
+
+# Print the initial "LABELS <image>" list
+run_step_rows_begin() {
+  STEP_ROWS_LABELS=("$@")
+  STEP_ROWS_COUNT=${#STEP_ROWS_LABELS[@]}
+  STEP_ROWS_DONE=()
+  STEP_ROWS_TTY_REDRAW=0
+  STEP_ROWS_MAX_LABEL_LEN=0
+
+  # stdout is teed to RUN_ON_VM_LOG; use /dev/tty for in-place redraw when interactive.
+  # Skip in CI: /dev/tty may exist but cannot be opened (bash still errors on failed exec).
+  if [[ -z "${CI:-}${GITHUB_ACTIONS:-}${GITLAB_CI:-}${BUILD_ID:-}" ]]; then
+    set +e
+    exec 9>/dev/tty 2>/dev/null
+    local _tty_rc=$?
+    set -e
+    if ((_tty_rc == 0)); then
+      STEP_ROWS_TTY_REDRAW=1
+    fi
+  fi
+
+  for _line in "${STEP_ROWS_LABELS[@]}"; do
+    [[ ${#_line} -gt $STEP_ROWS_MAX_LABEL_LEN ]] && STEP_ROWS_MAX_LABEL_LEN=${#_line}
+  done
+
+  if [[ "${STEP_ROWS_TTY_REDRAW}" == 1 ]]; then
+    for _line in "${STEP_ROWS_LABELS[@]}"; do
+      printf '  %-*s\n' "${STEP_ROWS_MAX_LABEL_LEN}" "${_line}" >&9
+    done
+  else
+    for _line in "${STEP_ROWS_LABELS[@]}"; do
+      printf '  %-*s\n' "${STEP_ROWS_MAX_LABEL_LEN}" "${_line}"
+    done
+  fi
+}
+
+# Marks a row as done if the command completed, otherwise print the row.
+run_step_row_done() {
+  local completed_label="$1"
+  STEP_ROWS_DONE["${completed_label}"]=1
+
+  if [[ "${STEP_ROWS_TTY_REDRAW}" == 1 ]]; then
+    # Cursor is on the line after the block; move up to the first row of this block.
+    printf '\033[%dA' "${STEP_ROWS_COUNT}" >&9
+    local _line
+    for _line in "${STEP_ROWS_LABELS[@]}"; do
+      printf '\033[2K\r' >&9
+      if [[ "${STEP_ROWS_DONE["${_line}"]:-0}" == 1 ]]; then
+        printf '  %-*s %bOK%b\n' "${STEP_ROWS_MAX_LABEL_LEN}" "${_line}" "${COLOR_OK}" "${COLOR_RESET}" >&9
+      else
+        printf '  %-*s\n' "${STEP_ROWS_MAX_LABEL_LEN}" "${_line}" >&9
+      fi
+    done
+
+  else
+    printf '  %-*s %bOK%b %b@ %s%b\n' \
+      "${STEP_ROWS_MAX_LABEL_LEN}" "${completed_label}" \
+      "${COLOR_OK}" "${COLOR_RESET}" \
+      "${COLOR_GRAY}" "$(log_ts)" "${COLOR_RESET}"
+  fi
+}
+
+run_step_rows_end() {
+  if [[ "${STEP_ROWS_TTY_REDRAW}" == 1 ]]; then
+    exec 9>&-
+    STEP_ROWS_TTY_REDRAW=0
+  fi
+}
+
+# Parallel `make -s podman-<verb>-<img>` for each image tag, with the same step-row UI as sequential work:
+# print "<row_prefix> <img>" lines, run all makes concurrently, mark each row OK on completion.
+run_ptp_tools_parallel_make_step_rows() {
+  local row_prefix="$1"
+  local make_prefix="$2"
+  local fifo_tag="$3"
+  shift 3
+  local -a images=("$@")
+  local n=${#images[@]}
+
+  local -a rows=()
+  local _img
+  for _img in "${images[@]}"; do
+    rows+=("${row_prefix} ${_img}")
+  done
+  run_step_rows_begin "${rows[@]}"
+
+  local fifo="/tmp/ptp-operator/ptp-${fifo_tag}-done-$$.fifo"
+  rm -f "${fifo}"
+  mkfifo "${fifo}"
+  exec 8<> "${fifo}"
+
+  local -a pids=()
+  local _i
+  for _i in "${!images[@]}"; do
+    (
+      _img="${images[$_i]}"
+      if run_quiet_with_log_dump_on_failure "${make_prefix}-${_img}" make -s "${make_prefix}-${_img}"; then
+        echo "${_img}" >&8
+      else
+        echo "FAIL:${_img}" >&8
+      fi
+    ) &
+    pids+=($!)
+  done
+
+  local done_count=0
+  local failed=0
+  local line
+  while ((done_count < n)); do
+    IFS= read -r line <&8 || {
+      failed=1
+      break
+    }
+    if [[ "${line}" == FAIL:* ]]; then
+      failed=1
+      break
+    fi
+    ((done_count++)) || true
+    run_step_row_done "${row_prefix} ${line}"
+  done
+
+  if ((failed)); then
+    local _pid
+    for _pid in "${pids[@]}"; do
+      kill "${_pid}" 2>/dev/null || true
+    done
+    for _pid in "${pids[@]}"; do
+      wait "${_pid}" 2>/dev/null || true
+    done
+    exec 8>&-
+    rm -f "${fifo}"
+    run_step_rows_end
+    exit 1
+  fi
+
+  local _pid
+  for _pid in "${pids[@]}"; do
+    wait "${_pid}"
+  done
+  exec 8>&-
+  rm -f "${fifo}"
+  run_step_rows_end
+}
+
+step "Switching to script directory"
 cd "$(dirname "${BASH_SOURCE[0]}")"
-echo "Now in: $(pwd)"
+
+log_ind "Now in: $(pwd) ${COLOR_GRAY}@ $(log_ts)${COLOR_RESET}"
 
 export GOMAXPROCS=$(nproc)
 
-source ./install-tools.sh
+step "Installing required tools"
+run_quiet_with_log_dump_on_failure "install-tools" bash ./install-tools.sh
 
 export BASHRCSOURCED=1
 PS1="${PS1:-}" source ~/.bashrc
 
-go mod tidy
-go mod vendor
+step "Tidying and vendoring Go dependencies"
+run_step_rows_begin "go mod tidy" "go mod vendor"
+
+run_quiet_with_log_dump_on_failure "go-mod-tidy" go mod tidy
+run_step_row_done "go mod tidy"
+
+run_quiet_with_log_dump_on_failure "go-mod-vendor" go mod vendor
+run_step_row_done "go mod vendor"
+
+run_step_rows_end
+
 
 # ── Images phase (--images) ──────────────────────────────────────────
 if [[ "$RUN_PHASE" == "images" ]]; then
 
     export IMG_PREFIX="$VM_IP/test"
 
-    cd ../ptp-tools
-    make -j8 podman-build-and-saveall
+    read_ptp_tool_images
+    step "Building and saving ptp-tools images"
+    cd "${PTP_TOOLS_DIR}"
+    run_ptp_tools_parallel_make_step_rows BUILD podman-build-and-save build-save "${_ptp_tool_images[@]}"
     cd -
 
     tar cf /tmp/ptp-images.tar -C /tmp/ptp-images .
@@ -51,19 +289,35 @@ fi
 # ── Images + deploy (default) ───────────────────────────────────────
 if [[ "$RUN_PHASE" == "all" ]]; then
 
-    kind delete cluster --name kind-netdevsim || true
-    podman rm -f switch1 || true
+    step "Deleting existing kind cluster and containers"
+    run_quiet_with_log_dump_on_failure "kind-delete-cluster" kind delete cluster --name kind-netdevsim || true
+
+    run_quiet_with_log_dump_on_failure "podman-rm-switch1" podman rm -f switch1 || true
 
     export IMG_PREFIX="$VM_IP/test"
 
-    cd ..
-    make kustomize
+    cd "${PTP_TOOLS_DIR}"
+    read_ptp_tool_images
+
+    step "Pruning unused podman storage"
+    run_quiet_with_log_dump_on_failure "podman-system-prune" podman system prune -af || true
+
+    # clean is included in build step
+    step "Building ptp-tools images"
+    run_ptp_tools_parallel_make_step_rows BUILD podman-build build "${_ptp_tool_images[@]}"
+
     cd -
 
-    ./create-local-registry.sh "$VM_IP"
+    step "Building kustomize"
+    cd ..
+    run_quiet_with_log_dump_on_failure "make-kustomize" make kustomize
+    cd -
+
+    step "Creating local registry"
+    run_quiet_with_log_dump_on_failure "create-local-registry" ./create-local-registry.sh "$VM_IP"
 
     cd ../ptp-tools
-    make podman-build-and-pushall
+    run_ptp_tools_parallel_make_step_rows PUSH podman-push push "${_ptp_tool_images[@]}"
     cd -
 
 fi
@@ -75,6 +329,8 @@ if [[ "$RUN_PHASE" == "load" ]]; then
 
     mkdir -p /tmp/ptp-images-load
     tar xf "$TARBALL" -C /tmp/ptp-images-load
+
+    step "Retagging images for local registry"
     TAGS=(lptpd cep ptpop krp openvswitch prometheus ptpmg debug)
     for t in "${TAGS[@]}"; do
         podman load -i "/tmp/ptp-images-load/$t.tar"
@@ -87,16 +343,17 @@ if [[ "$RUN_PHASE" == "load" ]]; then
         done
     fi
 
+    step "Building kustomize"
     cd ..
-    make kustomize
+    run_quiet_with_log_dump_on_failure "make-kustomize" make kustomize
     cd -
 
-    ./create-local-registry.sh "$VM_IP"
+    step "Creating local registry"
+    run_quiet_with_log_dump_on_failure "create-local-registry" ./create-local-registry.sh "$VM_IP"
 
     for t in "${TAGS[@]}"; do
-        podman push "$IMG_PREFIX:$t" "docker://$IMG_PREFIX:$t" &
+        podman push --quiet "$IMG_PREFIX:$t" "docker://$IMG_PREFIX:$t"
     done
-    wait
 
 fi
 
@@ -109,30 +366,46 @@ if [[ "$RUN_PHASE" == "all" || "$RUN_PHASE" == "deploy" ]]; then
         export IMG_PREFIX="${IMG_PREFIX:-$VM_IP/test}"
     fi
 
-    kind delete cluster --name kind-netdevsim || true
-    podman rm -f switch1 || true
+    step "Deleting kind cluster and containers"
+    run_quiet_with_log_dump_on_failure "kind-delete-cluster" kind delete cluster --name kind-netdevsim || true
+    run_quiet_with_log_dump_on_failure "podman-rm-switch1" podman rm -f switch1 || true
 
-    ./k8s-start.sh "$VM_IP"
+    step "Starting kind cluster"
+    run_step_rows_begin "Building kind cluster..."
+    run_quiet_with_log_dump_on_failure "k8s-start" ./k8s-start.sh "$VM_IP"
+    run_step_row_done "Building kind cluster..."
+    run_step_rows_end
 
-    cd ../ptp-tools
-    make deploy-all || true
-    sleep 5
+    step "Deploying ptp-operator manifests"
+    cd "${PTP_TOOLS_DIR}"
+    run_quiet_with_log_dump_on_failure "make-deploy-all" sh -c "make deploy-all || true"
     cd -
 
-    kubectl apply -f certs.yaml
-    ./retry.sh 60 5 ./fix-certs.sh
+    step "Applying certificate manifests"
+    run_quiet_with_log_dump_on_failure "kubectl-apply-certs" kubectl apply -f certs.yaml
+
+    step "Fixing certificates"
+    run_quiet_with_log_dump_on_failure "retry-fix-certs" ./retry.sh 60 5 ./fix-certs.sh
     sleep 5
 
-    kubectl delete pods -l name=ptp-operator -n openshift-ptp
-    kubectl rollout status deployment ptp-operator -n openshift-ptp
+    step "Restarting ptp-operator pod"
+    run_quiet_with_log_dump_on_failure "kubectl-delete-pods" kubectl delete pods -l name=ptp-operator -n openshift-ptp
 
-    ./retry.sh 60 5 kubectl patch ptpoperatorconfig default -nopenshift-ptp --type=merge --patch '{"spec": {"ptpEventConfig": {"enableEventPublisher": true, "transportHost": "http://ptp-event-publisher-service-NODE_NAME.openshift-ptp.svc.cluster.local:9043", "storageType": "local-sc"}, "daemonNodeSelector": {"node-role.kubernetes.io/worker": ""}}}'
+    step "Waiting for ptp-operator rollout"
+    run_quiet_with_log_dump_on_failure "kubectl-rollout-status" kubectl rollout status deployment ptp-operator -n openshift-ptp
 
-    ./retry.sh 30 3 kubectl rollout status ds linuxptp-daemon -n openshift-ptp
+    # Patch ptpoperatorconfig to start events (in case it is not configured yet )
+    step "Patching ptpoperatorconfig for event publishing"
+    run_quiet_with_log_dump_on_failure "retry-patch-ptpoperatorconfig" ./retry.sh 60 5 kubectl patch ptpoperatorconfig default -nopenshift-ptp --type=merge --patch '{"spec": {"ptpEventConfig": {"enableEventPublisher": true, "transportHost": "http://ptp-event-publisher-service-NODE_NAME.openshift-ptp.svc.cluster.local:9043", "storageType": "local-sc"}, "daemonNodeSelector": {"node-role.kubernetes.io/worker": ""}}}'
 
-    ./fix-ptp-prometheus-monitoring.sh
+    step "Waiting for linuxptp-daemon rollout"
+    run_quiet_with_log_dump_on_failure "retry-rollout-status" ./retry.sh 30 3 kubectl rollout status ds linuxptp-daemon -n openshift-ptp
 
-    kubectl get pods -n openshift-ptp -o wide
+    step "Fixing Prometheus monitoring"
+    run_quiet_with_log_dump_on_failure "fix-ptp-prometheus-monitoring" ./fix-ptp-prometheus-monitoring.sh
+
+    step "Listing openshift-ptp pods"
+    run_ind kubectl get pods -n openshift-ptp -o wide
 
     ./run-tests.sh --kind serial --mode "$TEST_MODES" \
       --linuxptp-daemon-image "$IMG_PREFIX:lptpd" \

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -13,8 +13,10 @@
 #   --must-gather-image <url>       Full image URL for the ptp must-gather image.
 #                                   When provided, must-gather runs for oc mode and on failure.
 #
-set -x
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GINKGO_HEADLINE_REWRITE="${SCRIPT_DIR}/ginkgo-headline-rewrite.sh"
 
 usage() {
   echo "Usage: $0 --kind <serial|parallel|both> --mode <modes> [--loglevel <level>] [--linuxptp-daemon-image <url>] [--must-gather-image <url>]"
@@ -188,11 +190,31 @@ run_ginkgo_suite() {
     ginkgo_args+=(--skip="${skip}")
   done
 
-  if [[ "${suite_kind}" == "parallel" ]]; then
-    PTP_TEST_MODE="${mode}" ginkgo -p "${ginkgo_args[@]}" "${SUITE}/parallel"
+  local ginkgo_rc
+  set +e
+  if [[ "${PTP_GINKGO_HEADLINE_REWRITE:-1}" != "0" ]] && [[ -f "${GINKGO_HEADLINE_REWRITE}" ]]; then
+    case "${suite_kind}" in
+      parallel)
+        PTP_TEST_MODE="${mode}" ginkgo -p "${ginkgo_args[@]}" "${SUITE}/parallel" 2>&1 | bash "${GINKGO_HEADLINE_REWRITE}"
+        ;;
+      *)
+        PTP_TEST_MODE="${mode}" ginkgo "${ginkgo_args[@]}" "${SUITE}/serial" 2>&1 | bash "${GINKGO_HEADLINE_REWRITE}"
+        ;;
+    esac
+    ginkgo_rc=${PIPESTATUS[0]}
   else
-    PTP_TEST_MODE="${mode}" ginkgo "${ginkgo_args[@]}" "${SUITE}/serial"
+    case "${suite_kind}" in
+      parallel)
+        PTP_TEST_MODE="${mode}" ginkgo -p "${ginkgo_args[@]}" "${SUITE}/parallel"
+        ;;
+      *)
+        PTP_TEST_MODE="${mode}" ginkgo "${ginkgo_args[@]}" "${SUITE}/serial"
+        ;;
+    esac
+    ginkgo_rc=$?
   fi
+  set -e
+  return "${ginkgo_rc}"
 }
 
 for mode in "${TEST_MODES[@]}"; do

--- a/test/conformance/parallel/parallel_suite_test.go
+++ b/test/conformance/parallel/parallel_suite_test.go
@@ -35,7 +35,9 @@ func init() {
 func TestTest(t *testing.T) {
 	logging.InitLogLevel()
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "PTP e2e tests : Parallel")
+	suiteCfg, repCfg := GinkgoConfiguration()
+	repCfg.SilenceSkips = true
+	RunSpecs(t, "PTP e2e tests : Parallel", suiteCfg, repCfg)
 }
 
 var _ = SynchronizedBeforeSuite(func() []byte {

--- a/test/conformance/serial/serial_suite_test.go
+++ b/test/conformance/serial/serial_suite_test.go
@@ -38,7 +38,9 @@ func TestTest(t *testing.T) {
 	logging.InitLogLevel()
 	RegisterFailHandler(Fail)
 	InitDeletePtpConfig()
-	RunSpecs(t, "PTP e2e integration tests")
+	suiteCfg, repCfg := GinkgoConfiguration()
+	repCfg.SilenceSkips = true
+	RunSpecs(t, "PTP e2e integration tests", suiteCfg, repCfg)
 }
 
 var _ = BeforeSuite(func() {


### PR DESCRIPTION
- Add stepped progress with multi-row blocks. When /dev/tty is available print pending step labels once and rewrite the block in place to append OK as each step finishes.
-  Parallel ptp-tools image build/push/clean.
- Add timestamps logging.
- Runs commands quietly and dump acptured logs only on failure.
- Add a bash filter that wraps each Ginkgo spec with START and DONE + STATUS (with coloring) lines.
- Enable SilenceSkips in serial and parallel suite reporters so Ginkgo omits redundant end-of-spec skip blocks. In addition, suppress the verbose EmitFailure skip line.