### PR TITLE
ci: use plain podman build in CI instead of manifest lists

### DIFF
--- a/ptp-tools/Makefile
+++ b/ptp-tools/Makefile
@@ -46,14 +46,25 @@ podman-build-%:
 
 podman-pushall: $(foreach v, $(VALUES), podman-push-$(v))
 
+ifdef GITHUB_ACTIONS
+podman-push-%:
+	podman push ${IMG_PREFIX}:$* docker://${IMG_PREFIX}:$*
+else
 podman-push-%:
 	podman manifest push ${IMG_PREFIX}:$* docker://${IMG_PREFIX}:$*
+endif
 
 podman-saveall: $(foreach v, $(VALUES), podman-save-$(v))
 
+ifdef GITHUB_ACTIONS
+podman-save-%:
+	mkdir -p $(SAVE_DIR)
+	podman save -o $(SAVE_DIR)/$*.tar ${IMG_PREFIX}:$*
+else
 podman-save-%:
 	mkdir -p $(SAVE_DIR)
 	podman save -m -o $(SAVE_DIR)/$*.tar ${IMG_PREFIX}:$*
+endif
 
 podman-build-and-pushall: $(foreach v, $(VALUES), podman-build-and-push-$(v))
 
@@ -69,15 +80,28 @@ podman-build-and-save-%:
 	$(MAKE) podman-build-$*
 	$(MAKE) podman-save-$*
 
+ifdef GITHUB_ACTIONS
+build-image:
+	podman build $(CACHE_FLAG) --network host --platform $(PLATFORM) -t ${IMG_PREFIX}:$(VAR) -f Dockerfile.$(VAR) ..
+else
 build-image:
 	podman manifest create ${IMG_PREFIX}:$(VAR)
-	podman build $(CACHE_FLAG) --network host --platform $(PLATFORM) -f Dockerfile.$(VAR)  --manifest ${IMG_PREFIX}:$(VAR)  ..
+	podman build $(CACHE_FLAG) --network host --platform $(PLATFORM) -f Dockerfile.$(VAR) --manifest ${IMG_PREFIX}:$(VAR) ..
+endif
 
+ifdef GITHUB_ACTIONS
+clean-image:
+	podman rmi ${IMG_PREFIX}:$(VAR) || true
+
+podman-clean-%:
+	podman rmi ${IMG_PREFIX}:$* || true
+else
 clean-image:
 	podman manifest rm ${IMG_PREFIX}:$(VAR) || true
 
 podman-clean-%:
 	podman manifest rm ${IMG_PREFIX}:$* || true
+endif
 
 podman-cleanall: $(foreach v, $(VALUES), podman-clean-$(v))
 

--- a/scripts/run-on-vm.sh
+++ b/scripts/run-on-vm.sh
@@ -93,6 +93,7 @@ run_quiet_with_log_dump_on_failure() {
   fi
 
   echo -e "${COLOR_ERR}FAIL ${log_tag}:${COLOR_RESET} (exit code ${rc}) ${COLOR_GRAY}@ $(log_ts)${COLOR_RESET}"
+  echo -e "${COLOR_ERR}  CMD:${COLOR_RESET} $*"
   echo -e "${COLOR_ERR}---- BEGIN ${log_tag} LOG ----${COLOR_RESET} ${COLOR_GRAY}@ $(log_ts)${COLOR_RESET}"
   cat "${log_file}"
   echo -e "${COLOR_ERR}---- END ${log_tag} LOG ----${COLOR_RESET} ${COLOR_GRAY}@ $(log_ts)${COLOR_RESET}"


### PR DESCRIPTION
## Summary

- In CI (`GITHUB_ACTIONS` set), use plain `podman build -t` / `podman save` / `podman push` / `podman rmi` instead of manifest-based commands (`podman manifest create` / `build --manifest` / `save -m` / `manifest push` / `manifest rm`).
- CI only builds for a single platform (`linux/amd64`), so manifest lists are unnecessary.
- Fixes a race condition where parallel builds cause `podman save -m` to fail with `image not known` because concurrent manifest storage operations conflict.
- Local (non-CI) builds are unchanged and continue using manifest lists.

## Test plan

- [ ] CI `ptp-images` job passes (previously failing with `Error: could not find image instance ... image not known`)
- [ ] Local `make podman-buildall` still uses manifest-based flow
- [ ] `GITHUB_ACTIONS=true make -n podman-build-debug` shows `podman build -t` (no manifest)
- [ ] `make -n podman-build-debug` shows `podman manifest create` + `podman build --manifest` (unchanged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adapted image build, push, save, and cleanup operations with conditional execution logic for different deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->