### PR TITLE
CNF-25274: Add minKubeVersion to CSV for OCP 5.0 certification

### DIFF
--- a/bundle/manifests/ptp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ptp-operator.clusterserviceversion.yaml
@@ -61,7 +61,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/openshift/origin-ptp-operator:5.0
-    createdAt: "2026-06-25T00:57:11Z"
+    createdAt: "2026-07-02T18:03:02Z"
     description: This software enables configuration of Precision Time Protocol(PTP)
       on Kubernetes. It detects hardware capable PTP devices on each node, and configures
       linuxptp processes such as ptp4l, phc2sys and timemaster.
@@ -493,6 +493,7 @@ spec:
   - email: support@redhat.com
     name: Red Hat
   maturity: alpha
+  minKubeVersion: 1.35.0
   provider:
     name: Red Hat
   version: 5.0.0

--- a/config/manifests/bases/ptp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ptp-operator.clusterserviceversion.yaml
@@ -175,6 +175,7 @@ spec:
   - email: support@redhat.com
     name: Red Hat
   maturity: alpha
+  minKubeVersion: 1.35.0
   provider:
     name: Red Hat
   version: 0.0.0

--- a/manifests/stable/ptp-operator.clusterserviceversion.yaml
+++ b/manifests/stable/ptp-operator.clusterserviceversion.yaml
@@ -61,7 +61,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/openshift/origin-ptp-operator:5.0
-    createdAt: "2026-06-25T00:57:11Z"
+    createdAt: "2026-07-02T18:03:02Z"
     description: This software enables configuration of Precision Time Protocol(PTP)
       on Kubernetes. It detects hardware capable PTP devices on each node, and configures
       linuxptp processes such as ptp4l, phc2sys and timemaster.
@@ -493,6 +493,7 @@ spec:
   - email: support@redhat.com
     name: Red Hat
   maturity: alpha
+  minKubeVersion: 1.35.0
   provider:
     name: Red Hat
   version: 5.0.0


### PR DESCRIPTION
## Summary
- Add `minKubeVersion: 1.35.0` to CSV spec, matching the K8s API version (v0.35.2) used by OCP 4.22/5.0
- Ensures the operator only installs on clusters with compatible Kubernetes versions
- Bundle passes `operator-sdk bundle validate`
- `olm.skipRange: ">=4.3.0-0 <5.0.0"` verified correct for upgrades from any 4.x on both OCP 4.22 and 5.0

Fixes: [CNF-25274](https://redhat.atlassian.net/browse/CNF-25274)

## Test plan
- [x] `make bundle` succeeds (includes `operator-sdk bundle validate`)
- [x] `minKubeVersion: 1.35.0` present in all 3 CSV files (template, bundle, stable)
- [x] `olm.skipRange` unchanged at `>=4.3.0-0 <5.0.0`
- [x] Verify operator installs correctly on OCP 4.22 cluster (cnfdg32: OCP 4.22.0-rc.5, K8s 1.35.5 — CSV Succeeded via `operator-sdk run bundle`, operator 1/1, daemonset 3/3)
- [x] Verify operator installs correctly on OCP 5.0 cluster (cnfdg14: OCP 5.0.0-ec.3, K8s 1.35.3 — OLM accepted minKubeVersion 1.35.0, CSV requirementStatus: "CSV minKubeVersion (1.35.0) less than server version (v1.35.3)")
- [x] Verify operator appears in OperatorHub on both versions — N/A: OperatorHub visibility is controlled by the Red Hat certification/release pipeline (IIB). Developer-side verification completed via `operator-sdk run bundle` and direct CSV apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)