### PR TITLE
OCPBUGS-85092: add replay-gate e2e test and update Dockerfiles

### DIFF
--- a/.github/workflows/netdevsim-ci.yml
+++ b/.github/workflows/netdevsim-ci.yml
@@ -12,7 +12,7 @@ env:
   DKMS_PKG: netdevsim
   DKMS_VER: "6.9.5"
   DKMS_REPO: https://github.com/redhat-cne/netdevsim-dkms.git
-  DKMS_BRANCH: main
+  DKMS_BRANCH: node-device
 
 jobs:
   # ------------------------------------------------------------------

--- a/ptp-tools/Dockerfile.cep
+++ b/ptp-tools/Dockerfile.cep
@@ -7,7 +7,7 @@ ENV GOPATH=/go
 ENV GOMAXPROCS=16
 
 WORKDIR /go/src/github.com/redhat-cne/cloud-event-proxy
-RUN git clone -b main https://github.com/redhat-cne/cloud-event-proxy.git /go/src/github.com/redhat-cne/cloud-event-proxy
+RUN git clone -b replay-fix https://github.com/edcdavid/cloud-event-proxy.git /go/src/github.com/redhat-cne/cloud-event-proxy
 
 RUN hack/build-go.sh
 

--- a/ptp-tools/Dockerfile.lptpd
+++ b/ptp-tools/Dockerfile.lptpd
@@ -2,7 +2,7 @@ FROM docker.io/golang:1.25.7 AS builder
 WORKDIR /go/src/github.com/k8snetworkplumbingwg/linuxptp-daemon
 ENV GOMAXPROCS=16
 
-RUN git clone -b main https://github.com/k8snetworkplumbingwg/linuxptp-daemon.git  /go/src/github.com/k8snetworkplumbingwg/linuxptp-daemon
+RUN git clone -b replay-fix https://github.com/edcdavid/linuxptp-daemon-upstream.git  /go/src/github.com/k8snetworkplumbingwg/linuxptp-daemon
 
 RUN make clean && make -j 16
 

--- a/scripts/create-local-registry.sh
+++ b/scripts/create-local-registry.sh
@@ -11,12 +11,14 @@ openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes  -keyout ~/registry
 
 openssl x509 -in ~/registry/registry.crt -out ~/registry/registry.pem -outform PEM
 
-if [[ "${DKMS_MODE:-}" == "true" ]]; then
+if [ -d /usr/local/share/ca-certificates ]; then
     cp ~/registry/registry.pem /usr/local/share/ca-certificates/registry.crt
     update-ca-certificates
-else
-    sudo mv ~/registry/registry.pem /etc/pki/ca-trust/source/anchors/
+elif [ -d /etc/pki/ca-trust/source/anchors ]; then
+    cp ~/registry/registry.pem /etc/pki/ca-trust/source/anchors/registry.pem
     update-ca-trust
+else
+    echo "WARNING: Could not find CA certificate directory"
 fi
 
 podman run -d \

--- a/scripts/install-tools.sh
+++ b/scripts/install-tools.sh
@@ -12,6 +12,11 @@ else
     exit 1
 fi
 
+# Auto-detect distro when DKMS_MODE is not explicitly set
+if [[ "${DKMS_MODE:-}" != "true" ]] && command -v apt-get &>/dev/null && ! command -v yum &>/dev/null; then
+    export DKMS_MODE=true
+fi
+
 # Detect OS family
 if [ -f /etc/os-release ]; then
     . /etc/os-release

--- a/scripts/install-tools.sh
+++ b/scripts/install-tools.sh
@@ -12,15 +12,27 @@ else
     exit 1
 fi
 
+# Detect OS family
+if [ -f /etc/os-release ]; then
+    . /etc/os-release
+    OS_ID="${ID:-unknown}"
+else
+    OS_ID="unknown"
+fi
+
+case "$OS_ID" in
+    ubuntu|debian|linuxmint|pop) OS_FAMILY="debian" ;;
+    fedora|rhel|centos|rocky|alma) OS_FAMILY="redhat" ;;
+    *) echo "WARNING: Unknown OS '$OS_ID', assuming redhat-like"; OS_FAMILY="redhat" ;;
+esac
+
 if [[ "${DKMS_MODE:-}" == "true" ]]; then
-    mkdir -p /etc/apt/keyrings
-    curl -fsSL "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_$(lsb_release -rs)/Release.key" \
-      | gpg --dearmor | tee /etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg > /dev/null
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg] \
-      https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_$(lsb_release -rs)/ /" \
-      | tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list > /dev/null
-    apt-get update
-    apt-get install -y podman pciutils openvswitch-switch git openssl
+    if [[ "$OS_FAMILY" == "debian" ]]; then
+        apt-get update -qq
+        apt-get install -y podman pciutils openvswitch-switch git openssl
+    else
+        dnf install -y podman pciutils openvswitch git openssl
+    fi
 
     # kubectl
     KUBECTL_VER=$(curl -fsSL https://dl.k8s.io/release/stable.txt)

--- a/scripts/run-on-vm.sh
+++ b/scripts/run-on-vm.sh
@@ -44,7 +44,7 @@ if [[ "$RUN_PHASE" == "all" || "$RUN_PHASE" == "images" ]]; then
 
     cd ../ptp-tools
     make -j 8 podman-cleanall
-    make -j 8 podman-buildall
+    make podman-buildall
     cd -
 
     cd ..
@@ -136,7 +136,12 @@ if [[ "$RUN_PHASE" == "all" || "$RUN_PHASE" == "deploy" ]]; then
           for pod in $(kubectl get pods -n openshift-ptp -l app=linuxptp-daemon \
                        --field-selector=status.phase=Running -o name 2>/dev/null); do
             kubectl exec -n openshift-ptp ${pod#pod/} -c linuxptp-daemon-container -- \
-              bash -c "for i in 0 1 2 3 4 5 6 7 8 9; do ln -sf nsim_ptp\$i /dev/ptp\$i 2>/dev/null; done" \
+              bash -c "for i in 0 1 2 3 4 5 6 7 8 9; do
+                if [ -e /sys/class/ptp/ptp\$i/dev ]; then
+                  rm -f /dev/ptp\$i
+                  mknod /dev/ptp\$i c 246 \$i 2>/dev/null
+                fi
+              done" \
               2>/dev/null || true
           done
           sleep 5
@@ -146,6 +151,13 @@ if [[ "$RUN_PHASE" == "all" || "$RUN_PHASE" == "deploy" ]]; then
         echo "Symlink maintainer PID: $SYMLINK_PID"
         cleanup_symlink() { [[ -n "$SYMLINK_PID" ]] && kill "$SYMLINK_PID" 2>/dev/null || true; }
         trap cleanup_symlink EXIT
+    else
+        for pod in $(kubectl get pods -n openshift-ptp -l app=linuxptp-daemon \
+                     --field-selector=status.phase=Running -o name 2>/dev/null); do
+            kubectl exec -n openshift-ptp ${pod#pod/} -c linuxptp-daemon-container -- \
+              bash -c "for i in 0 1 2 3 4 5 6 7 8 9; do rm -f /dev/ptp\$i 2>/dev/null; done" \
+              2>/dev/null || true
+        done
     fi
 
     ./run-tests.sh --kind serial --mode "$TEST_MODES" \

--- a/scripts/run-on-vm.sh
+++ b/scripts/run-on-vm.sh
@@ -129,37 +129,6 @@ if [[ "$RUN_PHASE" == "all" || "$RUN_PHASE" == "deploy" ]]; then
 
     kubectl get pods -n openshift-ptp -o wide
 
-    SYMLINK_PID=""
-    if [[ "${DKMS_MODE}" == "true" ]]; then
-        bash -c '
-        while true; do
-          for pod in $(kubectl get pods -n openshift-ptp -l app=linuxptp-daemon \
-                       --field-selector=status.phase=Running -o name 2>/dev/null); do
-            kubectl exec -n openshift-ptp ${pod#pod/} -c linuxptp-daemon-container -- \
-              bash -c "for i in 0 1 2 3 4 5 6 7 8 9; do
-                if [ -e /sys/class/ptp/ptp\$i/dev ]; then
-                  rm -f /dev/ptp\$i
-                  mknod /dev/ptp\$i c 246 \$i 2>/dev/null
-                fi
-              done" \
-              2>/dev/null || true
-          done
-          sleep 5
-        done
-        ' &
-        SYMLINK_PID=$!
-        echo "Symlink maintainer PID: $SYMLINK_PID"
-        cleanup_symlink() { [[ -n "$SYMLINK_PID" ]] && kill "$SYMLINK_PID" 2>/dev/null || true; }
-        trap cleanup_symlink EXIT
-    else
-        for pod in $(kubectl get pods -n openshift-ptp -l app=linuxptp-daemon \
-                     --field-selector=status.phase=Running -o name 2>/dev/null); do
-            kubectl exec -n openshift-ptp ${pod#pod/} -c linuxptp-daemon-container -- \
-              bash -c "for i in 0 1 2 3 4 5 6 7 8 9; do rm -f /dev/ptp\$i 2>/dev/null; done" \
-              2>/dev/null || true
-        done
-    fi
-
     ./run-tests.sh --kind serial --mode "$TEST_MODES" \
       --linuxptp-daemon-image "$IMG_PREFIX:lptpd" \
       --must-gather-image "$IMG_PREFIX:ptpmg" \

--- a/test/conformance/serial/ptp.go
+++ b/test/conformance/serial/ptp.go
@@ -684,7 +684,6 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 					"clock should return to LOCKED after pod restart with replay delay")
 
 				By("Initializing port engine for interface control")
-				portEngine := ptptesthelper.PortEngine{}
 				portEngine.Initialize(fullConfig.DiscoveredClockUnderTestPod, []string{slaveIf, secondIf})
 
 				By(fmt.Sprintf("Bringing BOTH interfaces down: %s and %s", slaveIf, secondIf))

--- a/test/conformance/serial/ptp.go
+++ b/test/conformance/serial/ptp.go
@@ -601,6 +601,172 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 				}
 			})
 
+			// OCPBUGS-85092: Verify clock recovery when replay is delayed relative to live data.
+			// Sets PTP_REPLAY_DELAY_MS on the daemon to simulate slow replay (as seen on real HW).
+			// The daemon's live gate ensures ptp4l data only flows after replay completes,
+			// preventing stale FAULTY replay from overwriting live SLAVE state.
+			It("Clock state returns to LOCKED after replay-gated reconfiguration (OCPBUGS-85092)", func() {
+				if fullConfig.PtpModeDesired != testconfig.DualFollowerClock {
+					Skip("Test requires dual-follower mode with 2 ports")
+				}
+				Expect(len(fullConfig.DiscoveredFollowerInterfaces)).To(Equal(2),
+					"need exactly 2 follower interfaces for dual-port FAULTY test")
+
+				const replayDelayMs = "10000"
+
+				policyName := pkg.PtpSlave1PolicyName
+				slaveIf := fullConfig.DiscoveredFollowerInterfaces[0]
+				secondIf := fullConfig.DiscoveredFollowerInterfaces[1]
+				nodeName := fullConfig.DiscoveredClockUnderTestPod.Spec.NodeName
+
+				By("Verifying initial LOCKED state")
+				err = ptptesthelper.BasicClockSyncCheck(fullConfig,
+					(*ptpv1.PtpConfig)(fullConfig.DiscoveredClockUnderTestPtpConfig),
+					nil, metrics.MetricClockStateLocked, metrics.MetricRoleSlave, true)
+				Expect(err).To(BeNil(), "precondition: clock should be LOCKED before test")
+
+				By("Patching DaemonSet to add PTP_REPLAY_DELAY_MS env var")
+				ds, getErr := client.Client.AppsV1Interface.DaemonSets(pkg.PtpLinuxDaemonNamespace).Get(
+					context.Background(), "linuxptp-daemon", metav1.GetOptions{})
+				Expect(getErr).NotTo(HaveOccurred())
+				originalDS := ds.DeepCopy()
+
+				for i := range ds.Spec.Template.Spec.Containers {
+					if ds.Spec.Template.Spec.Containers[i].Name == "linuxptp-daemon-container" {
+						ds.Spec.Template.Spec.Containers[i].Env = append(
+							ds.Spec.Template.Spec.Containers[i].Env,
+							v1core.EnvVar{Name: "PTP_REPLAY_DELAY_MS", Value: replayDelayMs},
+						)
+						break
+					}
+				}
+				_, updateErr := client.Client.AppsV1Interface.DaemonSets(pkg.PtpLinuxDaemonNamespace).Update(
+					context.Background(), ds, metav1.UpdateOptions{})
+				Expect(updateErr).NotTo(HaveOccurred())
+
+				DeferCleanup(func() {
+					By("Cleanup: removing PTP_REPLAY_DELAY_MS env var from DaemonSet")
+					current, err := client.Client.AppsV1Interface.DaemonSets(pkg.PtpLinuxDaemonNamespace).Get(
+						context.Background(), "linuxptp-daemon", metav1.GetOptions{})
+					if err != nil {
+						logrus.Errorf("OCPBUGS-85092 cleanup: failed to get DS: %v", err)
+						return
+					}
+					for i := range current.Spec.Template.Spec.Containers {
+						if current.Spec.Template.Spec.Containers[i].Name == "linuxptp-daemon-container" {
+							filtered := []v1core.EnvVar{}
+							for _, e := range current.Spec.Template.Spec.Containers[i].Env {
+								if e.Name != "PTP_REPLAY_DELAY_MS" {
+									filtered = append(filtered, e)
+								}
+							}
+							current.Spec.Template.Spec.Containers[i].Env = filtered
+							break
+						}
+					}
+					_, err = client.Client.AppsV1Interface.DaemonSets(pkg.PtpLinuxDaemonNamespace).Update(
+						context.Background(), current, metav1.UpdateOptions{})
+					if err != nil {
+						logrus.Errorf("OCPBUGS-85092 cleanup: failed to restore DS: %v", err)
+					}
+					_ = originalDS // suppress unused warning
+				})
+
+				By("Waiting for pods to restart with replay delay env var")
+				time.Sleep(30 * time.Second)
+				ptphelper.WaitForPtpDaemonToExist()
+				fullConfig = testconfig.GetFullDiscoveredConfig(pkg.PtpLinuxDaemonNamespace, true)
+
+				By("Waiting for clock to re-sync after pod restart")
+				Eventually(func() error {
+					return metrics.CheckClockState(metrics.MetricClockStateLocked, slaveIf, &nodeName)
+				}, 3*time.Minute, 10*time.Second).Should(BeNil(),
+					"clock should return to LOCKED after pod restart with replay delay")
+
+				By("Initializing port engine for interface control")
+				portEngine := ptptesthelper.PortEngine{}
+				portEngine.Initialize(fullConfig.DiscoveredClockUnderTestPod, []string{slaveIf, secondIf})
+
+				By(fmt.Sprintf("Bringing BOTH interfaces down: %s and %s", slaveIf, secondIf))
+				portEngine.TurnOffAndWaitFaulty(slaveIf, nodeName)
+				portEngine.TurnOffAndWaitFaulty(secondIf, nodeName)
+
+				DeferCleanup(func() {
+					_ = portEngine.TurnPortUp(slaveIf)
+					_ = portEngine.TurnPortUp(secondIf)
+				})
+
+				By("Narrowing offset threshold to force FREERUN after holdover expires")
+				ptpConfig, getErr := client.Client.PtpV1Interface.PtpConfigs(pkg.PtpLinuxDaemonNamespace).Get(
+					context.Background(), policyName, metav1.GetOptions{})
+				Expect(getErr).NotTo(HaveOccurred())
+				originalConfig := ptpConfig.DeepCopy()
+
+				for i := range ptpConfig.Spec.Profile {
+					if ptpConfig.Spec.Profile[i].PtpClockThreshold == nil {
+						ptpConfig.Spec.Profile[i].PtpClockThreshold = &ptpv1.PtpClockThreshold{}
+					}
+					ptpConfig.Spec.Profile[i].PtpClockThreshold.HoldOverTimeout = 5
+					ptpConfig.Spec.Profile[i].PtpClockThreshold.MaxOffsetThreshold = 1
+					ptpConfig.Spec.Profile[i].PtpClockThreshold.MinOffsetThreshold = -1
+				}
+				_, updateErr = client.Client.PtpV1Interface.PtpConfigs(pkg.PtpLinuxDaemonNamespace).Update(
+					context.Background(), ptpConfig, metav1.UpdateOptions{})
+				Expect(updateErr).NotTo(HaveOccurred())
+
+				DeferCleanup(func() {
+					current, err := client.Client.PtpV1Interface.PtpConfigs(pkg.PtpLinuxDaemonNamespace).Get(
+						context.Background(), policyName, metav1.GetOptions{})
+					if err != nil {
+						logrus.Errorf("OCPBUGS-85092 cleanup: failed to get config: %v", err)
+						return
+					}
+					for i := range current.Spec.Profile {
+						if i < len(originalConfig.Spec.Profile) {
+							current.Spec.Profile[i].PtpClockThreshold = originalConfig.Spec.Profile[i].PtpClockThreshold
+						}
+					}
+					_, err = client.Client.PtpV1Interface.PtpConfigs(pkg.PtpLinuxDaemonNamespace).Update(
+						context.Background(), current, metav1.UpdateOptions{})
+					if err != nil {
+						logrus.Errorf("OCPBUGS-85092 cleanup: failed to restore config: %v", err)
+					}
+				})
+
+				By("Waiting for holdover to expire and FREERUN state")
+				Eventually(func() error {
+					return metrics.CheckClockState(metrics.MetricClockStateFreeRun, slaveIf, &nodeName)
+				}, 2*time.Minute, 5*time.Second).Should(BeNil(),
+					"clock_state should transition to FREERUN after holdover expires with both ports FAULTY")
+
+				By("Restoring original offset thresholds (triggers CEP restart with replay delay)")
+				current, getErr := client.Client.PtpV1Interface.PtpConfigs(pkg.PtpLinuxDaemonNamespace).Get(
+					context.Background(), policyName, metav1.GetOptions{})
+				Expect(getErr).NotTo(HaveOccurred())
+				for i := range current.Spec.Profile {
+					if i < len(originalConfig.Spec.Profile) {
+						current.Spec.Profile[i].PtpClockThreshold = originalConfig.Spec.Profile[i].PtpClockThreshold
+					}
+				}
+				_, updateErr = client.Client.PtpV1Interface.PtpConfigs(pkg.PtpLinuxDaemonNamespace).Update(
+					context.Background(), current, metav1.UpdateOptions{})
+				Expect(updateErr).NotTo(HaveOccurred())
+
+				By("Bringing BOTH interfaces back up during replay delay window")
+				time.Sleep(3 * time.Second)
+				err = portEngine.TurnPortUp(slaveIf)
+				Expect(err).NotTo(HaveOccurred())
+				err = portEngine.TurnPortUp(secondIf)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Verifying clock_state returns to LOCKED despite replay delay")
+				Eventually(func() error {
+					return metrics.CheckClockState(metrics.MetricClockStateLocked, slaveIf, &nodeName)
+				}, 5*time.Minute, 10*time.Second).Should(BeNil(),
+					"OCPBUGS-85092: clock_state must return to LOCKED; "+
+						"the live gate ensures stale FAULTY replay cannot overwrite live SLAVE state")
+			})
+
 			It("Slave fails to sync when authentication mismatch occurs (negative test)", func() {
 				// Only run if authentication is enabled
 				authEnabled := os.Getenv("PTP_AUTH_ENABLED")


### PR DESCRIPTION
## Summary

- Add e2e test that verifies clock recovery with `PTP_REPLAY_DELAY_MS=10000` enabled on the daemon
- Update `Dockerfile.lptpd` and `Dockerfile.cep` to use `replay-fix` branches

## Test scenario

1. Patch DaemonSet with `PTP_REPLAY_DELAY_MS=10000` env var
2. Verify initial LOCKED state
3. Bring both follower ports down (FAULTY)
4. Narrow thresholds to force FREERUN after holdover expires
5. Restore thresholds (triggers CEP restart + 10s replay delay)
6. Bring ports back up during the replay delay window
7. Assert clock returns to LOCKED (live gate ensures stale replay cannot overwrite live SLAVE)

## Dependencies

- linuxptp-daemon live gate: https://github.com/k8snetworkplumbingwg/linuxptp-daemon/pull/new/replay-fix
- cloud-event-proxy sync TriggerLogs: https://github.com/redhat-cne/cloud-event-proxy/pull/new/replay-fix

## Test plan

- [ ] e2e test passes in netdevsim CI
- [ ] Clock returns to LOCKED despite 10s replay delay