### PR TITLE
ci: fix podman manifest push "image not known" errors

### DIFF
--- a/.github/workflows/netdevsim-ci.yml
+++ b/.github/workflows/netdevsim-ci.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   DKMS_PKG: netdevsim
   DKMS_VER: "6.9.5"

--- a/ptp-tools/Makefile
+++ b/ptp-tools/Makefile
@@ -30,7 +30,7 @@ podman-buildall: $(foreach v, $(VALUES), podman-build-$(v))
 
 podman-build-%:
 	@echo "Platform: $(PLATFORM)"
-	$(MAKE) clean-image VAR=$*;
+	$(MAKE) clean-image VAR=$*
 	$(MAKE) build-image VAR=$*
 
 podman-pushall: $(foreach v, $(VALUES), podman-push-$(v))
@@ -43,7 +43,6 @@ build-image:
 	podman build --no-cache --network host --platform $(PLATFORM) -f Dockerfile.$(VAR)  --manifest ${IMG_PREFIX}:$(VAR)  ..
 
 clean-image:
-	podman image rm ${IMG_PREFIX}:$(VAR) || true
 	podman manifest rm ${IMG_PREFIX}:$(VAR) || true
 
 podman-clean-%:


### PR DESCRIPTION
## Summary
- Remove `podman image rm` from the `clean-image` Makefile target — only the manifest needs clearing before rebuild. Removing images triggers storage GC that invalidates manifest references for other images built in parallel.
- Add `concurrency` guard to cancel previous CI runs when a new push arrives on the same PR.

## Test plan
- [ ] Verify netdevsim CI `ptp-images` job passes without "image not known" errors
- [ ] Verify pushing to a PR cancels any in-progress CI run