### PR TITLE
test: propagate labeling errors and retry on conflicts

### DIFF
--- a/test/pkg/k8sutil/retriable.go
+++ b/test/pkg/k8sutil/retriable.go
@@ -22,3 +22,19 @@ func IsTransientL2OrPrivilegedNamespaceError(err error) bool {
 	}
 	return false
 }
+
+// IsRetryableConfigError returns true for transient errors that can be resolved
+// by retrying the entire configuration (includes namespace errors and Kubernetes
+// conflict errors from concurrent node modifications).
+func IsRetryableConfigError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if IsTransientL2OrPrivilegedNamespaceError(err) {
+		return true
+	}
+	if strings.Contains(err.Error(), "the object has been modified") {
+		return true
+	}
+	return false
+}

--- a/test/pkg/testconfig/testconfig.go
+++ b/test/pkg/testconfig/testconfig.go
@@ -595,7 +595,7 @@ func CreatePtpConfigurationsWithRetryContext(ctx context.Context, maxAttempts in
 		if last == nil {
 			return nil
 		}
-		if i < maxAttempts-1 && k8sutil.IsTransientL2OrPrivilegedNamespaceError(last) {
+		if i < maxAttempts-1 && k8sutil.IsRetryableConfigError(last) {
 			logrus.Warnf("CreatePtpConfigurations attempt %d/%d failed (transient): %v; retrying after %v", i+1, maxAttempts, last, retryDelay)
 			timer := time.NewTimer(retryDelay)
 			select {
@@ -849,7 +849,7 @@ func CreatePtpConfigGrandMaster(nodeName, ifName string) error {
 	// Labeling the grandmaster node
 	_, err = nodes.LabelNode(nodeName, pkg.PtpGrandmasterNodeLabel, "")
 	if err != nil {
-		logrus.Errorf("Error setting Grandmaster node role label: %s", err)
+		return fmt.Errorf("error setting Grandmaster node role label: %w", err)
 	}
 
 	// Grandmaster - add interface section with auth settings
@@ -874,12 +874,13 @@ func CreatePtpConfigWPCGrandMaster(policyName string, nodeName string, ifList []
 	if err == nil && configureFifo {
 		ptpSchedulingPolicy = SCHED_FIFO
 	}
-	// Sleep for a second to allow previous label on the same node to complete
-	time.Sleep(time.Second)
 	_, err = nodes.LabelNode(nodeName, pkg.PtpClockUnderTestNodeLabel, "")
+	if err != nil {
+		return fmt.Errorf("error setting WPC GM clock-under-test node role label: %w", err)
+	}
 	_, err = nodes.LabelNode(nodeName, pkg.PtpGrandmasterNodeLabel, "")
 	if err != nil {
-		logrus.Errorf("Error setting WPC GM node role label: %s", err)
+		return fmt.Errorf("error setting WPC GM grandmaster node role label: %w", err)
 	}
 
 	ts2phcConfig := BaseTs2PhcConfig + fmt.Sprintf("\nts2phc.nmea_serialport  /dev/%s\n", deviceID)
@@ -1006,11 +1007,9 @@ func CreatePtpConfigBC(policyName, nodeName, ifMasterName, ifSlaveName string, p
 	if err == nil && configureFifo {
 		ptpSchedulingPolicy = SCHED_FIFO
 	}
-	// Sleep for a second to allow previous label on the same node to complete
-	time.Sleep(time.Second)
 	_, err = nodes.LabelNode(nodeName, pkg.PtpClockUnderTestNodeLabel, "")
 	if err != nil {
-		logrus.Errorf("Error setting BC node role label: %s", err)
+		return fmt.Errorf("error setting BC node role label: %w", err)
 	}
 
 	bcConfig := GetPtp4lConfigWithAuth(BasePtp4lConfig) + "\nboundary_clock_jbod 1\ngmCapable 0"
@@ -1042,11 +1041,9 @@ func CreatePtpConfigOC(profileName, nodeName, ifSlaveName string, phc2sys bool, 
 	if err == nil && configureFifo {
 		ptpSchedulingPolicy = SCHED_FIFO
 	}
-	// Sleep for a second to allow previous label on the same node to complete
-	time.Sleep(time.Second)
 	_, err = nodes.LabelNode(nodeName, label, "")
 	if err != nil {
-		logrus.Errorf("Error setting Slave node role label: %s", err)
+		return fmt.Errorf("error setting Slave node role label: %w", err)
 	}
 	ptp4lsysOpts := ptp4lEthernetSlave
 	var phc2sysOpts *string
@@ -1077,11 +1074,9 @@ func CreatePtpConfigDualFollower(profileName, nodeName, ifSlave1Name, ifSlave2Na
 	if err == nil && configureFifo {
 		ptpSchedulingPolicy = SCHED_FIFO
 	}
-	// Sleep for a second to allow previous label on the same node to complete
-	time.Sleep(time.Second)
 	_, err = nodes.LabelNode(nodeName, label, "")
 	if err != nil {
-		logrus.Errorf("Error setting Slave node role label: %s", err)
+		return fmt.Errorf("error setting Slave node role label: %w", err)
 	}
 	ptp4lsysOpts := ptp4lEthernetSlave
 	var phc2sysOpts *string
@@ -1344,7 +1339,7 @@ func createPtpConfigPhc2SysHA(policyName string, nodeName string, haProfiles []s
 	clockUnderTestNodeLabel := pkg.PtpClockUnderTestNodeLabel
 	_, err := nodes.LabelNode(nodeName, clockUnderTestNodeLabel, "")
 	if err != nil {
-		return fmt.Errorf("error setting HA node role label: %s", err)
+		return fmt.Errorf("error setting HA node role label: %w", err)
 	}
 
 	ptpSchedulingPolicy := SCHED_OTHER


### PR DESCRIPTION
LabelNode does a Get + Update on the node object, which can fail with a conflict error if the node is modified concurrently (e.g. by kubelet heartbeats or operator reconciliation). Previously the error was only logged and the test proceeded in a broken state, causing downstream "no linuxptp-daemon pod found" failures.

Propagate the labeling error from CreatePtpConfigGrandMaster, CreatePtpConfigWPCGrandMaster, CreatePtpConfigBC, CreatePtpConfigOC, and CreatePtpConfigDualFollower so it reaches
CreatePtpConfigurationsWithRetryContext. Add conflict detection to the retryable error check so the entire configuration is retried on transient node conflicts.

Generated-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced retry mechanism for configuration operations with improved error detection for transient failures.
  * Configuration creation now properly reports errors when node labeling operations fail instead of continuing silently.
  * Improved error information through better error wrapping during setup processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->