### PR TITLE
ci: add ginkgo flake mitigation and fix higher-priority test

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -178,6 +178,7 @@ run_ginkgo_suite() {
   local junit_base="${JUNIT_OUTPUT_FILE%.xml}"
   local ginkgo_args=(
     --keep-going
+    --flake-attempts="${FLAKE_ATTEMPTS:-2}"
     --output-dir="${JUNIT_OUTPUT_DIR}"
     --junit-report="${junit_base}_${mode}_${suite_kind}.xml"
     -v

--- a/test/conformance/serial/ptp.go
+++ b/test/conformance/serial/ptp.go
@@ -937,15 +937,12 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 					})
 
 					// Wait for operator to reconcile the config map with the
-					// temp profile before restarting the daemon pod, so the new
-					// pod starts with the correct config on first boot.
+					// temp profile. The daemon watches the configmap and will
+					// hot-reload ptp4l internally — no pod restart needed.
 					err = ptphelper.WaitForConfigMapProfile(nodes.Items[0].Name, pkg.PtpTempPolicyName, 2*time.Minute)
 					Expect(err).NotTo(HaveOccurred(), "operator did not reconcile temp profile into configmap in time")
 
 					testPtpPod, err = ptphelper.GetPtpPodOnNode(nodes.Items[0].Name)
-					Expect(err).NotTo(HaveOccurred())
-
-					testPtpPod, err = ptphelper.ReplaceTestPod(&testPtpPod, time.Minute)
 					Expect(err).NotTo(HaveOccurred())
 				})
 


### PR DESCRIPTION
## Summary

- **scripts/run-tests.sh**: Add --flake-attempts to ginkgo invocations (defaults to 2 attempts, configurable via FLAKE_ATTEMPTS env var)
- **test/conformance/serial/ptp.go**: Remove ReplaceTestPod from the "Can provide a profile with higher priority" test. The pod restart causes a cold ptp4l restart where ens2f0 gets stuck in LISTENING in the netdevsim environment. Instead, rely on the daemon's configmap watcher to hot-reload the temp profile without disrupting PTP port negotiation.

Assisted-By: Cursor