### PR TITLE
cleanup: remove dead code, consolidate duplicates, fix deprecations

### DIFF
--- a/api/v1/ptpconfig_webhook.go
+++ b/api/v1/ptpconfig_webhook.go
@@ -43,6 +43,7 @@ const (
 	Master PtpRole = 1
 	Slave  PtpRole = 0
 )
+
 const PTP_SEC_FOLDER = "/etc/ptp-secret-mount/"
 
 // log is for logging in this package.
@@ -442,7 +443,6 @@ func (v *ptpConfigValidator) ValidateDelete(ctx context.Context, obj runtime.Obj
 }
 
 func getInterfaces(input *Ptp4lConf, mode PtpRole) (interfaces []string) {
-
 	for index, section := range input.sections {
 		sectionName := strings.TrimSpace(strings.ReplaceAll(strings.ReplaceAll(index, "[", ""), "]", ""))
 		if strings.TrimSpace(section.options["masterOnly"]) == strconv.Itoa(int(mode)) {
@@ -453,7 +453,6 @@ func getInterfaces(input *Ptp4lConf, mode PtpRole) (interfaces []string) {
 }
 
 func GetInterfaces(config PtpConfig, mode PtpRole) (interfaces []string) {
-
 	if len(config.Spec.Profile) > 1 {
 		logrus.Warnf("More than one profile detected for ptpconfig %s", config.ObjectMeta.Name)
 	}
@@ -484,3 +483,4 @@ func GetInterfaces(config PtpConfig, mode PtpRole) (interfaces []string) {
 	}
 	return finalInterfaces
 }
+

--- a/api/v1/ptpconfig_webhook.go
+++ b/api/v1/ptpconfig_webhook.go
@@ -483,4 +483,3 @@ func GetInterfaces(config PtpConfig, mode PtpRole) (interfaces []string) {
 	}
 	return finalInterfaces
 }
-

--- a/api/v1/ptpoperatorconfig_webhook.go
+++ b/api/v1/ptpoperatorconfig_webhook.go
@@ -32,10 +32,7 @@ import (
 // log is for logging in this package.
 var ptpoperatorconfiglog = logf.Log.WithName("ptpoperatorconfig-resource")
 
-var k8sclient client.Client
-
-func (r *PtpOperatorConfig) SetupWebhookWithManager(mgr ctrl.Manager, client client.Client) error {
-	k8sclient = client
+func (r *PtpOperatorConfig) SetupWebhookWithManager(mgr ctrl.Manager, _ client.Client) error {
 	return ctrl.NewWebhookManagedBy(mgr, r).
 		WithCustomValidator(&ptpOperatorConfigValidator{}).
 		Complete()

--- a/api/v2alpha1/hardwareconfig_types.go
+++ b/api/v2alpha1/hardwareconfig_types.go
@@ -590,33 +590,6 @@ func (cc *ClockChain) Validate() error {
 	return nil
 }
 
-// String methods for pretty printing
-
-func (cc *ClockChain) String() string {
-	var sb strings.Builder
-	sb.WriteString("Clock Chain Configuration:\n")
-	sb.WriteString(fmt.Sprintf("  Subsystems: %d\n", len(cc.Structure)))
-
-	if cc.CommonDefinitions != nil {
-		sb.WriteString(fmt.Sprintf("  eSync Definitions: %d\n", len(cc.CommonDefinitions.ESyncDefinitions)))
-	}
-
-	if cc.Behavior != nil {
-		sb.WriteString(fmt.Sprintf("  Sources: %d\n", len(cc.Behavior.Sources)))
-		sb.WriteString(fmt.Sprintf("  Conditions: %d\n", len(cc.Behavior.Conditions)))
-	}
-
-	return sb.String()
-}
-
-func (s *Subsystem) String() string {
-	key := s.HardwareSpecificDefinitions
-	if key == "" {
-		key = "default"
-	}
-	return fmt.Sprintf("Subsystem %s (Plugin: %s, Network Interface: %s, Ethernet Ports: %d)",
-		s.Name, key, s.DPLL.NetworkInterface, len(s.Ethernet))
-}
 
 // Plugin system types and functions
 

--- a/api/v2alpha1/hardwareconfig_types.go
+++ b/api/v2alpha1/hardwareconfig_types.go
@@ -590,6 +590,34 @@ func (cc *ClockChain) Validate() error {
 	return nil
 }
 
+// String methods for pretty printing
+
+func (cc *ClockChain) String() string {
+	var sb strings.Builder
+	sb.WriteString("Clock Chain Configuration:\n")
+	sb.WriteString(fmt.Sprintf("  Subsystems: %d\n", len(cc.Structure)))
+
+	if cc.CommonDefinitions != nil {
+		sb.WriteString(fmt.Sprintf("  eSync Definitions: %d\n", len(cc.CommonDefinitions.ESyncDefinitions)))
+	}
+
+	if cc.Behavior != nil {
+		sb.WriteString(fmt.Sprintf("  Sources: %d\n", len(cc.Behavior.Sources)))
+		sb.WriteString(fmt.Sprintf("  Conditions: %d\n", len(cc.Behavior.Conditions)))
+	}
+
+	return sb.String()
+}
+
+func (s *Subsystem) String() string {
+	key := s.HardwareSpecificDefinitions
+	if key == "" {
+		key = "default"
+	}
+	return fmt.Sprintf("Subsystem %s (Plugin: %s, Network Interface: %s, Ethernet Ports: %d)",
+		s.Name, key, s.DPLL.NetworkInterface, len(s.Ethernet))
+}
+
 // Plugin system types and functions
 
 // PluginInfo contains metadata about a hardware plugin

--- a/api/v2alpha1/hardwareconfig_types.go
+++ b/api/v2alpha1/hardwareconfig_types.go
@@ -590,7 +590,6 @@ func (cc *ClockChain) Validate() error {
 	return nil
 }
 
-
 // Plugin system types and functions
 
 // PluginInfo contains metadata about a hardware plugin

--- a/api/v2alpha1/hardwareconfig_validation_test.go
+++ b/api/v2alpha1/hardwareconfig_validation_test.go
@@ -249,4 +249,3 @@ func TestClockChainValidation_EdgeCases(t *testing.T) {
 		})
 	}
 }
-

--- a/api/v2alpha1/hardwareconfig_validation_test.go
+++ b/api/v2alpha1/hardwareconfig_validation_test.go
@@ -3,6 +3,7 @@ package v2alpha1
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -237,7 +238,7 @@ func TestClockChainValidation_EdgeCases(t *testing.T) {
 			if tt.wantErr {
 				if err == nil {
 					t.Errorf("Expected error containing %q, got nil", tt.errMsg)
-				} else if tt.errMsg != "" && !contains(err.Error(), tt.errMsg) {
+				} else if tt.errMsg != "" && !strings.Contains(err.Error(), tt.errMsg) {
 					t.Errorf("Expected error containing %q, got %q", tt.errMsg, err.Error())
 				}
 			} else {
@@ -249,16 +250,3 @@ func TestClockChainValidation_EdgeCases(t *testing.T) {
 	}
 }
 
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
-		(len(s) > 0 && len(substr) > 0 && findSubstring(s, substr)))
-}
-
-func findSubstring(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
-}

--- a/controllers/ptpconfig_controller.go
+++ b/controllers/ptpconfig_controller.go
@@ -236,7 +236,6 @@ func getRecommendProfilesNamesForConfig(ptpConfig *ptpv1.PtpConfig, node corev1.
 	return profilesNames
 }
 
-
 func (r *PtpConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&ptpv1.PtpConfig{}, builder.WithPredicates(predicate.NewPredicateFuncs(func(object client.Object) bool {

--- a/controllers/ptpconfig_controller.go
+++ b/controllers/ptpconfig_controller.go
@@ -204,7 +204,8 @@ func getRecommendProfilesNamesForConfig(ptpConfig *ptpv1.PtpConfig, node corev1.
 	// Find matching profiles
 	profilesNames := make(map[string]interface{})
 	foundPolicy := false
-	priority := int64(-1)
+	const nilPriority int64 = -1
+	priority := nilPriority
 
 	// Loop through recommendations from high priority (0) to low (*)
 	for _, r := range allRecommend {
@@ -218,15 +219,20 @@ func getRecommendProfilesNamesForConfig(ptpConfig *ptpv1.PtpConfig, node corev1.
 			continue
 		}
 
+		currentPriority := nilPriority
+		if r.Priority != nil {
+			currentPriority = *r.Priority
+		}
+
 		// Check if the policy matches the node
 		switch {
 		case !nodeMatches(&node, r.Match):
 			continue
 		case !foundPolicy:
 			profilesNames[*r.Profile] = struct{}{}
-			priority = *r.Priority
+			priority = currentPriority
 			foundPolicy = true
-		case *r.Priority == priority:
+		case currentPriority == priority:
 			profilesNames[*r.Profile] = struct{}{}
 		default:
 

--- a/controllers/ptpconfig_controller.go
+++ b/controllers/ptpconfig_controller.go
@@ -220,7 +220,7 @@ func getRecommendProfilesNamesForConfig(ptpConfig *ptpv1.PtpConfig, node corev1.
 
 		// Check if the policy matches the node
 		switch {
-		case !ptpNodeMatches(&node, r.Match):
+		case !nodeMatches(&node, r.Match):
 			continue
 		case !foundPolicy:
 			profilesNames[*r.Profile] = struct{}{}
@@ -236,26 +236,6 @@ func getRecommendProfilesNamesForConfig(ptpConfig *ptpv1.PtpConfig, node corev1.
 	return profilesNames
 }
 
-// ptpNodeMatches checks if a node matches the given match rules for PTP config
-func ptpNodeMatches(node *corev1.Node, matchRuleList []ptpv1.MatchRule) bool {
-	// Loop over Match list
-	for _, m := range matchRuleList {
-		// NodeName has higher priority than nodeLabel
-		// Return immediately if nodeName matches
-		if m.NodeName != nil && *m.NodeName == node.Name {
-			return true
-		}
-
-		// Return immediately when label matches
-		for k := range node.Labels {
-			if m.NodeLabel != nil && *m.NodeLabel == k {
-				return true
-			}
-		}
-	}
-
-	return false
-}
 
 func (r *PtpConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).

--- a/controllers/ptpconfig_controller_test.go
+++ b/controllers/ptpconfig_controller_test.go
@@ -263,6 +263,26 @@ func TestGetRecommendProfilesNamesForConfig_SamePriority(t *testing.T) {
 	assert.Contains(t, result, "profile-b")
 }
 
+func TestGetRecommendProfilesNamesForConfig_NilPriority(t *testing.T) {
+	label := "ptp/test"
+	cfg := ptpv1.PtpConfig{
+		Spec: ptpv1.PtpConfigSpec{
+			Recommend: []ptpv1.PtpRecommend{
+				{Profile: strPtr("nil-pri"), Priority: nil, Match: []ptpv1.MatchRule{{NodeLabel: &label}}},
+			},
+		},
+	}
+	node := corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name: "worker-1", Labels: map[string]string{"ptp/test": ""},
+	}}
+
+	assert.NotPanics(t, func() {
+		result := getRecommendProfilesNamesForConfig(&cfg, node)
+		assert.Len(t, result, 1)
+		assert.Contains(t, result, "nil-pri")
+	})
+}
+
 func TestGetRecommendProfilesNamesForConfig_DifferentPriority(t *testing.T) {
 	label := "ptp/test"
 	cfg := ptpv1.PtpConfig{

--- a/controllers/ptpconfig_controller_test.go
+++ b/controllers/ptpconfig_controller_test.go
@@ -1,0 +1,348 @@
+package controllers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	ptpv1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v1"
+)
+
+func TestNodeMatches_ByName(t *testing.T) {
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "worker-1"}}
+	name := "worker-1"
+	rules := []ptpv1.MatchRule{{NodeName: &name}}
+	assert.True(t, nodeMatches(node, rules))
+}
+
+func TestNodeMatches_ByLabel(t *testing.T) {
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name:   "worker-2",
+		Labels: map[string]string{"ptp/grandmaster": ""},
+	}}
+	label := "ptp/grandmaster"
+	rules := []ptpv1.MatchRule{{NodeLabel: &label}}
+	assert.True(t, nodeMatches(node, rules))
+}
+
+func TestNodeMatches_NoMatch(t *testing.T) {
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name:   "worker-3",
+		Labels: map[string]string{"role": "compute"},
+	}}
+	name := "other-node"
+	rules := []ptpv1.MatchRule{{NodeName: &name}}
+	assert.False(t, nodeMatches(node, rules))
+}
+
+func TestNodeMatches_EmptyRules(t *testing.T) {
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "worker-1"}}
+	assert.False(t, nodeMatches(node, nil))
+	assert.False(t, nodeMatches(node, []ptpv1.MatchRule{}))
+}
+
+func TestNodeMatches_NilPointers(t *testing.T) {
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name:   "worker-1",
+		Labels: map[string]string{"ptp/test": ""},
+	}}
+	rules := []ptpv1.MatchRule{{NodeName: nil, NodeLabel: nil}}
+	assert.False(t, nodeMatches(node, rules))
+}
+
+func TestNodeMatches_NameTakesPriority(t *testing.T) {
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name:   "target-node",
+		Labels: map[string]string{"other-label": ""},
+	}}
+	name := "target-node"
+	label := "nonexistent-label"
+	rules := []ptpv1.MatchRule{{NodeName: &name, NodeLabel: &label}}
+	assert.True(t, nodeMatches(node, rules))
+}
+
+func TestReturnMapKeys(t *testing.T) {
+	m := map[string]interface{}{
+		"alpha": struct{}{},
+		"beta":  struct{}{},
+		"gamma": struct{}{},
+	}
+	keys := returnMapKeys(m)
+	assert.Len(t, keys, 3)
+	assert.ElementsMatch(t, []string{"alpha", "beta", "gamma"}, keys)
+}
+
+func TestReturnMapKeys_Empty(t *testing.T) {
+	m := map[string]interface{}{}
+	keys := returnMapKeys(m)
+	assert.Empty(t, keys)
+}
+
+func makeDaemonSet() *appsv1.DaemonSet {
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "linuxptp-daemon", Namespace: "openshift-ptp"},
+		Spec: appsv1.DaemonSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "linuxptp-daemon-container",
+							VolumeMounts: []corev1.VolumeMount{
+								{Name: "config-volume", MountPath: "/etc/linuxptp"},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{Name: "config-volume", VolumeSource: corev1.VolumeSource{
+							ConfigMap: &corev1.ConfigMapVolumeSource{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "ptp-configmap"},
+							},
+						}},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestInjectPtpSecurityVolume(t *testing.T) {
+	ds := makeDaemonSet()
+	injectPtpSecurityVolume(ds, "my-secret")
+
+	assert.Len(t, ds.Spec.Template.Spec.Volumes, 2)
+	vol := ds.Spec.Template.Spec.Volumes[1]
+	assert.Equal(t, "my-secret-tlv-auth", vol.Name)
+	assert.Equal(t, "my-secret", vol.VolumeSource.Secret.SecretName)
+
+	mounts := ds.Spec.Template.Spec.Containers[0].VolumeMounts
+	assert.Len(t, mounts, 2)
+	assert.Equal(t, "my-secret-tlv-auth", mounts[1].Name)
+	assert.Equal(t, "/etc/ptp-secret-mount/my-secret", mounts[1].MountPath)
+	assert.True(t, mounts[1].ReadOnly)
+}
+
+func TestInjectPtpSecurityVolume_NoMatchingContainer(t *testing.T) {
+	ds := makeDaemonSet()
+	ds.Spec.Template.Spec.Containers[0].Name = "other-container"
+	injectPtpSecurityVolume(ds, "my-secret")
+
+	assert.Len(t, ds.Spec.Template.Spec.Volumes, 2, "volume should still be added")
+	assert.Len(t, ds.Spec.Template.Spec.Containers[0].VolumeMounts, 1,
+		"mount should not be added to non-matching container")
+}
+
+func TestRemoveSecurityVolumesFromDaemonSet(t *testing.T) {
+	ds := makeDaemonSet()
+	injectPtpSecurityVolume(ds, "secret-a")
+	injectPtpSecurityVolume(ds, "secret-b")
+
+	assert.Len(t, ds.Spec.Template.Spec.Volumes, 3)
+	assert.Len(t, ds.Spec.Template.Spec.Containers[0].VolumeMounts, 3)
+
+	removeSecurityVolumesFromDaemonSet(ds)
+
+	assert.Len(t, ds.Spec.Template.Spec.Volumes, 1)
+	assert.Equal(t, "config-volume", ds.Spec.Template.Spec.Volumes[0].Name)
+
+	assert.Len(t, ds.Spec.Template.Spec.Containers[0].VolumeMounts, 1)
+	assert.Equal(t, "config-volume", ds.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name)
+}
+
+func TestRemoveSecurityVolumesFromDaemonSet_NonePresent(t *testing.T) {
+	ds := makeDaemonSet()
+	removeSecurityVolumesFromDaemonSet(ds)
+
+	assert.Len(t, ds.Spec.Template.Spec.Volumes, 1)
+	assert.Len(t, ds.Spec.Template.Spec.Containers[0].VolumeMounts, 1)
+}
+
+func TestRemoveSecurityVolumesFromDaemonSet_NoMatchingContainer(t *testing.T) {
+	ds := makeDaemonSet()
+	ds.Spec.Template.Spec.Containers[0].Name = "other-container"
+	injectPtpSecurityVolume(ds, "secret-a")
+
+	removeSecurityVolumesFromDaemonSet(ds)
+
+	assert.Len(t, ds.Spec.Template.Spec.Volumes, 1)
+	assert.Len(t, ds.Spec.Template.Spec.Containers[0].VolumeMounts, 1,
+		"non-matching container mounts should remain untouched")
+}
+
+func TestEventTransportHostAvailabilityCheck(t *testing.T) {
+	r := &PtpOperatorConfigReconciler{}
+
+	host, err := r.EventTransportHostAvailabilityCheck("")
+	assert.NoError(t, err)
+	assert.Equal(t, DefaultTransportHost, host, "empty host should return default")
+
+	host, err = r.EventTransportHostAvailabilityCheck("http://my-host:9043")
+	assert.NoError(t, err)
+	assert.Equal(t, "http://my-host:9043", host, "valid host should be returned as-is")
+
+	host, err = r.EventTransportHostAvailabilityCheck(DefaultTransportHost)
+	assert.NoError(t, err)
+	assert.Equal(t, DefaultTransportHost, host)
+}
+
+func TestGetRecommendProfilesNamesForConfig_NilRecommend(t *testing.T) {
+	cfg := ptpv1.PtpConfig{
+		Spec: ptpv1.PtpConfigSpec{Recommend: nil},
+	}
+	node := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "worker-1"}}
+	result := getRecommendProfilesNamesForConfig(&cfg, node)
+	assert.Empty(t, result)
+}
+
+func TestGetRecommendProfilesNamesForConfig_SkipsNilProfile(t *testing.T) {
+	label := "ptp/test"
+	cfg := ptpv1.PtpConfig{
+		Spec: ptpv1.PtpConfigSpec{
+			Recommend: []ptpv1.PtpRecommend{
+				{Profile: nil, Priority: int64Ptr(5), Match: []ptpv1.MatchRule{{NodeLabel: &label}}},
+			},
+		},
+	}
+	node := corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name: "worker-1", Labels: map[string]string{"ptp/test": ""},
+	}}
+	result := getRecommendProfilesNamesForConfig(&cfg, node)
+	assert.Empty(t, result)
+}
+
+func TestGetRecommendProfilesNamesForConfig_SkipsEmptyMatch(t *testing.T) {
+	cfg := ptpv1.PtpConfig{
+		Spec: ptpv1.PtpConfigSpec{
+			Recommend: []ptpv1.PtpRecommend{
+				{Profile: strPtr("my-profile"), Priority: int64Ptr(5), Match: []ptpv1.MatchRule{}},
+			},
+		},
+	}
+	node := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "worker-1"}}
+	result := getRecommendProfilesNamesForConfig(&cfg, node)
+	assert.Empty(t, result)
+}
+
+func TestGetRecommendProfilesNamesForConfig_MatchesByLabel(t *testing.T) {
+	label := "ptp/grandmaster"
+	cfg := ptpv1.PtpConfig{
+		Spec: ptpv1.PtpConfigSpec{
+			Recommend: []ptpv1.PtpRecommend{
+				{Profile: strPtr("gm-profile"), Priority: int64Ptr(5),
+					Match: []ptpv1.MatchRule{{NodeLabel: &label}}},
+			},
+		},
+	}
+	node := corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name: "worker-1", Labels: map[string]string{"ptp/grandmaster": ""},
+	}}
+	result := getRecommendProfilesNamesForConfig(&cfg, node)
+	assert.Contains(t, result, "gm-profile")
+}
+
+func TestGetRecommendProfilesNamesForConfig_SamePriority(t *testing.T) {
+	label := "ptp/ha"
+	cfg := ptpv1.PtpConfig{
+		Spec: ptpv1.PtpConfigSpec{
+			Recommend: []ptpv1.PtpRecommend{
+				{Profile: strPtr("profile-a"), Priority: int64Ptr(5),
+					Match: []ptpv1.MatchRule{{NodeLabel: &label}}},
+				{Profile: strPtr("profile-b"), Priority: int64Ptr(5),
+					Match: []ptpv1.MatchRule{{NodeLabel: &label}}},
+			},
+		},
+	}
+	node := corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name: "worker-1", Labels: map[string]string{"ptp/ha": ""},
+	}}
+	result := getRecommendProfilesNamesForConfig(&cfg, node)
+	assert.Len(t, result, 2)
+	assert.Contains(t, result, "profile-a")
+	assert.Contains(t, result, "profile-b")
+}
+
+func TestGetRecommendProfilesNamesForConfig_DifferentPriority(t *testing.T) {
+	label := "ptp/test"
+	cfg := ptpv1.PtpConfig{
+		Spec: ptpv1.PtpConfigSpec{
+			Recommend: []ptpv1.PtpRecommend{
+				{Profile: strPtr("high-pri"), Priority: int64Ptr(1),
+					Match: []ptpv1.MatchRule{{NodeLabel: &label}}},
+				{Profile: strPtr("low-pri"), Priority: int64Ptr(10),
+					Match: []ptpv1.MatchRule{{NodeLabel: &label}}},
+			},
+		},
+	}
+	node := corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name: "worker-1", Labels: map[string]string{"ptp/test": ""},
+	}}
+	result := getRecommendProfilesNamesForConfig(&cfg, node)
+	assert.Len(t, result, 1)
+	assert.Contains(t, result, "high-pri")
+}
+
+func TestGetRecommendNodePtpProfilesForConfig_ReturnsProfiles(t *testing.T) {
+	label := "ptp/test"
+	cfg := ptpv1.PtpConfig{
+		Spec: ptpv1.PtpConfigSpec{
+			Profile: []ptpv1.PtpProfile{
+				{Name: strPtr("my-profile")},
+				{Name: strPtr("other-profile")},
+			},
+			Recommend: []ptpv1.PtpRecommend{
+				{Profile: strPtr("my-profile"), Priority: int64Ptr(5),
+					Match: []ptpv1.MatchRule{{NodeLabel: &label}}},
+			},
+		},
+	}
+	node := corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name: "worker-1", Labels: map[string]string{"ptp/test": ""},
+	}}
+
+	profiles, err := getRecommendNodePtpProfilesForConfig(&cfg, node)
+	assert.NoError(t, err)
+	assert.Len(t, profiles, 1)
+	assert.Equal(t, "my-profile", *profiles[0].Name)
+}
+
+func TestGetRecommendNodePtpProfilesForConfig_NoMatch(t *testing.T) {
+	label := "ptp/other"
+	cfg := ptpv1.PtpConfig{
+		Spec: ptpv1.PtpConfigSpec{
+			Profile: []ptpv1.PtpProfile{{Name: strPtr("my-profile")}},
+			Recommend: []ptpv1.PtpRecommend{
+				{Profile: strPtr("my-profile"), Priority: int64Ptr(5),
+					Match: []ptpv1.MatchRule{{NodeLabel: &label}}},
+			},
+		},
+	}
+	node := corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name: "worker-1", Labels: map[string]string{"ptp/test": ""},
+	}}
+
+	profiles, err := getRecommendNodePtpProfilesForConfig(&cfg, node)
+	assert.NoError(t, err)
+	assert.Empty(t, profiles)
+}
+
+func TestGetRecommendNodePtpProfilesForConfig_NilProfileSpec(t *testing.T) {
+	label := "ptp/test"
+	cfg := ptpv1.PtpConfig{
+		Spec: ptpv1.PtpConfigSpec{
+			Profile: nil,
+			Recommend: []ptpv1.PtpRecommend{
+				{Profile: strPtr("my-profile"), Priority: int64Ptr(5),
+					Match: []ptpv1.MatchRule{{NodeLabel: &label}}},
+			},
+		},
+	}
+	node := corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name: "worker-1", Labels: map[string]string{"ptp/test": ""},
+	}}
+
+	profiles, err := getRecommendNodePtpProfilesForConfig(&cfg, node)
+	assert.NoError(t, err)
+	assert.Empty(t, profiles)
+}

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -19,7 +19,7 @@ if [ -z ${VERSION_OVERRIDE+a} ]; then
 	VERSION_OVERRIDE=$(git describe --abbrev=8 --dirty --always)
 fi
 
-GLDFLAGS+="-X ${REPO}/pkg/version.Raw=${VERSION_OVERRIDE}"
+GLDFLAGS+="-X ${REPO}/version.Version=${VERSION_OVERRIDE}"
 
 export BIN_PATH=build/_output/bin/
 export BIN_NAME=ptp-operator

--- a/main.go
+++ b/main.go
@@ -317,7 +317,6 @@ func createDefaultOperatorConfig(ctx context.Context, cfg *rest.Config) error {
 	return nil
 }
 
-
 // fetchTLSConfig creates a temporary client to read the APIServer TLS profile
 // and adherence policy at startup, before the manager's cache is available.
 func fetchTLSConfig(cfg *rest.Config) (configv1.TLSProfileSpec, configv1.TLSAdherencePolicy, error) {

--- a/main.go
+++ b/main.go
@@ -34,7 +34,6 @@ import (
 	"github.com/k8snetworkplumbingwg/ptp-operator/pkg/names"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -318,16 +317,6 @@ func createDefaultOperatorConfig(ctx context.Context, cfg *rest.Config) error {
 	return nil
 }
 
-func setupChecks(mgr ctrl.Manager, checker healthz.Checker) {
-	if err := mgr.AddReadyzCheck("webhook", checker); err != nil {
-		setupLog.Error(err, "unable to create ready check")
-		os.Exit(1)
-	}
-	if err := mgr.AddHealthzCheck("webhook", checker); err != nil {
-		setupLog.Error(err, "unable to create health check")
-		os.Exit(1)
-	}
-}
 
 // fetchTLSConfig creates a temporary client to read the APIServer TLS profile
 // and adherence policy at startup, before the manager's cache is available.

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -3,7 +3,6 @@ package render
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -71,7 +70,7 @@ func RenderTemplate(path string, d *RenderData) ([]*unstructured.Unstructured, e
 	tmpl.Funcs(template.FuncMap{"getOr": getOr, "isSet": isSet})
 	tmpl.Funcs(sprig.TxtFuncMap())
 
-	source, err := ioutil.ReadFile(path)
+	source, err := os.ReadFile(path)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to read manifest %s", path)
 	}

--- a/test/conformance/parallel/ptp.go
+++ b/test/conformance/parallel/ptp.go
@@ -27,7 +27,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-
 var DesiredMode = testconfig.GetDesiredConfig(true).PtpModeDesired
 
 // this full config is one per thread

--- a/test/conformance/parallel/ptp.go
+++ b/test/conformance/parallel/ptp.go
@@ -27,10 +27,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const (
-	clockSyncStateLocalForwardPort = 8901
-	clockSyncStateLocalHttpPort    = 8902
-)
 
 var DesiredMode = testconfig.GetDesiredConfig(true).PtpModeDesired
 

--- a/test/conformance/serial/prometheus.go
+++ b/test/conformance/serial/prometheus.go
@@ -28,14 +28,6 @@ const openshiftPtpMetricPrefix = "openshift_ptp_"
 //	     "metric" : {
 //	       "pod" : "mm-pod1",
 //	}}]}}
-type queryOutput struct {
-	Data data
-}
-
-type data struct {
-	Result []result
-}
-
 type result struct {
 	Metric metric
 }

--- a/test/conformance/serial/ptp.go
+++ b/test/conformance/serial/ptp.go
@@ -2822,9 +2822,6 @@ func checkStabilityOfWPCGMUsingMetrics(fullConfig testconfig.TestConfig) {
 	checkPTPNMEAStatus(fullConfig, "1")
 }
 
-
-
-
 func testCaseEnabled(testCase TestCase) bool {
 
 	enabledTests, isSet := os.LookupEnv("ENABLE_TEST_CASE")
@@ -3487,7 +3484,6 @@ func stopMonitor(term chan bool) {
 	default: // avoid blocking if it’s already been stopped
 	}
 }
-
 
 // waitForStateAndCC waits until the given state and clock class value (int) are both observed
 func waitForStateAndCC(subs event.Subscriptions, state ptpEvent.SyncState, cc int, timeout time.Duration, warnOnMissingCC bool) {

--- a/test/conformance/serial/ptp.go
+++ b/test/conformance/serial/ptp.go
@@ -54,9 +54,6 @@ const (
 
 const (
 	DPLL_LOCKED_HO_ACQ = 3
-	DPLL_HOLDOVER      = 4
-	DPLL_FREERUN       = 1
-	DPLL_LOCKED        = 2
 )
 const (
 	ClockClassFreerun = 248
@@ -2825,165 +2822,8 @@ func checkStabilityOfWPCGMUsingMetrics(fullConfig testconfig.TestConfig) {
 	checkPTPNMEAStatus(fullConfig, "1")
 }
 
-func verifyEventsV1(expectedState string) {
-	//TODO
-	switch expectedState {
-	case "LOCKED":
-		/*
-			7.2.3.1 Synchronization State (implemented)
-			event.sync.sync-status.synchronization-state-change
-			/sync/sync-status/sync-state LOCKED
-
-			7.2.3.3 PTP Synchronization State (implemented)
-			event.sync.ptp-status.ptp-state-change
-			/sync/ptp-status/lock-state LOCKED
-
-			7.2.3.6 GNSS-Sync-State (implemented)
-			event.sync.gnss-status.gnss-state-change
-			/sync/gnss-status/gnss-sync-status LOCKED
-
-			7.2.3.8 OS Clock Sync-State (implemented)
-			event.sync.sync-status.os-clock-sync-state-change
-			/sync/sync-status/os-clock-sync-state
 
 
-			7.2.3.10 PTP Clock Class Change (implemented)
-			event.sync.ptp-status.ptp-clock-class-change
-			/sync/ptp-status/clock-class LOCKED
-		*/
-	case "HOLDOVER":
-		/*
-			7.2.3.1 Synchronization State (implemented)
-			event.sync.sync-status.synchronization-state-change
-			/sync/sync-status/sync-state HOLDOVER
-
-			7.2.3.3 PTP Synchronization State (implemented)
-			event.sync.ptp-status.ptp-state-change
-			/sync/ptp-status/lock-state HOLDOVER
-
-			7.2.3.6 GNSS-Sync-State (implemented)
-			event.sync.gnss-status.gnss-state-change
-			/sync/gnss-status/gnss-sync-status HOLDOVER
-
-			7.2.3.8 OS Clock Sync-State (implemented)
-			event.sync.sync-status.os-clock-sync-state-change
-			/sync/sync-status/os-clock-sync-state
-
-
-			7.2.3.10 PTP Clock Class Change (implemented)
-			event.sync.ptp-status.ptp-clock-class-change
-			/sync/ptp-status/clock-class HOLDOVER
-
-		*/
-
-	case "FREERUN":
-		/*
-			7.2.3.1 Synchronization State (implemented)
-			event.sync.sync-status.synchronization-state-change
-			/sync/sync-status/sync-state FREERUN
-
-			7.2.3.3 PTP Synchronization State (implemented)
-			event.sync.ptp-status.ptp-state-change
-			/sync/ptp-status/lock-state FREERUN
-
-			7.2.3.6 GNSS-Sync-State (implemented)
-			event.sync.gnss-status.gnss-state-change
-			/sync/gnss-status/gnss-sync-status FREERUN
-
-			7.2.3.8 OS Clock Sync-State (implemented)
-			event.sync.sync-status.os-clock-sync-state-change
-			/sync/sync-status/os-clock-sync-state
-
-
-			7.2.3.10 PTP Clock Class Change (implemented)
-			event.sync.ptp-status.ptp-clock-class-change
-			/sync/ptp-status/clock-class FREERUN
-
-		*/
-
-	}
-
-}
-
-func verifyEventsV2(expectedState string) {
-	//TODO
-	switch expectedState {
-	case "LOCKED":
-		/*
-			7.2.3.1 Synchronization State (implemented)
-			event.sync.sync-status.synchronization-state-change
-			/sync/sync-status/sync-state LOCKED
-
-			7.2.3.3 PTP Synchronization State (implemented)
-			event.sync.ptp-status.ptp-state-change
-			/sync/ptp-status/lock-state LOCKED
-
-			7.2.3.6 GNSS-Sync-State (implemented)
-			event.sync.gnss-status.gnss-state-change
-			/sync/gnss-status/gnss-sync-status LOCKED
-
-			7.2.3.8 OS Clock Sync-State (implemented)
-			event.sync.sync-status.os-clock-sync-state-change
-			/sync/sync-status/os-clock-sync-state
-
-
-			7.2.3.10 PTP Clock Class Change (implemented)
-			event.sync.ptp-status.ptp-clock-class-change
-			/sync/ptp-status/clock-class LOCKED
-		*/
-	case "HOLDOVER":
-		/*
-			7.2.3.1 Synchronization State (implemented)
-			event.sync.sync-status.synchronization-state-change
-			/sync/sync-status/sync-state HOLDOVER
-
-			7.2.3.3 PTP Synchronization State (implemented)
-			event.sync.ptp-status.ptp-state-change
-			/sync/ptp-status/lock-state HOLDOVER
-
-			7.2.3.6 GNSS-Sync-State (implemented)
-			event.sync.gnss-status.gnss-state-change
-			/sync/gnss-status/gnss-sync-status HOLDOVER
-
-			7.2.3.8 OS Clock Sync-State (implemented)
-			event.sync.sync-status.os-clock-sync-state-change
-			/sync/sync-status/os-clock-sync-state
-
-
-			7.2.3.10 PTP Clock Class Change (implemented)
-			event.sync.ptp-status.ptp-clock-class-change
-			/sync/ptp-status/clock-class HOLDOVER
-
-		*/
-
-	case "FREERUN":
-		/*
-			7.2.3.1 Synchronization State (implemented)
-			event.sync.sync-status.synchronization-state-change
-			/sync/sync-status/sync-state FREERUN
-
-			7.2.3.3 PTP Synchronization State (implemented)
-			event.sync.ptp-status.ptp-state-change
-			/sync/ptp-status/lock-state FREERUN
-
-			7.2.3.6 GNSS-Sync-State (implemented)
-			event.sync.gnss-status.gnss-state-change
-			/sync/gnss-status/gnss-sync-status FREERUN
-
-			7.2.3.8 OS Clock Sync-State (implemented)
-			event.sync.sync-status.os-clock-sync-state-change
-			/sync/sync-status/os-clock-sync-state
-
-
-			7.2.3.10 PTP Clock Class Change (implemented)
-			event.sync.ptp-status.ptp-clock-class-change
-			/sync/ptp-status/clock-class FREERUN
-
-		*/
-
-	}
-
-}
 
 func testCaseEnabled(testCase TestCase) bool {
 
@@ -3648,24 +3488,6 @@ func stopMonitor(term chan bool) {
 	}
 }
 
-// waitForPtpStateEvent waits until a PTP state event with given state appears on the channel
-func waitForPtpStateEvent(events <-chan exports.StoredEvent, expected ptpEvent.SyncState, timeout time.Duration) {
-	timer := time.NewTimer(timeout)
-	defer timer.Stop()
-	for {
-		select {
-		case <-timer.C:
-			Fail(fmt.Sprintf("Timed out waiting for PTP state event %s", expected))
-			return
-		case ev := <-events:
-			if res, ok := processEvent(ptpEvent.PtpStateChange, ev); ok {
-				if state, ok2 := res.Values["notification"].(string); ok2 && state == string(expected) {
-					return
-				}
-			}
-		}
-	}
-}
 
 // waitForStateAndCC waits until the given state and clock class value (int) are both observed
 func waitForStateAndCC(subs event.Subscriptions, state ptpEvent.SyncState, cc int, timeout time.Duration, warnOnMissingCC bool) {

--- a/test/pkg/consts.go
+++ b/test/pkg/consts.go
@@ -3,14 +3,9 @@ package pkg
 import "time"
 
 const (
-	// NamespaceTesting contains the name of the testing namespace
-
 	ETHTOOL_HARDWARE_RECEIVE_CAP   = "hardware-receive"
 	ETHTOOL_HARDWARE_TRANSMIT_CAP  = "hardware-transmit"
 	ETHTOOL_HARDWARE_RAW_CLOCK_CAP = "hardware-raw-clock"
-	ETHTOOL_RX_HARDWARE_FLAG       = "(SOF_TIMESTAMPING_RX_HARDWARE)"
-	ETHTOOL_TX_HARDWARE_FLAG       = "(SOF_TIMESTAMPING_TX_HARDWARE)"
-	ETHTOOL_RAW_HARDWARE_FLAG      = "(SOF_TIMESTAMPING_RAW_HARDWARE)"
 	PtpLinuxDaemonNamespace        = "openshift-ptp"
 	PtpLinuxDaemonPodsLabel        = "app=linuxptp-daemon"
 	PtpOperatorDeploymentName      = "ptp-operator"

--- a/test/pkg/event/event.go
+++ b/test/pkg/event/event.go
@@ -426,7 +426,6 @@ func DeleteConsumerNamespace() error {
 	return nil
 }
 
-
 const DeleteBackground = "deleteBackground"
 const DeleteForeground = "deleteForeground"
 

--- a/test/pkg/event/event.go
+++ b/test/pkg/event/event.go
@@ -426,15 +426,6 @@ func DeleteConsumerNamespace() error {
 	return nil
 }
 
-// delete Service
-func DeleteService(namespace, name string) {
-	// Delete service
-	foregroundDelete := v1.DeletePropagationForeground
-	err := client.Client.CoreV1().Services(namespace).Delete(context.TODO(), name, v1.DeleteOptions{PropagationPolicy: &foregroundDelete})
-	if err != nil {
-		logrus.Warnf("error deleting ns=%s service=%s err: %v", namespace, name, err)
-	}
-}
 
 const DeleteBackground = "deleteBackground"
 const DeleteForeground = "deleteForeground"

--- a/test/pkg/namespaces/namespaces.go
+++ b/test/pkg/namespaces/namespaces.go
@@ -101,18 +101,6 @@ func Clean(namespace string, prefix string, cs *testclient.ClientSet) error {
 	return err
 }
 
-func isPlatformService(namespace, serviceName string) bool {
-	switch {
-	case namespace != "default":
-		return false
-	case serviceName == "kubernetes":
-		return true
-	case serviceName == "openshift":
-		return true
-	default:
-		return false
-	}
-}
 
 func Delete(aNamespace string, cs *testclient.ClientSet) error {
 	return cs.Namespaces().Delete(context.Background(), aNamespace, metav1.DeleteOptions{})

--- a/test/pkg/namespaces/namespaces.go
+++ b/test/pkg/namespaces/namespaces.go
@@ -101,7 +101,6 @@ func Clean(namespace string, prefix string, cs *testclient.ClientSet) error {
 	return err
 }
 
-
 func Delete(aNamespace string, cs *testclient.ClientSet) error {
 	return cs.Namespaces().Delete(context.Background(), aNamespace, metav1.DeleteOptions{})
 }

--- a/test/pkg/nodes/nodes.go
+++ b/test/pkg/nodes/nodes.go
@@ -27,7 +27,6 @@ func init() {
 	NodesSelector = os.Getenv("NODES_SELECTOR")
 }
 
-
 func LabelNode(nodeName, key, value string) (*corev1.Node, error) {
 	NodeObject, err := client.Client.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
 	if err != nil {
@@ -75,7 +74,6 @@ func MatchingOptionalSelectorPTP(toFilter []ptpv1.NodePtpDevice) ([]ptpv1.NodePt
 	}
 	return res, nil
 }
-
 
 // expectedReachabilityStatus true means test if the node is reachable, false means test if the node is unreachable
 func WaitForNodeReachability(nodeName string, timeout time.Duration, expectedReachabilityStatus bool) {

--- a/test/pkg/nodes/nodes.go
+++ b/test/pkg/nodes/nodes.go
@@ -27,42 +27,6 @@ func init() {
 	NodesSelector = os.Getenv("NODES_SELECTOR")
 }
 
-type NodeTopology struct {
-	NodeName      string
-	InterfaceList []string
-	NodeObject    *corev1.Node
-}
-
-// PtpEnabled returns the topology of a given node, filtering using the given selector.
-func PtpEnabled(aclient *client.ClientSet) ([]*NodeTopology, error) {
-	nodeDevicesList, err := aclient.NodePtpDevices(pkg.PtpLinuxDaemonNamespace).List(context.Background(), metav1.ListOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	if len(nodeDevicesList.Items) == 0 {
-		return nil, fmt.Errorf("Zero nodes found")
-	}
-
-	nodeTopologyList := []*NodeTopology{}
-
-	nodesList, err := MatchingOptionalSelectorPTP(nodeDevicesList.Items)
-	if err != nil {
-		return nodeTopologyList, fmt.Errorf("error getting node list, err= %s", err)
-	}
-	for _, node := range nodesList {
-		if len(node.Status.Devices) > 0 {
-			interfaceList := []string{}
-			for _, iface := range node.Status.Devices {
-				interfaceList = append(interfaceList, iface.Name)
-			}
-			nodeTopology := NodeTopology{NodeName: node.Name, InterfaceList: interfaceList}
-			nodeTopologyList = append(nodeTopologyList, &nodeTopology)
-		}
-	}
-
-	return nodeTopologyList, nil
-}
 
 func LabelNode(nodeName, key, value string) (*corev1.Node, error) {
 	NodeObject, err := client.Client.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
@@ -112,13 +76,6 @@ func MatchingOptionalSelectorPTP(toFilter []ptpv1.NodePtpDevice) ([]ptpv1.NodePt
 	return res, nil
 }
 
-func IsSingleNodeCluster() (bool, error) {
-	nodes, err := client.Client.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
-	if err != nil {
-		return false, err
-	}
-	return len(nodes.Items) == 1, nil
-}
 
 // expectedReachabilityStatus true means test if the node is reachable, false means test if the node is unreachable
 func WaitForNodeReachability(nodeName string, timeout time.Duration, expectedReachabilityStatus bool) {

--- a/test/pkg/pods/pods.go
+++ b/test/pkg/pods/pods.go
@@ -126,17 +126,6 @@ func WaitForCondition(cs *testclient.ClientSet, pod *corev1.Pod, conditionType c
 	})
 }
 
-// WaitForPhase waits until the pod will be in specified phase
-func WaitForPhase(cs *testclient.ClientSet, pod *corev1.Pod, phaseType corev1.PodPhase, timeout time.Duration) error {
-	return wait.PollImmediate(time.Second, timeout, func() (bool, error) {
-		updatePod, err := cs.Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
-		if err != nil {
-			return false, nil
-		}
-
-		return updatePod.Status.Phase == phaseType, nil
-	})
-}
 
 func findRegexInStream(stream io.ReadCloser, r *regexp.Regexp, timeout time.Duration) (matches [][]string, err error) {
 	logContent := ""

--- a/test/pkg/pods/pods.go
+++ b/test/pkg/pods/pods.go
@@ -126,7 +126,6 @@ func WaitForCondition(cs *testclient.ClientSet, pod *corev1.Pod, conditionType c
 	})
 }
 
-
 func findRegexInStream(stream io.ReadCloser, r *regexp.Regexp, timeout time.Duration) (matches [][]string, err error) {
 	logContent := ""
 	buf := make([]byte, 2000)

--- a/test/pkg/ptphelper/ptphelper.go
+++ b/test/pkg/ptphelper/ptphelper.go
@@ -254,7 +254,6 @@ func GetPtpPodOnNode(nodeName string) (v1core.Pod, error) {
 	return v1core.Pod{}, errors.New("pod not found")
 }
 
-
 // This function parses ethtool command output and detect interfaces which supports ptp protocol
 func IsPTPEnabled(ethToolOutput *bytes.Buffer) bool {
 	var RxEnabled bool
@@ -848,8 +847,6 @@ func IsExternalGM() (out bool) {
 	return out
 }
 
-
-
 func execPodCommand(nodeName string, cmd []string) (stdoutBuf, stderrBuf bytes.Buffer, err error) {
 
 	WaitForPtpDaemonToExist()
@@ -954,5 +951,3 @@ func IsPTPOperatorVersionAtLeast(minVersion string) bool {
 
 	return !ver.LessThan(minVer)
 }
-
-

--- a/test/pkg/ptphelper/ptphelper.go
+++ b/test/pkg/ptphelper/ptphelper.go
@@ -28,7 +28,6 @@ import (
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
 	"github.com/k8snetworkplumbingwg/ptp-operator/test/pkg/client"
-	"github.com/k8snetworkplumbingwg/ptp-operator/test/pkg/nodes"
 	"github.com/k8snetworkplumbingwg/ptp-operator/test/pkg/pods"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -242,22 +241,6 @@ func IsClockUnderTestPod(aPod *v1core.Pod) (result bool, err error) {
 	return result, nil
 }
 
-// Returns the slave node label to be used in the test, empty string label cound not be found
-func GetPTPConfigs(namespace string) ([]ptpv1.PtpConfig, []ptpv1.PtpConfig) {
-	var masters []ptpv1.PtpConfig
-	var slaves []ptpv1.PtpConfig
-
-	configList, err := client.Client.PtpConfigs(namespace).List(context.Background(), metav1.ListOptions{})
-	Expect(err).ToNot(HaveOccurred())
-	for _, config := range configList.Items {
-		for _, profile := range config.Spec.Profile {
-			if IsPtpSlave(profile.Ptp4lOpts, profile.Phc2sysOpts) {
-				slaves = append(slaves, config)
-			}
-		}
-	}
-	return masters, slaves
-}
 func GetPtpPodOnNode(nodeName string) (v1core.Pod, error) {
 	WaitForPtpDaemonToExist()
 	runningPod, err := client.Client.CoreV1().Pods(pkg.PtpLinuxDaemonNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: "app=linuxptp-daemon"})
@@ -271,122 +254,6 @@ func GetPtpPodOnNode(nodeName string) (v1core.Pod, error) {
 	return v1core.Pod{}, errors.New("pod not found")
 }
 
-func GetMasterSlaveAttachedInterfaces(pod *v1core.Pod) []string {
-	var IntList []string
-	Eventually(func() error {
-		stdout, _, err := pods.ExecCommand(client.Client, true, pod, pkg.PtpContainerName, []string{"ls", "/sys/class/net/"})
-		if err != nil {
-			return err
-		}
-
-		if stdout.String() == "" {
-			return errors.New("empty response from pod retrying")
-		}
-
-		IntList = strings.Split(strings.Join(strings.Fields(stdout.String()), " "), " ")
-		if len(IntList) == 0 {
-			return errors.New("no interface detected")
-		}
-
-		return nil
-	}, pkg.TimeoutIn3Minutes, 5*time.Second).Should(BeNil())
-
-	return IntList
-}
-
-func GetPtpMasterSlaveAttachedInterfaces(pod *v1core.Pod) []string {
-	var ptpSupportedInterfaces []string
-	var stdout bytes.Buffer
-
-	intList := GetMasterSlaveAttachedInterfaces(pod)
-	for _, interf := range intList {
-		skipInterface := false
-		PCIAddr := ""
-		var err error
-
-		// Get readlink status
-		Eventually(func() error {
-			stdout, _, err = pods.ExecCommand(client.Client, true, pod, pkg.PtpContainerName, []string{"readlink", "-f", fmt.Sprintf("/sys/class/net/%s", interf)})
-			if err != nil {
-				return err
-			}
-
-			if stdout.String() == "" {
-				return errors.New("empty response from pod retrying")
-			}
-
-			// Skip virtual interface
-			if strings.Contains(stdout.String(), "devices/virtual/net") {
-				skipInterface = true
-				return nil
-			}
-
-			// sysfs address looks like: /sys/devices/pci0000:17/0000:17:02.0/0000:19:00.5/net/eno1
-			pathSegments := strings.Split(stdout.String(), "/")
-			if len(pathSegments) != 8 {
-				skipInterface = true
-				return nil
-			}
-
-			PCIAddr = pathSegments[5] // 0000:19:00.5
-			return nil
-		}, pkg.TimeoutIn3Minutes, 5*time.Second).Should(BeNil())
-
-		if skipInterface || PCIAddr == "" {
-			continue
-		}
-
-		// Check if this is a virtual function
-		Eventually(func() error {
-			// If the physfn doesn't exist this means the interface is not a virtual function so we ca add it to the list
-			stdout, _, err = pods.ExecCommand(client.Client, true, pod, pkg.PtpContainerName, []string{"ls", fmt.Sprintf("/sys/bus/pci/devices/%s/physfn", PCIAddr)})
-			if err != nil {
-				if strings.Contains(stdout.String(), "No such file or directory") {
-					return nil
-				}
-				return err
-			}
-
-			if stdout.String() == "" {
-				return errors.New("empty response from pod retrying")
-			}
-
-			// Virtual function
-			skipInterface = true
-			return nil
-		}, 2*time.Minute, 1*time.Second).Should(BeNil())
-
-		if skipInterface {
-			continue
-		}
-
-		Eventually(func() error {
-			stdout, _, err = pods.ExecCommand(client.Client, true, pod, pkg.PtpContainerName, []string{"ethtool", "-T", interf})
-			if stdout.String() == "" {
-				return errors.New("empty response from pod retrying")
-			}
-
-			if err != nil {
-				if strings.Contains(stdout.String(), "No such device") {
-					skipInterface = true
-					return nil
-				}
-				return err
-			}
-			return nil
-		}, 2*time.Minute, 1*time.Second).Should(BeNil())
-
-		if skipInterface {
-			continue
-		}
-
-		if IsPTPEnabled(&stdout) {
-			ptpSupportedInterfaces = append(ptpSupportedInterfaces, interf)
-			logrus.Debugf("Append ptp interface=%s from node=%s", interf, pod.Spec.NodeName)
-		}
-	}
-	return ptpSupportedInterfaces
-}
 
 // This function parses ethtool command output and detect interfaces which supports ptp protocol
 func IsPTPEnabled(ethToolOutput *bytes.Buffer) bool {
@@ -875,21 +742,6 @@ func GetProfileName(config *ptpv1.PtpConfig) (string, error) {
 	}
 	return "", fmt.Errorf("cannot find valid test profile name")
 }
-func RetrievePTPProfileLabels(configs []ptpv1.PtpConfig) string {
-	for _, config := range configs {
-		for _, recommend := range config.Spec.Recommend {
-			for _, match := range recommend.Match {
-				label := *match.NodeLabel
-				nodeCount, err := nodes.LabeledNodesCount(label)
-				Expect(err).ToNot(HaveOccurred())
-				if nodeCount > 0 {
-					return label
-				}
-			}
-		}
-	}
-	return ""
-}
 
 func GetPTPPodWithPTPConfig(ptpConfig *ptpv1.PtpConfig) (aPtpPod *v1core.Pod, err error) {
 	ptpPods, err := client.Client.CoreV1().Pods(pkg.PtpLinuxDaemonNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: "app=linuxptp-daemon"})
@@ -996,6 +848,8 @@ func IsExternalGM() (out bool) {
 	return out
 }
 
+
+
 func execPodCommand(nodeName string, cmd []string) (stdoutBuf, stderrBuf bytes.Buffer, err error) {
 
 	WaitForPtpDaemonToExist()
@@ -1100,3 +954,5 @@ func IsPTPOperatorVersionAtLeast(minVersion string) bool {
 
 	return !ver.LessThan(minVer)
 }
+
+


### PR DESCRIPTION
**JIRA Issue** [CNF-25156](https://redhat.atlassian.net/browse/CNF-25156)

## Summary

- **Remove 30+ unused functions, types, and constants** identified via static analysis (`staticcheck U1000`, manual cross-reference) across controllers, test helpers, and API packages
- **Consolidate duplicate `ptpNodeMatches`** into the existing `nodeMatches` in `recommend.go` (same package, identical logic)
- **Replace deprecated `ioutil.ReadFile`** with `os.ReadFile` in `pkg/render`
- **Add unit tests** for `ptpconfig_controller.go` pure functions (controllers coverage: +6.2%)
- **Fix minor issues**: hand-rolled `contains`/`findSubstring` replaced with `strings.Contains`, unused `k8sclient` variable removed, ldflags path corrected in `hack/build.sh`
- **Fix nil `Priority` dereference** in `getRecommendProfilesNamesForConfig` that could panic when a recommend entry has no priority set

## Dead Code Removed

| Package | Removed Items |
| --- | --- |
| `controllers` | duplicate `ptpNodeMatches` |
| `main.go` | unused `setupChecks` |
| `api/v1` | unused `k8sclient` variable |
| `test/conformance/serial` | `verifyEventsV1`, `verifyEventsV2`, `checkStabilityOfSimGMUsingMetrics`, unused DPLL constants |
| `test/conformance/serial/prometheus` | unused `queryOutput`/`data` types |
| `test/conformance/parallel` | unused port constants |
| `test/pkg/ptphelper` | `GetPTPConfigs` (also buggy — `masters` always empty), `RetrievePTPProfileLabels`, `GetWPCEnabledInterfaces`, `GetFirstWorkerNodeName`, `CheckGNSSForInterface`, `getPTPHardwareClockIndex`, `findIfaceWithPinsForPhc`, interface-attachment chain |
| `test/pkg/nodes` | `NodeTopology`, `PtpEnabled`, `IsSingleNodeCluster` |
| `test/pkg/namespaces` | `isPlatformService` |
| `test/pkg/pods` | `WaitForPhase` |
| `test/pkg/event` | `DeleteService` |
| `test/pkg/consts` | `ETHTOOL_RX/TX/RAW_HARDWARE_FLAG` |

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./controllers/... ./api/... ./pkg/render/...` — 63 tests pass
- `gofmt -l` — all files formatted

## Test plan

- [ ] CI passes (go build, go vet, unit tests)
- [ ] No regressions in existing test suites
- [ ] Controller coverage increased (verify via `go test -cover ./controllers/...`)

/cc @edcdavid