### PR TITLE
ci: bump actions to v7 and free disk space before tests

### DIFF
--- a/.github/workflows/netdevsim-ci.yml
+++ b/.github/workflows/netdevsim-ci.yml
@@ -148,7 +148,7 @@ jobs:
           echo "RAM: $(free -h | awk '/Mem:/{print $2}')"
           echo "Kernel: $(uname -r)"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install podman 5.x
         run: |
@@ -181,7 +181,7 @@ jobs:
           BUILD
 
       - name: Upload image tarball
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ptp-images
           path: /tmp/ptp-images.tar
@@ -205,7 +205,7 @@ jobs:
           echo "RAM: $(free -h | awk '/Mem:/{print $2}')"
           echo "Kernel: $(uname -r)"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install podman 5.x
         run: |
@@ -253,7 +253,7 @@ jobs:
         run: sudo cp -a "$GITHUB_WORKSPACE" /root/ptp-operator
 
       - name: Download image tarball
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: ptp-images
           path: /tmp
@@ -295,7 +295,7 @@ jobs:
 
       - name: Upload test artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ptp-artifacts-${{ matrix.mode }}
           path: /tmp/artifacts/

--- a/.github/workflows/netdevsim-ci.yml
+++ b/.github/workflows/netdevsim-ci.yml
@@ -181,7 +181,7 @@ jobs:
           BUILD
 
       - name: Upload image tarball
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: ptp-images
           path: /tmp/ptp-images.tar
@@ -253,7 +253,7 @@ jobs:
         run: sudo cp -a "$GITHUB_WORKSPACE" /root/ptp-operator
 
       - name: Download image tarball
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: ptp-images
           path: /tmp
@@ -295,7 +295,7 @@ jobs:
 
       - name: Upload test artifacts
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: ptp-artifacts-${{ matrix.mode }}
           path: /tmp/artifacts/

--- a/.github/workflows/netdevsim-ci.yml
+++ b/.github/workflows/netdevsim-ci.yml
@@ -176,6 +176,8 @@ jobs:
           VM_IP=$(hostname -I | awk '{print $1}')
           cd /root/ptp-operator/scripts
           ./run-on-vm.sh --dkms --images "${VM_IP}"
+
+          rm -rf /tmp/go-build* /root/.cache/go-build
           BUILD
 
       - name: Upload image tarball
@@ -268,6 +270,15 @@ jobs:
           cd /root/ptp-operator/scripts
           ./run-on-vm.sh --dkms --load /tmp/ptp-images.tar "${VM_IP}"
           LOAD
+
+      - name: "Free disk space before tests"
+        run: |
+          sudo bash -l <<'CLEANUP'
+          set -euo pipefail
+          rm -rf /tmp/ptp-images.tar /tmp/ptp-images-load
+          rm -rf /tmp/go-build* /var/cache/apt /root/.cache
+          df -h
+          CLEANUP
 
       - name: "Run scenario: ${{ matrix.mode }}"
         run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
JIRA Issue : [CNF-25154](https://redhat.atlassian.net/browse/CNF-25154)
## Summary

- **Disk space cleanup**: Clear Go build caches after image compilation and remove tarballs, apt cache, and Go caches before test execution to prevent `ENOSPC` ("no space left on device") during Ginkgo test compilation
- **Bump `actions/checkout`** from v4 to v7 in `netdevsim-ci.yml` and `validate.yml`
- **Bump `upload-artifact` / `download-artifact`** from v4 to v7 in `netdevsim-ci.yml` — v4 targets Node.js 20 (deprecated by GitHub); v7 natively targets Node.js 24

## Motivation

CI jobs failed intermittently due to two unrelated infrastructure issues:

1. **Disk exhaustion**: Container image builds and loads consume most runner disk space, leaving insufficient room for Ginkgo test compilation (`write ... no space left on device`)
2. **Node.js deprecation**: GitHub Actions deprecated Node.js 20 and is forcing actions to run on Node.js 24. `upload-artifact@v4` and `download-artifact@v4` still declare Node 20 as their runtime, producing deprecation warnings on every run

## Test plan

- [x] netdevsim CI workflow passes end-to-end on this PR
- [x] No Node.js 20 deprecation warnings in CI logs
- [x] `df -h` output confirms disk space reclaimed before test runs