### PR TITLE
ci: skip --no-cache for podman builds on GitHub Actions

### DIFF
--- a/ptp-tools/Makefile
+++ b/ptp-tools/Makefile
@@ -25,6 +25,12 @@ KUSTOMIZE ?= $(LOCALBIN)/kustomize
 IMG_PREFIX ?= quay.io/<your user id here>/<your image name>
 SAVE_DIR ?= /tmp/ptp-images
 
+ifdef GITHUB_ACTIONS
+CACHE_FLAG ?=
+else
+CACHE_FLAG ?= --no-cache
+endif
+
 VALUES = lptpd cep ptpop krp openvswitch prometheus ptpmg debug
 
 .PHONY: print-values
@@ -65,7 +71,7 @@ podman-build-and-save-%:
 
 build-image:
 	podman manifest create ${IMG_PREFIX}:$(VAR)
-	podman build --no-cache --network host --platform $(PLATFORM) -f Dockerfile.$(VAR)  --manifest ${IMG_PREFIX}:$(VAR)  ..
+	podman build $(CACHE_FLAG) --network host --platform $(PLATFORM) -f Dockerfile.$(VAR)  --manifest ${IMG_PREFIX}:$(VAR)  ..
 
 clean-image:
 	podman manifest rm ${IMG_PREFIX}:$(VAR) || true


### PR DESCRIPTION
## Summary
- GitHub Actions runners start with an empty image store, making `--no-cache` redundant
- Adds a `CACHE_FLAG` variable to `ptp-tools/Makefile` that defaults to `--no-cache` for local builds and is automatically cleared when `GITHUB_ACTIONS` is set
- Reduces build time by allowing layer reuse between parallel builds and avoids `podman save` race conditions caused by concurrent uncached rebuilds

## Test plan
- [ ] Verify Netdevsim CI `ptp-images` job passes without `--no-cache`
- [ ] Verify local `make podman-build-and-saveall` still uses `--no-cache`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build process configuration to conditionally manage image caching behavior, improving build performance efficiency across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->