### PR TITLE
ci: upgrade to podman 5.x to fix manifest storage bugs

### DIFF
--- a/.github/workflows/netdevsim-ci.yml
+++ b/.github/workflows/netdevsim-ci.yml
@@ -146,8 +146,14 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Install podman
+      - name: Install podman 5.x
         run: |
+          sudo mkdir -p /etc/apt/keyrings
+          curl -fsSL "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_$(lsb_release -rs)/Release.key" \
+            | gpg --dearmor | sudo tee /etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg > /dev/null
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg] \
+            https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_$(lsb_release -rs)/ /" \
+            | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list > /dev/null
           sudo apt-get update
           sudo apt-get install -y podman
           podman --version
@@ -195,8 +201,14 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Install podman
+      - name: Install podman 5.x
         run: |
+          sudo mkdir -p /etc/apt/keyrings
+          curl -fsSL "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_$(lsb_release -rs)/Release.key" \
+            | gpg --dearmor | sudo tee /etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg > /dev/null
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg] \
+            https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_$(lsb_release -rs)/ /" \
+            | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list > /dev/null
           sudo apt-get update
           sudo apt-get install -y podman
           podman --version

--- a/scripts/install-tools.sh
+++ b/scripts/install-tools.sh
@@ -13,6 +13,12 @@ else
 fi
 
 if [[ "${DKMS_MODE:-}" == "true" ]]; then
+    mkdir -p /etc/apt/keyrings
+    curl -fsSL "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_$(lsb_release -rs)/Release.key" \
+      | gpg --dearmor | tee /etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg > /dev/null
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg] \
+      https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_$(lsb_release -rs)/ /" \
+      | tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list > /dev/null
     apt-get update
     apt-get install -y podman pciutils openvswitch-switch git openssl
 


### PR DESCRIPTION
## Summary
- Install podman 5.x from the kubic unstable repo instead of using Ubuntu 24.04's bundled podman 4.9.3
- Fixes "image not known" errors during `podman manifest push` caused by known overlay storage bugs in podman 4.x

Assisted by: Cursor