### PR TITLE
ci: improve netdevsim CI robustness and portability

### DIFF
--- a/scripts/install-tools.sh
+++ b/scripts/install-tools.sh
@@ -12,15 +12,27 @@ else
     exit 1
 fi
 
+# Detect OS family
+if [ -f /etc/os-release ]; then
+    . /etc/os-release
+    OS_ID="${ID:-unknown}"
+else
+    OS_ID="unknown"
+fi
+
+case "$OS_ID" in
+    ubuntu|debian|linuxmint|pop) OS_FAMILY="debian" ;;
+    fedora|rhel|centos|rocky|alma) OS_FAMILY="redhat" ;;
+    *) echo "WARNING: Unknown OS '$OS_ID', assuming redhat-like"; OS_FAMILY="redhat" ;;
+esac
+
 if [[ "${DKMS_MODE:-}" == "true" ]]; then
-    mkdir -p /etc/apt/keyrings
-    curl -fsSL "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_$(lsb_release -rs)/Release.key" \
-      | gpg --dearmor | tee /etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg > /dev/null
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/devel_kubic_libcontainers_unstable.gpg] \
-      https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_$(lsb_release -rs)/ /" \
-      | tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list > /dev/null
-    apt-get update
-    apt-get install -y podman pciutils openvswitch-switch git openssl
+    if [[ "$OS_FAMILY" == "debian" ]]; then
+        apt-get update -qq
+        apt-get install -y podman pciutils openvswitch-switch git openssl
+    else
+        dnf install -y podman pciutils openvswitch git openssl
+    fi
 
     # kubectl
     KUBECTL_VER=$(curl -fsSL https://dl.k8s.io/release/stable.txt)

--- a/scripts/run-on-vm.sh
+++ b/scripts/run-on-vm.sh
@@ -129,25 +129,6 @@ if [[ "$RUN_PHASE" == "all" || "$RUN_PHASE" == "deploy" ]]; then
 
     kubectl get pods -n openshift-ptp -o wide
 
-    SYMLINK_PID=""
-    if [[ "${DKMS_MODE}" == "true" ]]; then
-        bash -c '
-        while true; do
-          for pod in $(kubectl get pods -n openshift-ptp -l app=linuxptp-daemon \
-                       --field-selector=status.phase=Running -o name 2>/dev/null); do
-            kubectl exec -n openshift-ptp ${pod#pod/} -c linuxptp-daemon-container -- \
-              bash -c "for i in 0 1 2 3 4 5 6 7 8 9; do ln -sf nsim_ptp\$i /dev/ptp\$i 2>/dev/null; done" \
-              2>/dev/null || true
-          done
-          sleep 5
-        done
-        ' &
-        SYMLINK_PID=$!
-        echo "Symlink maintainer PID: $SYMLINK_PID"
-        cleanup_symlink() { [[ -n "$SYMLINK_PID" ]] && kill "$SYMLINK_PID" 2>/dev/null || true; }
-        trap cleanup_symlink EXIT
-    fi
-
     ./run-tests.sh --kind serial --mode "$TEST_MODES" \
       --linuxptp-daemon-image "$IMG_PREFIX:lptpd" \
       --must-gather-image "$IMG_PREFIX:ptpmg" \


### PR DESCRIPTION
## Summary

- Detect CA cert directory by path instead of relying on DKMS_MODE variable
- Detect OS family from /etc/os-release for package manager selection (apt vs dnf)
- Remove symlink maintainer loop (no longer needed after symlink removal commit)

## Test plan

- [ ] Run netdevsim CI on Ubuntu (DKMS) VM
- [ ] Run netdevsim CI on Fedora/RHEL VM