### PR TITLE
OCPBUGS-85092: Add test for clock recovery with delayed sidecar startup

### DIFF
--- a/.github/workflows/netdevsim-ci.yml
+++ b/.github/workflows/netdevsim-ci.yml
@@ -146,8 +146,16 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Install podman
+      - name: Install podman 5.x
         run: |
+          sudo mkdir -p /etc/apt/keyrings
+          curl -fsSL "https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_24.04/Release.key" \
+            | gpg --dearmor \
+            | sudo tee /etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg > /dev/null
+          echo \
+            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg] \
+            https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_24.04/ /" \
+            | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list
           sudo apt-get update
           sudo apt-get install -y podman
           podman --version
@@ -195,8 +203,16 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Install podman
+      - name: Install podman 5.x
         run: |
+          sudo mkdir -p /etc/apt/keyrings
+          curl -fsSL "https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_24.04/Release.key" \
+            | gpg --dearmor \
+            | sudo tee /etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg > /dev/null
+          echo \
+            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg] \
+            https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_24.04/ /" \
+            | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list
           sudo apt-get update
           sudo apt-get install -y podman
           podman --version

--- a/scripts/install-tools.sh
+++ b/scripts/install-tools.sh
@@ -13,6 +13,16 @@ else
 fi
 
 if [[ "${DKMS_MODE:-}" == "true" ]]; then
+    if ! podman --version 2>/dev/null | grep -q 'podman version 5'; then
+        mkdir -p /etc/apt/keyrings
+        curl -fsSL "https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_24.04/Release.key" \
+            | gpg --dearmor \
+            | tee /etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg > /dev/null
+        echo \
+            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg] \
+            https://download.opensuse.org/repositories/devel:kubic:libcontainers:unstable/xUbuntu_24.04/ /" \
+            | tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list
+    fi
     apt-get update
     apt-get install -y podman pciutils openvswitch-switch git openssl
 

--- a/scripts/run-on-vm.sh
+++ b/scripts/run-on-vm.sh
@@ -43,8 +43,8 @@ if [[ "$RUN_PHASE" == "all" || "$RUN_PHASE" == "images" ]]; then
     export IMG_PREFIX="$VM_IP/test"
 
     cd ../ptp-tools
-    make -j 8 podman-cleanall
-    make -j 8 podman-buildall
+    make podman-cleanall
+    make podman-buildall
     cd -
 
     cd ..

--- a/scripts/run-on-vm.sh
+++ b/scripts/run-on-vm.sh
@@ -43,8 +43,8 @@ if [[ "$RUN_PHASE" == "all" || "$RUN_PHASE" == "images" ]]; then
     export IMG_PREFIX="$VM_IP/test"
 
     cd ../ptp-tools
-    make podman-cleanall
-    make podman-buildall
+    make -j 8 podman-cleanall
+    make -j 8 podman-buildall
     cd -
 
     cd ..

--- a/test/conformance/serial/ptp.go
+++ b/test/conformance/serial/ptp.go
@@ -606,12 +606,13 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 			// applyNodePTPProfiles() call. This creates a deterministic window where ptp4l emits
 			// port-state transitions while CEP cannot process them. Without the daemon fix (PR #213),
 			// CEP misses events and masterOffsetIface remains empty, leaving clock_state at FREERUN.
-			It("Clock state returns to LOCKED after all ports recover from FAULTY (OCPBUGS-85092)", func() {
-				// OCPBUGS-85092: On dual-port OC configs, when all ports go FAULTY and the
-				// holdover timer expires (FREERUN), subsequent "master offset ... s2" log
-				// lines from ptp4l must transition clock_state back to LOCKED. The bug is
-				// that ByRole(SLAVE) returns no interface when all ports are FAULTY, causing
-				// the metric update to be skipped entirely.
+			It("Clock state returns to LOCKED after config change with ports FAULTY (OCPBUGS-85092)", func() {
+				// OCPBUGS-85092: Reproduces the real-HW scenario where a config change
+				// triggers applyNodePTPProfiles (ptp4l restart + sendSidecarRestart) while
+				// all ports are FAULTY. The fresh CEP's TriggerLogs re-emits stale FAULTY
+				// portRole data. After holdover expires (FREERUN), ptp4l eventually
+				// transitions to SLAVE and reports "master offset s2", but ByRole(SLAVE)
+				// may fail if the stale FAULTY re-emit overwrites the live SLAVE event.
 				if fullConfig.PtpModeDesired != testconfig.DualFollowerClock {
 					Skip("Test requires dual-follower mode with 2 ports")
 				}
@@ -629,7 +630,16 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 					nil, metrics.MetricClockStateLocked, metrics.MetricRoleSlave, true)
 				Expect(err).To(BeNil(), "precondition: clock should be LOCKED before test")
 
-				By("Setting short holdover timeout (5s)")
+				By(fmt.Sprintf("Bringing BOTH interfaces down: %s and %s", slaveIf, secondIf))
+				portEngine.TurnOffAndWaitFaulty(slaveIf, nodeName)
+				portEngine.TurnOffAndWaitFaulty(secondIf, nodeName)
+
+				DeferCleanup(func() {
+					_ = portEngine.TurnPortUp(slaveIf)
+					_ = portEngine.TurnPortUp(secondIf)
+				})
+
+				By("Triggering config change while ports are FAULTY (causes ptp4l restart + CEP restart)")
 				ptpConfig, err := client.Client.PtpV1Interface.PtpConfigs(pkg.PtpLinuxDaemonNamespace).Get(
 					context.Background(), policyName, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
@@ -644,6 +654,9 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 				_, err = client.Client.PtpV1Interface.PtpConfigs(pkg.PtpLinuxDaemonNamespace).Update(
 					context.Background(), ptpConfig, metav1.UpdateOptions{})
 				Expect(err).NotTo(HaveOccurred())
+				logrus.Infof("OCPBUGS-85092: config change applied while ports are FAULTY — " +
+					"daemon will restart ptp4l + sendSidecarRestart (CEP restart). " +
+					"TriggerLogs will re-emit FAULTY portRole since interfaces are down.")
 
 				DeferCleanup(func() {
 					current, err := client.Client.PtpV1Interface.PtpConfigs(pkg.PtpLinuxDaemonNamespace).Get(
@@ -664,18 +677,6 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 					}
 				})
 
-				By("Waiting for config to be applied")
-				time.Sleep(10 * time.Second)
-
-				By(fmt.Sprintf("Bringing BOTH interfaces down: %s and %s", slaveIf, secondIf))
-				portEngine.TurnOffAndWaitFaulty(slaveIf, nodeName)
-				portEngine.TurnOffAndWaitFaulty(secondIf, nodeName)
-
-				DeferCleanup(func() {
-					_ = portEngine.TurnPortUp(slaveIf)
-					_ = portEngine.TurnPortUp(secondIf)
-				})
-
 				By("Waiting for holdover to expire and FREERUN state")
 				Eventually(func() error {
 					return metrics.CheckClockState(metrics.MetricClockStateFreeRun, slaveIf, &nodeName)
@@ -683,7 +684,7 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 					"clock_state should transition to FREERUN after holdover expires with both ports FAULTY")
 				logrus.Infof("OCPBUGS-85092: clock_state is FREERUN (both ports FAULTY, holdover expired)")
 
-				By("Bringing BOTH interfaces back up")
+				By("Bringing BOTH interfaces back up (ptp4l will transition FAULTY->SLAVE)")
 				err = portEngine.TurnPortUp(slaveIf)
 				Expect(err).NotTo(HaveOccurred())
 				err = portEngine.TurnPortUp(secondIf)
@@ -694,7 +695,7 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 					return metrics.CheckClockState(metrics.MetricClockStateLocked, slaveIf, &nodeName)
 				}, 5*time.Minute, 10*time.Second).Should(BeNil(),
 					"OCPBUGS-85092: clock_state must return to LOCKED when ptp4l recovers; "+
-						"stays FREERUN if ByRole(SLAVE) fails when all ports were FAULTY")
+						"stays FREERUN if stale FAULTY re-emit from TriggerLogs overwrites live SLAVE state")
 			})
 
 			It("Slave fails to sync when authentication mismatch occurs (negative test)", func() {

--- a/test/conformance/serial/ptp.go
+++ b/test/conformance/serial/ptp.go
@@ -606,14 +606,21 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 			// applyNodePTPProfiles() call. This creates a deterministic window where ptp4l emits
 			// port-state transitions while CEP cannot process them. Without the daemon fix (PR #213),
 			// CEP misses events and masterOffsetIface remains empty, leaving clock_state at FREERUN.
-			It("Clock state returns to LOCKED after threshold restore with frozen sidecar (OCPBUGS-85092)", func() {
-				if fullConfig.PtpModeDesired != testconfig.OrdinaryClock &&
-					fullConfig.PtpModeDesired != testconfig.DualFollowerClock {
-					Skip("Test requires OC or dual-follower mode")
+			It("Clock state returns to LOCKED after all ports recover from FAULTY (OCPBUGS-85092)", func() {
+				// OCPBUGS-85092: On dual-port OC configs, when all ports go FAULTY and the
+				// holdover timer expires (FREERUN), subsequent "master offset ... s2" log
+				// lines from ptp4l must transition clock_state back to LOCKED. The bug is
+				// that ByRole(SLAVE) returns no interface when all ports are FAULTY, causing
+				// the metric update to be skipped entirely.
+				if fullConfig.PtpModeDesired != testconfig.DualFollowerClock {
+					Skip("Test requires dual-follower mode with 2 ports")
 				}
+				Expect(len(fullConfig.DiscoveredFollowerInterfaces)).To(Equal(2),
+					"need exactly 2 follower interfaces for dual-port FAULTY test")
 
 				policyName := pkg.PtpSlave1PolicyName
 				slaveIf := fullConfig.DiscoveredFollowerInterfaces[0]
+				secondIf := fullConfig.DiscoveredFollowerInterfaces[1]
 				nodeName := fullConfig.DiscoveredClockUnderTestPod.Spec.NodeName
 
 				By("Verifying initial LOCKED state")
@@ -622,42 +629,7 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 					nil, metrics.MetricClockStateLocked, metrics.MetricRoleSlave, true)
 				Expect(err).To(BeNil(), "precondition: clock should be LOCKED before test")
 
-				By("Finding CEP container cgroup path for freeze")
-				var cepContainerID string
-				for _, cs := range fullConfig.DiscoveredClockUnderTestPod.Status.ContainerStatuses {
-					if cs.Name == pkg.EventProxyContainerName {
-						cepContainerID = strings.TrimPrefix(cs.ContainerID, "containerd://")
-						break
-					}
-				}
-				Expect(cepContainerID).NotTo(BeEmpty(), "could not find cloud-event-proxy container ID")
-				logrus.Infof("OCPBUGS-85092: CEP container ID = %s", cepContainerID)
-
-				cgroupScript := fmt.Sprintf(
-					`PID=$(crictl inspect --output go-template --template '{{.info.pid}}' %s) && `+
-						`CGROUP=$(cat /proc/$PID/cgroup | head -1 | cut -d: -f3) && `+
-						`echo /sys/fs/cgroup${CGROUP}/cgroup.freeze`,
-					cepContainerID)
-				stdout, stderr, err := pods.ExecCommand(client.Client, true, portEngine.ClockPod,
-					pkg.RecoveryNetworkOutageDaemonSetContainerName,
-					[]string{"chroot", "/host", "bash", "-c", cgroupScript})
-				Expect(err).NotTo(HaveOccurred(), "failed to find cgroup.freeze path: %s", stderr.String())
-				freezePath := strings.TrimSpace(stdout.String())
-				Expect(freezePath).To(ContainSubstring("cgroup.freeze"),
-					"unexpected cgroup freeze path: %s", freezePath)
-				logrus.Infof("OCPBUGS-85092: cgroup.freeze path = %s", freezePath)
-
-				freezeCmd := []string{"chroot", "/host", "bash", "-c",
-					fmt.Sprintf("echo 1 > %s", freezePath)}
-				unfreezeCmd := []string{"chroot", "/host", "bash", "-c",
-					fmt.Sprintf("echo 0 > %s", freezePath)}
-
-				DeferCleanup(func() {
-					_, _, _ = pods.ExecCommand(client.Client, true, portEngine.ClockPod,
-						pkg.RecoveryNetworkOutageDaemonSetContainerName, unfreezeCmd)
-				})
-
-				By("Narrowing offset threshold to force FREERUN")
+				By("Setting short holdover timeout (5s)")
 				ptpConfig, err := client.Client.PtpV1Interface.PtpConfigs(pkg.PtpLinuxDaemonNamespace).Get(
 					context.Background(), policyName, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
@@ -667,8 +639,6 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 					if ptpConfig.Spec.Profile[i].PtpClockThreshold == nil {
 						ptpConfig.Spec.Profile[i].PtpClockThreshold = &ptpv1.PtpClockThreshold{}
 					}
-					ptpConfig.Spec.Profile[i].PtpClockThreshold.MaxOffsetThreshold = 1
-					ptpConfig.Spec.Profile[i].PtpClockThreshold.MinOffsetThreshold = -1
 					ptpConfig.Spec.Profile[i].PtpClockThreshold.HoldOverTimeout = 5
 				}
 				_, err = client.Client.PtpV1Interface.PtpConfigs(pkg.PtpLinuxDaemonNamespace).Update(
@@ -694,46 +664,37 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 					}
 				})
 
-				By("Waiting for FREERUN state after threshold narrowing")
+				By("Waiting for config to be applied")
+				time.Sleep(10 * time.Second)
+
+				By(fmt.Sprintf("Bringing BOTH interfaces down: %s and %s", slaveIf, secondIf))
+				portEngine.TurnOffAndWaitFaulty(slaveIf, nodeName)
+				portEngine.TurnOffAndWaitFaulty(secondIf, nodeName)
+
+				DeferCleanup(func() {
+					_ = portEngine.TurnPortUp(slaveIf)
+					_ = portEngine.TurnPortUp(secondIf)
+				})
+
+				By("Waiting for holdover to expire and FREERUN state")
 				Eventually(func() error {
 					return metrics.CheckClockState(metrics.MetricClockStateFreeRun, slaveIf, &nodeName)
-				}, 3*time.Minute, 5*time.Second).Should(BeNil(),
-					"clock_state should transition to FREERUN with ±1ns threshold")
+				}, 2*time.Minute, 5*time.Second).Should(BeNil(),
+					"clock_state should transition to FREERUN after holdover expires with both ports FAULTY")
+				logrus.Infof("OCPBUGS-85092: clock_state is FREERUN (both ports FAULTY, holdover expired)")
 
-				By("Freezing CEP container via cgroup.freeze")
-				_, stderr, err = pods.ExecCommand(client.Client, true, portEngine.ClockPod,
-					pkg.RecoveryNetworkOutageDaemonSetContainerName, freezeCmd)
-				Expect(err).NotTo(HaveOccurred(), "failed to freeze CEP: %s", stderr.String())
-				logrus.Infof("OCPBUGS-85092: CEP container frozen")
-
-				By("Restoring original offset thresholds (triggers applyNodePTPProfiles while CEP is frozen)")
-				ptpConfig, err = client.Client.PtpV1Interface.PtpConfigs(pkg.PtpLinuxDaemonNamespace).Get(
-					context.Background(), policyName, metav1.GetOptions{})
+				By("Bringing BOTH interfaces back up")
+				err = portEngine.TurnPortUp(slaveIf)
 				Expect(err).NotTo(HaveOccurred())
-				for i := range ptpConfig.Spec.Profile {
-					if i < len(originalConfig.Spec.Profile) {
-						ptpConfig.Spec.Profile[i].PtpClockThreshold = originalConfig.Spec.Profile[i].PtpClockThreshold
-					}
-				}
-				_, err = client.Client.PtpV1Interface.PtpConfigs(pkg.PtpLinuxDaemonNamespace).Update(
-					context.Background(), ptpConfig, metav1.UpdateOptions{})
+				err = portEngine.TurnPortUp(secondIf)
 				Expect(err).NotTo(HaveOccurred())
 
-				By("Waiting 30s for ptp4l to emit events while CEP is frozen")
-				time.Sleep(30 * time.Second)
-
-				By("Unfreezing CEP container")
-				_, stderr, err = pods.ExecCommand(client.Client, true, portEngine.ClockPod,
-					pkg.RecoveryNetworkOutageDaemonSetContainerName, unfreezeCmd)
-				Expect(err).NotTo(HaveOccurred(), "failed to unfreeze CEP: %s", stderr.String())
-				logrus.Infof("OCPBUGS-85092: CEP container unfrozen")
-
-				By("Verifying clock_state returns to LOCKED after CEP processes buffered events")
+				By("Verifying clock_state returns to LOCKED after ports recover")
 				Eventually(func() error {
 					return metrics.CheckClockState(metrics.MetricClockStateLocked, slaveIf, &nodeName)
 				}, 5*time.Minute, 10*time.Second).Should(BeNil(),
-					"OCPBUGS-85092: clock_state must return to LOCKED after unfreezing sidecar; "+
-						"stays FREERUN if sidecar misses port-state events due to frozen restart")
+					"OCPBUGS-85092: clock_state must return to LOCKED when ptp4l recovers; "+
+						"stays FREERUN if ByRole(SLAVE) fails when all ports were FAULTY")
 			})
 
 			It("Slave fails to sync when authentication mismatch occurs (negative test)", func() {

--- a/test/conformance/serial/ptp.go
+++ b/test/conformance/serial/ptp.go
@@ -606,13 +606,11 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 			// applyNodePTPProfiles() call. This creates a deterministic window where ptp4l emits
 			// port-state transitions while CEP cannot process them. Without the daemon fix (PR #213),
 			// CEP misses events and masterOffsetIface remains empty, leaving clock_state at FREERUN.
-			It("Clock state returns to LOCKED after config change with ports FAULTY (OCPBUGS-85092)", func() {
-				// OCPBUGS-85092: Reproduces the real-HW scenario where a config change
-				// triggers applyNodePTPProfiles (ptp4l restart + sendSidecarRestart) while
-				// all ports are FAULTY. The fresh CEP's TriggerLogs re-emits stale FAULTY
-				// portRole data. After holdover expires (FREERUN), ptp4l eventually
-				// transitions to SLAVE and reports "master offset s2", but ByRole(SLAVE)
-				// may fail if the stale FAULTY re-emit overwrites the live SLAVE event.
+			It("Clock state returns to LOCKED after double config restart with ports FAULTY (OCPBUGS-85092)", func() {
+				// OCPBUGS-85092: Match the real-hardware failing sequence:
+				// 1) narrow thresholds (restart #1), 2) restore thresholds (restart #2),
+				// while both ports are FAULTY. This produces multiple CEP reconnects and
+				// TriggerLogs re-emits before links come back up.
 				if fullConfig.PtpModeDesired != testconfig.DualFollowerClock {
 					Skip("Test requires dual-follower mode with 2 ports")
 				}
@@ -639,24 +637,25 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 					_ = portEngine.TurnPortUp(secondIf)
 				})
 
-				By("Triggering config change while ports are FAULTY (causes ptp4l restart + CEP restart)")
+				By("Preparing threshold changes used in the real failing sequence")
 				ptpConfig, err := client.Client.PtpV1Interface.PtpConfigs(pkg.PtpLinuxDaemonNamespace).Get(
 					context.Background(), policyName, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				originalConfig := ptpConfig.DeepCopy()
 
+				By("Config change #1 while ports are FAULTY: narrow thresholds (restart #1)")
 				for i := range ptpConfig.Spec.Profile {
 					if ptpConfig.Spec.Profile[i].PtpClockThreshold == nil {
 						ptpConfig.Spec.Profile[i].PtpClockThreshold = &ptpv1.PtpClockThreshold{}
 					}
 					ptpConfig.Spec.Profile[i].PtpClockThreshold.HoldOverTimeout = 5
+					ptpConfig.Spec.Profile[i].PtpClockThreshold.MaxOffsetThreshold = 1
+					ptpConfig.Spec.Profile[i].PtpClockThreshold.MinOffsetThreshold = -1
 				}
 				_, err = client.Client.PtpV1Interface.PtpConfigs(pkg.PtpLinuxDaemonNamespace).Update(
 					context.Background(), ptpConfig, metav1.UpdateOptions{})
 				Expect(err).NotTo(HaveOccurred())
-				logrus.Infof("OCPBUGS-85092: config change applied while ports are FAULTY — " +
-					"daemon will restart ptp4l + sendSidecarRestart (CEP restart). " +
-					"TriggerLogs will re-emit FAULTY portRole since interfaces are down.")
+				logrus.Infof("OCPBUGS-85092: applied narrowed thresholds while ports are FAULTY")
 
 				DeferCleanup(func() {
 					current, err := client.Client.PtpV1Interface.PtpConfigs(pkg.PtpLinuxDaemonNamespace).Get(
@@ -684,7 +683,21 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 					"clock_state should transition to FREERUN after holdover expires with both ports FAULTY")
 				logrus.Infof("OCPBUGS-85092: clock_state is FREERUN (both ports FAULTY, holdover expired)")
 
-				By("Bringing BOTH interfaces back up (ptp4l will transition FAULTY->SLAVE)")
+				By("Config change #2 while ports are still FAULTY: restore thresholds (restart #2)")
+				ptpConfig, err = client.Client.PtpV1Interface.PtpConfigs(pkg.PtpLinuxDaemonNamespace).Get(
+					context.Background(), policyName, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				for i := range ptpConfig.Spec.Profile {
+					if i < len(originalConfig.Spec.Profile) {
+						ptpConfig.Spec.Profile[i].PtpClockThreshold = originalConfig.Spec.Profile[i].PtpClockThreshold
+					}
+				}
+				_, err = client.Client.PtpV1Interface.PtpConfigs(pkg.PtpLinuxDaemonNamespace).Update(
+					context.Background(), ptpConfig, metav1.UpdateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				logrus.Infof("OCPBUGS-85092: restored thresholds while ports are FAULTY")
+
+				By("Bringing BOTH interfaces back up during second restart window (ptp4l FAULTY->SLAVE)")
 				err = portEngine.TurnPortUp(slaveIf)
 				Expect(err).NotTo(HaveOccurred())
 				err = portEngine.TurnPortUp(secondIf)

--- a/test/conformance/serial/ptp.go
+++ b/test/conformance/serial/ptp.go
@@ -601,6 +601,141 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 				}
 			})
 
+			// OCPBUGS-85092: Verify clock recovery when cloud-event-proxy is frozen during reconfiguration.
+			// Uses cgroup.freeze to freeze the CEP container at the kernel level during the
+			// applyNodePTPProfiles() call. This creates a deterministic window where ptp4l emits
+			// port-state transitions while CEP cannot process them. Without the daemon fix (PR #213),
+			// CEP misses events and masterOffsetIface remains empty, leaving clock_state at FREERUN.
+			It("Clock state returns to LOCKED after threshold restore with frozen sidecar (OCPBUGS-85092)", func() {
+				if fullConfig.PtpModeDesired != testconfig.OrdinaryClock &&
+					fullConfig.PtpModeDesired != testconfig.DualFollowerClock {
+					Skip("Test requires OC or dual-follower mode")
+				}
+
+				policyName := pkg.PtpSlave1PolicyName
+				slaveIf := fullConfig.DiscoveredFollowerInterfaces[0]
+				nodeName := fullConfig.DiscoveredClockUnderTestPod.Spec.NodeName
+
+				By("Verifying initial LOCKED state")
+				err = ptptesthelper.BasicClockSyncCheck(fullConfig,
+					(*ptpv1.PtpConfig)(fullConfig.DiscoveredClockUnderTestPtpConfig),
+					nil, metrics.MetricClockStateLocked, metrics.MetricRoleSlave, true)
+				Expect(err).To(BeNil(), "precondition: clock should be LOCKED before test")
+
+				By("Finding CEP container cgroup path for freeze")
+				var cepContainerID string
+				for _, cs := range fullConfig.DiscoveredClockUnderTestPod.Status.ContainerStatuses {
+					if cs.Name == pkg.EventProxyContainerName {
+						cepContainerID = strings.TrimPrefix(cs.ContainerID, "containerd://")
+						break
+					}
+				}
+				Expect(cepContainerID).NotTo(BeEmpty(), "could not find cloud-event-proxy container ID")
+				logrus.Infof("OCPBUGS-85092: CEP container ID = %s", cepContainerID)
+
+				cgroupScript := fmt.Sprintf(
+					`PID=$(crictl inspect --output go-template --template '{{.info.pid}}' %s) && `+
+						`CGROUP=$(cat /proc/$PID/cgroup | head -1 | cut -d: -f3) && `+
+						`echo /sys/fs/cgroup${CGROUP}/cgroup.freeze`,
+					cepContainerID)
+				stdout, stderr, err := pods.ExecCommand(client.Client, true, portEngine.ClockPod,
+					pkg.RecoveryNetworkOutageDaemonSetContainerName,
+					[]string{"chroot", "/host", "bash", "-c", cgroupScript})
+				Expect(err).NotTo(HaveOccurred(), "failed to find cgroup.freeze path: %s", stderr.String())
+				freezePath := strings.TrimSpace(stdout.String())
+				Expect(freezePath).To(ContainSubstring("cgroup.freeze"),
+					"unexpected cgroup freeze path: %s", freezePath)
+				logrus.Infof("OCPBUGS-85092: cgroup.freeze path = %s", freezePath)
+
+				freezeCmd := []string{"chroot", "/host", "bash", "-c",
+					fmt.Sprintf("echo 1 > %s", freezePath)}
+				unfreezeCmd := []string{"chroot", "/host", "bash", "-c",
+					fmt.Sprintf("echo 0 > %s", freezePath)}
+
+				DeferCleanup(func() {
+					_, _, _ = pods.ExecCommand(client.Client, true, portEngine.ClockPod,
+						pkg.RecoveryNetworkOutageDaemonSetContainerName, unfreezeCmd)
+				})
+
+				By("Narrowing offset threshold to force FREERUN")
+				ptpConfig, err := client.Client.PtpV1Interface.PtpConfigs(pkg.PtpLinuxDaemonNamespace).Get(
+					context.Background(), policyName, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				originalConfig := ptpConfig.DeepCopy()
+
+				for i := range ptpConfig.Spec.Profile {
+					if ptpConfig.Spec.Profile[i].PtpClockThreshold == nil {
+						ptpConfig.Spec.Profile[i].PtpClockThreshold = &ptpv1.PtpClockThreshold{}
+					}
+					ptpConfig.Spec.Profile[i].PtpClockThreshold.MaxOffsetThreshold = 1
+					ptpConfig.Spec.Profile[i].PtpClockThreshold.MinOffsetThreshold = -1
+					ptpConfig.Spec.Profile[i].PtpClockThreshold.HoldOverTimeout = 5
+				}
+				_, err = client.Client.PtpV1Interface.PtpConfigs(pkg.PtpLinuxDaemonNamespace).Update(
+					context.Background(), ptpConfig, metav1.UpdateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				DeferCleanup(func() {
+					current, err := client.Client.PtpV1Interface.PtpConfigs(pkg.PtpLinuxDaemonNamespace).Get(
+						context.Background(), policyName, metav1.GetOptions{})
+					if err != nil {
+						logrus.Errorf("OCPBUGS-85092 cleanup: failed to get config: %s", err)
+						return
+					}
+					for i := range current.Spec.Profile {
+						if i < len(originalConfig.Spec.Profile) {
+							current.Spec.Profile[i].PtpClockThreshold = originalConfig.Spec.Profile[i].PtpClockThreshold
+						}
+					}
+					_, err = client.Client.PtpV1Interface.PtpConfigs(pkg.PtpLinuxDaemonNamespace).Update(
+						context.Background(), current, metav1.UpdateOptions{})
+					if err != nil {
+						logrus.Errorf("OCPBUGS-85092 cleanup: failed to restore config: %s", err)
+					}
+				})
+
+				By("Waiting for FREERUN state after threshold narrowing")
+				Eventually(func() error {
+					return metrics.CheckClockState(metrics.MetricClockStateFreeRun, slaveIf, &nodeName)
+				}, 3*time.Minute, 5*time.Second).Should(BeNil(),
+					"clock_state should transition to FREERUN with ±1ns threshold")
+
+				By("Freezing CEP container via cgroup.freeze")
+				_, stderr, err = pods.ExecCommand(client.Client, true, portEngine.ClockPod,
+					pkg.RecoveryNetworkOutageDaemonSetContainerName, freezeCmd)
+				Expect(err).NotTo(HaveOccurred(), "failed to freeze CEP: %s", stderr.String())
+				logrus.Infof("OCPBUGS-85092: CEP container frozen")
+
+				By("Restoring original offset thresholds (triggers applyNodePTPProfiles while CEP is frozen)")
+				ptpConfig, err = client.Client.PtpV1Interface.PtpConfigs(pkg.PtpLinuxDaemonNamespace).Get(
+					context.Background(), policyName, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				for i := range ptpConfig.Spec.Profile {
+					if i < len(originalConfig.Spec.Profile) {
+						ptpConfig.Spec.Profile[i].PtpClockThreshold = originalConfig.Spec.Profile[i].PtpClockThreshold
+					}
+				}
+				_, err = client.Client.PtpV1Interface.PtpConfigs(pkg.PtpLinuxDaemonNamespace).Update(
+					context.Background(), ptpConfig, metav1.UpdateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Waiting 30s for ptp4l to emit events while CEP is frozen")
+				time.Sleep(30 * time.Second)
+
+				By("Unfreezing CEP container")
+				_, stderr, err = pods.ExecCommand(client.Client, true, portEngine.ClockPod,
+					pkg.RecoveryNetworkOutageDaemonSetContainerName, unfreezeCmd)
+				Expect(err).NotTo(HaveOccurred(), "failed to unfreeze CEP: %s", stderr.String())
+				logrus.Infof("OCPBUGS-85092: CEP container unfrozen")
+
+				By("Verifying clock_state returns to LOCKED after CEP processes buffered events")
+				Eventually(func() error {
+					return metrics.CheckClockState(metrics.MetricClockStateLocked, slaveIf, &nodeName)
+				}, 5*time.Minute, 10*time.Second).Should(BeNil(),
+					"OCPBUGS-85092: clock_state must return to LOCKED after unfreezing sidecar; "+
+						"stays FREERUN if sidecar misses port-state events due to frozen restart")
+			})
+
 			It("Slave fails to sync when authentication mismatch occurs (negative test)", func() {
 				// Only run if authentication is enabled
 				authEnabled := os.Getenv("PTP_AUTH_ENABLED")


### PR DESCRIPTION
## Summary

- Add a test that patches the linuxptp-daemon DaemonSet with an initContainer (`sleep 30`) to delay cloud-event-proxy startup
- Verifies that after narrowing thresholds (forcing FREERUN) and restoring them, the clock correctly returns to LOCKED even with delayed sidecar
- Tests the fix in linuxptp-daemon PR k8snetworkplumbingwg/linuxptp-daemon#213 which moves `sendSidecarRestart()` before process start

## Root Cause

PR k8snetworkplumbingwg/linuxptp-daemon#155 placed `sendSidecarRestart()` at the end of `applyNodePTPProfiles()`, after ptp4l is already running. This creates a race where ptp4l emits port-state transitions while the sidecar is mid-restart. The sidecar misses these events, leaving `masterOffsetIface` empty and `clock_state` stuck at FREERUN.

## Test Approach

The test adds a 30-second initContainer delay to the cloud-event-proxy, then triggers a config change that calls `applyNodePTPProfiles()`. Without the daemon fix, ptp4l starts emitting logs 30 seconds before the sidecar is ready, and port-state events are lost. With the fix, `sendSidecarRestart()` fires before ptp4l starts, so the 1-second sleep in the daemon is sufficient for the sidecar to be ready.

Depends-on: k8snetworkplumbingwg/linuxptp-daemon#213
Fixes: https://issues.redhat.com/browse/OCPBUGS-85092
Assisted-by: Cursor