### PR TITLE
CNF-24031: stop polluting git working tree with generated artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,5 @@ catalog.Dockerfile
 # Backup files created during build
 *.bak
 config/manager/env.yaml.bak
+# Per-run temp artifacts created by scripts/run-on-vm.sh
+.local-runs

--- a/ptp-tools/Makefile
+++ b/ptp-tools/Makefile
@@ -80,9 +80,13 @@ podman-cleanall: $(foreach v, $(VALUES), podman-clean-$(v))
 .PHONY: build-image clean-image deploy-all
 
 deploy-all: 
+	cp ../config/manager/env.yaml ../config/manager/env.yaml.bak
+	cp ../config/manager/kustomization.yaml ../config/manager/kustomization.yaml.bak
 	./scripts/customize-env.sh ${IMG_PREFIX} ../config/manager
 	cd ../config/manager && $(KUSTOMIZE) edit set image controller=${IMG_PREFIX}:ptpop
-	$(KUSTOMIZE) build ../config/default | kubectl apply -f -
+	$(KUSTOMIZE) build ../config/default | kubectl apply -f - ; \
+		mv -f ../config/manager/env.yaml.bak ../config/manager/env.yaml ; \
+		mv -f ../config/manager/kustomization.yaml.bak ../config/manager/kustomization.yaml
 	$(KUSTOMIZE) build ../config/custom | kubectl apply -f -
 	# Operator creates default asynchronously; ensure it exists before patch.
 	kubectl apply -n openshift-ptp -f ../config/samples/ptp_v1_ptpoperatorconfig.yaml

--- a/scripts/fix-certs.sh
+++ b/scripts/fix-certs.sh
@@ -2,6 +2,6 @@
 set -x
 set -euo pipefail
 
-kubectl get secret webhook-server-cert -n openshift-ptp -o jsonpath='{.data.ca\.crt}' | base64 -d > ca.crt
-kubectl patch validatingwebhookconfiguration ptpconfig-validating-webhook-configuration --type='json' -p="[{'op': 'replace', 'path': '/webhooks/0/clientConfig/caBundle', 'value': '$(cat ca.crt | base64 -w0)'}]"
-kubectl patch validatingwebhookconfiguration ptpconfig-validating-webhook-configuration --type='json' -p="[{'op': 'replace', 'path': '/webhooks/1/clientConfig/caBundle', 'value': '$(cat ca.crt | base64 -w0)'}]"
+CA_BUNDLE="$(kubectl get secret webhook-server-cert -n openshift-ptp -o jsonpath='{.data.ca\.crt}')"
+kubectl patch validatingwebhookconfiguration ptpconfig-validating-webhook-configuration --type='json' -p="[{'op': 'replace', 'path': '/webhooks/0/clientConfig/caBundle', 'value': '${CA_BUNDLE}'}]"
+kubectl patch validatingwebhookconfiguration ptpconfig-validating-webhook-configuration --type='json' -p="[{'op': 'replace', 'path': '/webhooks/1/clientConfig/caBundle', 'value': '${CA_BUNDLE}'}]"

--- a/scripts/install-tools.sh
+++ b/scripts/install-tools.sh
@@ -47,13 +47,18 @@ else
     yum install -y podman pciutils helm
 
     echo "Installing kubectl/oc for $ARCH"
+    _tmp="${PTP_RUN_DIR:-/tmp}"
+    OC_TARBALL="$(mktemp "${_tmp}/openshift-client-linux.XXXXXX.tar.gz")"
     if [[ "$ARCH" == "x86_64" ]]; then
-        curl -Lo ./openshift-client-linux.tar.gz "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz"
+        curl -Lo "${OC_TARBALL}" "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz"
     elif [[ "$ARCH" == "aarch64" ]]; then
-        curl -Lo openshift-client-linux.tar.gz "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux-arm64.tar.gz"
+        curl -Lo "${OC_TARBALL}" "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux-arm64.tar.gz"
     fi
-    tar -xvf openshift-client-linux.tar.gz
-    sudo mv oc kubectl /usr/local/bin/
+    OC_TMP_DIR="$(mktemp -d "${_tmp}/openshift-client.XXXXXX")"
+    trap 'rm -rf "${OC_TMP_DIR:-}" "${OC_TARBALL:-}"' EXIT
+    tar -xf "${OC_TARBALL}" -C "${OC_TMP_DIR}" oc kubectl
+    sudo install -m 0755 "${OC_TMP_DIR}/oc" "${OC_TMP_DIR}/kubectl" /usr/local/bin/
+    rm -f "${OC_TARBALL}"
     oc version || true
 fi
 
@@ -62,11 +67,13 @@ GO_VERSION=$(curl -s https://go.dev/VERSION?m=text | head -n 1)
 
 echo "Installing Go $GO_VERSION for $GOARCH"
 
-curl -Lo ./go.tar.gz "https://go.dev/dl/${GO_VERSION}.linux-${GOARCH}.tar.gz"
+GO_TARBALL="$(mktemp "${PTP_RUN_DIR:-/tmp}/go.XXXXXX.tar.gz")"
+curl -Lo "${GO_TARBALL}" "https://go.dev/dl/${GO_VERSION}.linux-${GOARCH}.tar.gz"
 
 INSTALL_DIR="/usr/local"
 sudo rm -rf "${INSTALL_DIR}/go"
-sudo tar -C "${INSTALL_DIR}" -xzf ./go.tar.gz
+sudo tar -C "${INSTALL_DIR}" -xzf "${GO_TARBALL}"
+rm -f "${GO_TARBALL}"
 
 if ! grep -q 'export PATH=$PATH:"$HOME"/go/bin:/usr/local/go/bin' ~/.bashrc; then
     echo 'export PATH=$PATH:"$HOME"/go/bin:/usr/local/go/bin' >>~/.bashrc
@@ -80,7 +87,6 @@ PS1="${PS1:-}" source ~/.bashrc
 go mod tidy
 go mod vendor
 go install github.com/onsi/ginkgo/v2/ginkgo
-go get github.com/onsi/gomega/...
 
 # Install kind
 curl -Lo ./kind "https://kind.sigs.k8s.io/dl/v0.27.0/kind-linux-${GOARCH}"

--- a/scripts/k8s-start.sh
+++ b/scripts/k8s-start.sh
@@ -3,6 +3,7 @@ set -x
 set -euo pipefail
 
 VM_IP=$1
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Delete cluster
 kind delete cluster --name kind-netdevsim
@@ -10,12 +11,13 @@ kind delete cluster --name kind-netdevsim
 # Delete and re-create netdevsim and openvswitch devices
 ./reset-devices.sh
 
-# restore template and substitute registry IP
-git checkout -- kind-config.yaml 2>/dev/null || true
-sed -i "s/IP/$VM_IP/g" kind-config.yaml
+# Substitute registry IP into a temp copy so the tracked template stays clean.
+KIND_CONFIG="$(mktemp "${PTP_RUN_DIR:-/tmp}/ptp-kind-config.XXXXXX.yaml")"
+trap 'rm -f "${KIND_CONFIG}"' EXIT
+sed "s/IP/$VM_IP/g" "${SCRIPT_DIR}/kind-config.yaml" >"${KIND_CONFIG}"
 
 # Create new cluster
-kind create cluster --name kind-netdevsim --config=kind-config.yaml
+kind create cluster --name kind-netdevsim --config="${KIND_CONFIG}"
 
 # Wait a bit until the cluster API becomes reacheable
 ./retry.sh 30 3 kubectl get nodes

--- a/scripts/run-on-vm.sh
+++ b/scripts/run-on-vm.sh
@@ -6,6 +6,7 @@ TEST_MODES="oc,bc,dualnicbc,dualnicbcha,dualfollower"
 RUN_PHASE="all"
 REGISTRY_IP=""
 TARBALL=""
+KEEP_TMP=true
 
 while [[ "${1:-}" == --* ]]; do
     case "$1" in
@@ -14,13 +15,25 @@ while [[ "${1:-}" == --* ]]; do
         --images)  RUN_PHASE="images"; shift ;;
         --deploy)  RUN_PHASE="deploy"; REGISTRY_IP="$2"; shift 2 ;;
         --load)    RUN_PHASE="load"; TARBALL="$2"; shift 2 ;;
+        --clean-tmp) KEEP_TMP=false; shift ;;
         *) echo "Unknown flag: $1"; exit 1 ;;
     esac
 done
 
-# Save full run output under /tmp/ptp-operator (timestamped file; also shown on the terminal).
-mkdir -p /tmp/ptp-operator
-RUN_ON_VM_LOG="/tmp/ptp-operator/run-on-vm-$(date +%Y%m%d-%H%M%S).log"
+# Per-run temp directory shared by all child scripts.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export PTP_RUN_DIR="${REPO_ROOT}/.local-runs/$(date +%Y%m%d-%H%M%S)"
+mkdir -p "${PTP_RUN_DIR}"
+cleanup_run_dir() {
+  if [[ "${KEEP_TMP}" == false ]]; then
+    rm -rf "${PTP_RUN_DIR}"
+  else
+    echo "Temp directory retained: ${PTP_RUN_DIR}"
+  fi
+}
+trap cleanup_run_dir EXIT
+
+RUN_ON_VM_LOG="${PTP_RUN_DIR}/run-on-vm.log"
 : >"${RUN_ON_VM_LOG}"
 exec > >(tee -a "${RUN_ON_VM_LOG}") 2>&1
 
@@ -78,7 +91,7 @@ run_quiet_with_log_dump_on_failure() {
   shift
 
   local log_file
-  log_file="$(mktemp "/tmp/ptp-operator/${log_tag// /_}.XXXXXX.log")"
+  log_file="$(mktemp "${PTP_RUN_DIR}/${log_tag// /_}.XXXXXX.log")"
 
   local rc
   if "$@" >"${log_file}" 2>&1 </dev/null; then
@@ -187,7 +200,7 @@ run_ptp_tools_parallel_make_step_rows() {
   done
   run_step_rows_begin "${rows[@]}"
 
-  local fifo="/tmp/ptp-operator/ptp-${fifo_tag}-done-$$.fifo"
+  local fifo="${PTP_RUN_DIR}/ptp-${fifo_tag}-done-$$.fifo"
   rm -f "${fifo}"
   mkfifo "${fifo}"
   exec 8<> "${fifo}"
@@ -258,17 +271,6 @@ run_quiet_with_log_dump_on_failure "install-tools" bash ./install-tools.sh
 export BASHRCSOURCED=1
 PS1="${PS1:-}" source ~/.bashrc
 
-step "Tidying and vendoring Go dependencies"
-run_step_rows_begin "go mod tidy" "go mod vendor"
-
-run_quiet_with_log_dump_on_failure "go-mod-tidy" go mod tidy
-run_step_row_done "go mod tidy"
-
-run_quiet_with_log_dump_on_failure "go-mod-vendor" go mod vendor
-run_step_row_done "go mod vendor"
-
-run_step_rows_end
-
 
 # ── Images phase (--images) ──────────────────────────────────────────
 if [[ "$RUN_PHASE" == "images" ]]; then
@@ -327,13 +329,13 @@ if [[ "$RUN_PHASE" == "load" ]]; then
 
     export IMG_PREFIX="$VM_IP/test"
 
-    mkdir -p /tmp/ptp-images-load
-    tar xf "$TARBALL" -C /tmp/ptp-images-load
+    mkdir -p "${PTP_RUN_DIR}/ptp-images-load"
+    tar xf "$TARBALL" -C "${PTP_RUN_DIR}/ptp-images-load"
 
     step "Retagging images for local registry"
     TAGS=(lptpd cep ptpop krp openvswitch prometheus ptpmg debug)
     for t in "${TAGS[@]}"; do
-        podman load -i "/tmp/ptp-images-load/$t.tar"
+        podman load -i "${PTP_RUN_DIR}/ptp-images-load/$t.tar"
     done
 
     OLD_PREFIX=$(podman images --format '{{.Repository}}:{{.Tag}}' | grep ":${TAGS[0]}$" | head -1 | sed "s/:${TAGS[0]}$//")

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -67,7 +67,8 @@ export MIN_OFFSET_IN_NS="${MIN_OFFSET_IN_NS:--10000}"
 export COLLECT_POD_LOGS="${COLLECT_POD_LOGS:-true}"
 export LOG_ARTIFACTS_DIR="${LOG_ARTIFACTS_DIR:-${JUNIT_OUTPUT_DIR}/pod-logs}"
 
-cat <<EOF >config.yaml
+CONFIG_YAML="$(mktemp "${PTP_RUN_DIR:-/tmp}/ptp-config.XXXXXX.yaml")"
+cat <<EOF >"${CONFIG_YAML}"
 global:
   maxoffset: $MAX_OFFSET_IN_NS
   minoffset: $MIN_OFFSET_IN_NS
@@ -75,7 +76,7 @@ global:
   DisableAllSlaveRTUpdate: true
 EOF
 export USE_CONTAINER_CMDS=
-export PTP_TEST_CONFIG_FILE="$(pwd)/config.yaml"
+export PTP_TEST_CONFIG_FILE="${CONFIG_YAML}"
 export PTP_LOG_LEVEL
 export GOFLAGS=-mod=vendor
 export KEEP_PTPCONFIG="${KEEP_PTPCONFIG:-true}"
@@ -132,6 +133,7 @@ run_must_gather() {
 
 on_exit() {
   local exit_code=$?
+  rm -f "${CONFIG_YAML:-}"
   if [[ ${exit_code} -ne 0 ]]; then
     echo "Script failed with exit code ${exit_code}, collecting must-gather..."
     run_must_gather


### PR DESCRIPTION
CNF-24031: stop polluting git working tree with generated artifacts Running run-on-vm.sh left behind artifacts that made git status noisy and confusing after a test run. This commit redirects all generated and downloaded files to a per-run .local-runs/<timestamp> directory so the following stay clean:

-  go.mod / go.sum — removed `go get gomega/...` from install-tools.sh which pulled latest versions and caused dependency drift. Consolidated duplicate go mod tidy/vendor calls into install-tools.sh only.

- vendor/ — no longer modified by redundant go mod vendor in run-on-vm.sh.

- scripts/kind-config.yaml — k8s-start.sh now substitutes registry IP into a temp copy instead of editing the tracked template in-place.

- scripts/openshift-client-linux.tar.gz, scripts/go.tar.gz — tarballs now download to the run directory and are cleaned up after extraction.

- scripts/config.yaml — ginkgo test config now written to the run directory and cleaned up via the existing on_exit trap.

- config/manager/env.yaml, config/manager/kustomization.yaml — the deploy-all Makefile target now runs `git checkout` after kustomize build to restore these files to their committed state.

- scripts/ca.crt — fix-certs.sh no longer writes a temporary ca.crt file; the CA bundle is now fetched directly into a variable.

Run logs (.local-runs/) are now kept by default for post-run debugging. Pass --clean-tmp to delete them automatically.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved setup and test workflows to generate configuration and run artifacts in temporary locations with automatic cleanup (including removing the generated test YAML).
  * Streamlined VM-based execution by isolating per-run logs/artifacts in a timestamped workspace, adding a `--keep-tmp` option to retain it, and simplifying the Go preparation phase.
  * Hardened cluster startup by using a temporary Kind config instead of modifying the tracked file.
  * Updated tool installation to download architecture-specific bundles into temporary locations with reliable cleanup, and simplified Go module preparation.
  * Updated `.gitignore` to exclude per-run temporary artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->