### PR TITLE
ci: add podman-build-and-pushall target to ptp-tools

### DIFF
--- a/ptp-tools/Makefile
+++ b/ptp-tools/Makefile
@@ -23,6 +23,7 @@ endif
 KUSTOMIZE ?= $(LOCALBIN)/kustomize
 
 IMG_PREFIX ?= quay.io/<your user id here>/<your image name>
+SAVE_DIR ?= /tmp/ptp-images
 
 VALUES = lptpd cep ptpop krp openvswitch prometheus ptpmg debug
 
@@ -38,6 +39,26 @@ podman-pushall: $(foreach v, $(VALUES), podman-push-$(v))
 podman-push-%:
 	podman manifest push ${IMG_PREFIX}:$* docker://${IMG_PREFIX}:$*
 
+podman-saveall: $(foreach v, $(VALUES), podman-save-$(v))
+
+podman-save-%:
+	mkdir -p $(SAVE_DIR)
+	podman save -m -o $(SAVE_DIR)/$*.tar ${IMG_PREFIX}:$*
+
+podman-build-and-pushall: $(foreach v, $(VALUES), podman-build-and-push-$(v))
+
+podman-build-and-push-%:
+	$(MAKE) podman-clean-$*
+	$(MAKE) podman-build-$*
+	$(MAKE) podman-push-$*
+
+podman-build-and-saveall: $(foreach v, $(VALUES), podman-build-and-save-$(v))
+
+podman-build-and-save-%:
+	$(MAKE) podman-clean-$*
+	$(MAKE) podman-build-$*
+	$(MAKE) podman-save-$*
+
 build-image:
 	podman manifest create ${IMG_PREFIX}:$(VAR)
 	podman build --no-cache --network host --platform $(PLATFORM) -f Dockerfile.$(VAR)  --manifest ${IMG_PREFIX}:$(VAR)  ..
@@ -49,6 +70,10 @@ podman-clean-%:
 	podman manifest rm ${IMG_PREFIX}:$* || true
 
 podman-cleanall: $(foreach v, $(VALUES), podman-clean-$(v))
+
+.PHONY: podman-buildall podman-pushall podman-saveall podman-cleanall
+.PHONY: podman-build-and-pushall podman-build-and-saveall
+.PHONY: build-image clean-image deploy-all
 
 deploy-all: 
 	./scripts/customize-env.sh ${IMG_PREFIX} ../config/manager

--- a/scripts/run-on-vm.sh
+++ b/scripts/run-on-vm.sh
@@ -34,18 +34,27 @@ PS1="${PS1:-}" source ~/.bashrc
 go mod tidy
 go mod vendor
 
-# ── Images phase (--images or default) ──────────────────────────────
-if [[ "$RUN_PHASE" == "all" || "$RUN_PHASE" == "images" ]]; then
+# ── Images phase (--images) ──────────────────────────────────────────
+if [[ "$RUN_PHASE" == "images" ]]; then
+
+    export IMG_PREFIX="$VM_IP/test"
+
+    cd ../ptp-tools
+    make -j8 podman-build-and-saveall
+    cd -
+
+    tar cf /tmp/ptp-images.tar -C /tmp/ptp-images .
+    echo "Images saved to /tmp/ptp-images.tar ($(du -h /tmp/ptp-images.tar | cut -f1))"
+
+fi
+
+# ── Images + deploy (default) ───────────────────────────────────────
+if [[ "$RUN_PHASE" == "all" ]]; then
 
     kind delete cluster --name kind-netdevsim || true
     podman rm -f switch1 || true
 
     export IMG_PREFIX="$VM_IP/test"
-
-    cd ../ptp-tools
-    make podman-cleanall
-    make podman-buildall
-    cd -
 
     cd ..
     make kustomize
@@ -54,16 +63,8 @@ if [[ "$RUN_PHASE" == "all" || "$RUN_PHASE" == "images" ]]; then
     ./create-local-registry.sh "$VM_IP"
 
     cd ../ptp-tools
-    make podman-pushall
+    make podman-build-and-pushall
     cd -
-
-    if [[ "$RUN_PHASE" == "images" ]]; then
-        TAGS=(lptpd cep ptpop krp openvswitch prometheus ptpmg debug)
-        SAVE_ARGS=()
-        for t in "${TAGS[@]}"; do SAVE_ARGS+=("$IMG_PREFIX:$t"); done
-        podman save -m -o /tmp/ptp-images.tar "${SAVE_ARGS[@]}"
-        echo "Images saved to /tmp/ptp-images.tar ($(du -h /tmp/ptp-images.tar | cut -f1))"
-    fi
 
 fi
 
@@ -72,9 +73,13 @@ if [[ "$RUN_PHASE" == "load" ]]; then
 
     export IMG_PREFIX="$VM_IP/test"
 
-    podman load -i "$TARBALL"
-
+    mkdir -p /tmp/ptp-images-load
+    tar xf "$TARBALL" -C /tmp/ptp-images-load
     TAGS=(lptpd cep ptpop krp openvswitch prometheus ptpmg debug)
+    for t in "${TAGS[@]}"; do
+        podman load -i "/tmp/ptp-images-load/$t.tar"
+    done
+
     OLD_PREFIX=$(podman images --format '{{.Repository}}:{{.Tag}}' | grep ":${TAGS[0]}$" | head -1 | sed "s/:${TAGS[0]}$//")
     if [[ "$OLD_PREFIX" != "$IMG_PREFIX" ]]; then
         for t in "${TAGS[@]}"; do


### PR DESCRIPTION
## Summary
- Add per-image build targets to `ptp-tools/Makefile` that sequentially clean, build, and save/push each image one by one
- New targets: `podman-build-and-saveall` (clean→build→save per image), `podman-build-and-pushall` (clean→build→push per image), `podman-saveall` / `podman-save-%`
- Each image is saved to its own file under `/tmp/ptp-images/<tag>.tar` (configurable via `SAVE_DIR`)
- `--images` phase no longer creates a registry or pushes — it only builds and saves
- `--load` now loads from per-image tar files in the given directory
- Default `all` phase uses `podman-build-and-pushall` for the full build→push→deploy flow
- Add missing `.PHONY` declarations

## Test plan
- [ ] `make podman-build-and-saveall` — verify each image is built and saved to `/tmp/ptp-images/<tag>.tar`
- [ ] `run-on-vm.sh --images <VM_IP>` — verify images are built and saved without registry/push
- [ ] `run-on-vm.sh --load /tmp/ptp-images <VM_IP>` — verify per-image tarballs are loaded, retagged, and pushed
- [ ] `run-on-vm.sh <VM_IP>` — verify default flow builds, pushes, and deploys end-to-end