### PR TITLE
ci: remove parallelism from podman image builds

### DIFF
--- a/scripts/run-on-vm.sh
+++ b/scripts/run-on-vm.sh
@@ -43,8 +43,8 @@ if [[ "$RUN_PHASE" == "all" || "$RUN_PHASE" == "images" ]]; then
     export IMG_PREFIX="$VM_IP/test"
 
     cd ../ptp-tools
-    make -j 8 podman-cleanall
-    make -j 8 podman-buildall
+    make podman-cleanall
+    make podman-buildall
     cd -
 
     cd ..


### PR DESCRIPTION
## Summary
- Remove `-j 8` from `make podman-cleanall` and `make podman-buildall` in `scripts/run-on-vm.sh`
- Parallel podman builds are still failing; running sequentially to fix stability

## Test plan
- [ ] Verify CI image build step completes without errors

Assisted-By: Cursor