### PR TITLE
test: fix DualNICBCHA phc2sys interface selection assertions

### DIFF
--- a/test/conformance/serial/ptp.go
+++ b/test/conformance/serial/ptp.go
@@ -1028,16 +1028,13 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 					fullConfig.DiscoveredClockUnderTestPod.Name, pkg.PtpContainerName,
 					phc2sysLogPattern, false, pkg.TimeoutIn1Minute)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(len(logMatches)).To(BeNumerically("==", 1), "Could not identify which interface phc2sys is using")
-
-				logrus.Infof("phc2sys log matching line: %v", logMatches[0][0])
-				selectedInterface = logMatches[0][1]
+				Expect(len(logMatches)).To(BeNumerically(">=", 1), "Could not identify which interface phc2sys is using")
+				logrus.Infof("phc2sys log matching line: %v", logMatches[len(logMatches)-1][0])
+				selectedInterface = logMatches[len(logMatches)-1][1]
 
 				// Save it as primary interface
 				primaryInterface := selectedInterface
 				By("Verifying the selected interface " + selectedInterface + " is a primary BC's slave interface")
-				// Check if the selected interface belongs to the primary boundary clock config
-
 				// Check if the selected interface belongs to the primary boundary clock config
 				if !slices.Contains(primaryBCSlaveInterfaces, selectedInterface) {
 					Fail(fmt.Sprintf("Selected interface %s does not belong to the primary boundary clock config. Primary interfaces: %v", selectedInterface, primaryBCSlaveInterfaces))
@@ -1060,22 +1057,22 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 				time.Sleep(5 * time.Second)
 
 				By("Verifying phc2sys switches to a different interface")
-				// Wait for phc2sys to switch to a different interface
 				var newSelectedInterface string
 				logMatches, err = pods.GetPodLogsRegexSince(fullConfig.DiscoveredClockUnderTestPod.Namespace,
 					fullConfig.DiscoveredClockUnderTestPod.Name, pkg.PtpContainerName,
 					phc2sysLogPattern, false, pkg.TimeoutIn1Minute, ifDownTime)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(len(logMatches)).To(BeNumerically("==", 1), "Could not identify which interface phc2sys is using")
-				// Get the most recent log entry
-				logrus.Infof("phc2sys log matching line: %v", logMatches[0][0])
-				newSelectedInterface = logMatches[0][1]
+				Expect(len(logMatches)).To(BeNumerically(">=", 1), "Could not identify which interface phc2sys switched to after primary interface failed")
+				Expect(ptptesthelper.CountPhc2sysTransitions(logMatches, selectedInterface)).To(Equal(1),
+					fmt.Sprintf("phc2sys should have made exactly 1 transition (primary->secondary) after primary failed; port may be flapping. Sequence: %v",
+						ptptesthelper.Phc2sysMatchedInterfaces(logMatches)))
+				logrus.Infof("phc2sys log matching line: %v", logMatches[len(logMatches)-1][0])
+				newSelectedInterface = logMatches[len(logMatches)-1][1]
 
 				// Verify that phc2sys switched to a different interface
 				Expect(newSelectedInterface).ToNot(Equal(selectedInterface), "phc2sys should have switched to a different interface")
 
 				By("Verifying the new selected interface " + newSelectedInterface + " is a secondary BC's slave interface")
-				// Check if the selected interface belongs to the primary boundary clock config
 				if !slices.Contains(secondaryBCSlaveInterfaces, newSelectedInterface) {
 					Fail(fmt.Sprintf("Selected interface %s does not belong to the secondary boundary clock config. Secondary interfaces: %v", newSelectedInterface, secondaryBCSlaveInterfaces))
 				}
@@ -1094,15 +1091,22 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 				By("Waiting 5 seconds for the primary BC's slave interface to be selected again")
 				time.Sleep(5 * time.Second)
 
-				// Check the new interfaces is the primary one
+				// Check the new interface is the primary one.
+				// On recovery, ptp4l briefly promotes the interface to MASTER before a better master
+				// is found and it transitions to SLAVE. This causes one phc2sys transition:
+				// secondary (during brief MASTER state) -> primary (on SLAVE transition).
+				// More than one transition indicates flapping (e.g. primary->secondary->primary).
 				logMatches, err = pods.GetPodLogsRegexSince(fullConfig.DiscoveredClockUnderTestPod.Namespace,
 					fullConfig.DiscoveredClockUnderTestPod.Name, pkg.PtpContainerName,
 					phc2sysLogPattern, false, pkg.TimeoutIn1Minute, ifUpTime)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(len(logMatches)).To(BeNumerically("==", 1), "Could not identify which interface phc2sys is using")
-				// Get the most recent log entry
-				logrus.Infof("phc2sys log matching line: %v", logMatches[0][0])
-				selectedInterface = logMatches[0][1]
+				Expect(len(logMatches)).To(BeNumerically(">=", 1), "Could not identify which interface phc2sys switched to after primary interface recovered")
+				Expect(ptptesthelper.CountPhc2sysTransitions(logMatches, newSelectedInterface)).To(Equal(1),
+					fmt.Sprintf("phc2sys should have made exactly 1 transition (secondary->primary) since primary recovered; "+
+						"0 means phc2sys never switched back, >1 indicates flapping. Sequence: %v",
+						ptptesthelper.Phc2sysMatchedInterfaces(logMatches)))
+				logrus.Infof("phc2sys log matching line: %v", logMatches[len(logMatches)-1][0])
+				selectedInterface = logMatches[len(logMatches)-1][1]
 
 				By("Verifying the selected interface " + selectedInterface + " is the original primary BC's slave interface " + primaryInterface)
 				if selectedInterface != primaryInterface {

--- a/test/pkg/ptptesthelper/ptptesthelper.go
+++ b/test/pkg/ptptesthelper/ptptesthelper.go
@@ -813,3 +813,31 @@ func (p *PortEngine) nmSetManaged(port string, managed bool) {
 	}
 	logrus.Infof("NM set managed=%s for %s: output: %s", val, port, stdout.String())
 }
+
+// Phc2sysMatchedInterfaces extracts the captured interface name (submatch index 1)
+// from each entry returned by GetPodLogsRegex / GetPodLogsRegexSince.
+func Phc2sysMatchedInterfaces(matches [][]string) []string {
+	ifaces := make([]string, len(matches))
+	for i, m := range matches {
+		ifaces[i] = m[1]
+	}
+	return ifaces
+}
+
+// CountPhc2sysTransitions counts interface changes in a sequence of phc2sys log
+// matches, starting from initialInterface. If the first log entry differs from
+// initialInterface that counts as a transition. Repeated selections of the same
+// interface do not increment the counter, so only genuine direction changes are
+// counted. This correctly detects flapping such as primary->secondary->primary
+// (2 transitions) while tolerating repeated same-interface log lines.
+func CountPhc2sysTransitions(matches [][]string, initialInterface string) int {
+	transitions := 0
+	prev := initialInterface
+	for _, m := range matches {
+		if m[1] != prev {
+			transitions++
+			prev = m[1]
+		}
+	}
+	return transitions
+}


### PR DESCRIPTION
When the primary interface recovers from a link-down, ptp4l briefly promotes it to MASTER before a better master is found and it transitions to SLAVE. Each state change (DISABLED->MASTER, MASTER->SLAVE) triggers a phc2sys reconfiguration, emitting a separate "selecting X as out-of-domain source clock" log line. The previous assertions expected exactly one such line in each check window, causing a spurious failure on the recovery check where two lines are produced.

Fix by deduplicating the matched interface names before asserting:
- After primary fails: expect exactly 1 unique interface (the secondary); 2+ unique interfaces indicates flapping.
- After primary recovers: expect 1-2 unique interfaces (secondary during brief MASTER state, then primary on SLAVE transition); 3+ indicates flapping. Take the last unique interface as the settled selection.
- Initial check: take the last match from full pod log history rather than asserting exactly one, making it robust to prior test runs in the same pod session.

Generated-by: Cursor