### PR TITLE
CNF-25331: fix webhook cert race condition on Kind

### DIFF
--- a/scripts/kind-webhook-ca-patch.yaml
+++ b/scripts/kind-webhook-ca-patch.yaml
@@ -1,0 +1,9 @@
+# Patch for local kind clusters: tells cert-manager to inject the CA bundle
+# from the serving-cert Certificate into the ValidatingWebhookConfiguration.
+# This is NOT needed on OpenShift (service.beta.openshift.io/inject-cabundle handles it).
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: ptpconfig-validating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: openshift-ptp/serving-cert

--- a/scripts/run-on-vm.sh
+++ b/scripts/run-on-vm.sh
@@ -376,20 +376,20 @@ if [[ "$RUN_PHASE" == "all" || "$RUN_PHASE" == "deploy" ]]; then
     run_step_row_done "Building kind cluster..."
     run_step_rows_end
 
+    step "Applying certificate manifests"
+    run_quiet_with_log_dump_on_failure "kubectl-apply-certs" kubectl apply -f certs.yaml
+
+    step "Waiting for TLS certificates to be ready"
+    run_quiet_with_log_dump_on_failure "wait-cert-serving" ./retry.sh 60 5 kubectl wait certificate/serving-cert -n openshift-ptp --for=condition=Ready --timeout=5s
+    run_quiet_with_log_dump_on_failure "wait-cert-daemon" ./retry.sh 60 5 kubectl wait certificate/serving-cert-daemon -n openshift-ptp --for=condition=Ready --timeout=5s
+
     step "Deploying ptp-operator manifests"
     cd "${PTP_TOOLS_DIR}"
     run_quiet_with_log_dump_on_failure "make-deploy-all" sh -c "make deploy-all || true"
     cd -
 
-    step "Applying certificate manifests"
-    run_quiet_with_log_dump_on_failure "kubectl-apply-certs" kubectl apply -f certs.yaml
-
-    step "Fixing certificates"
-    run_quiet_with_log_dump_on_failure "retry-fix-certs" ./retry.sh 60 5 ./fix-certs.sh
-    sleep 5
-
-    step "Restarting ptp-operator pod"
-    run_quiet_with_log_dump_on_failure "kubectl-delete-pods" kubectl delete pods -l name=ptp-operator -n openshift-ptp
+    step "Patching webhook for cert-manager CA injection (kind)"
+    run_quiet_with_log_dump_on_failure "retry-patch-webhook-ca" ./retry.sh 60 5 bash -c 'kubectl patch validatingwebhookconfiguration ptpconfig-validating-webhook-configuration --type=strategic --patch-file kind-webhook-ca-patch.yaml && kubectl wait -f kind-webhook-ca-patch.yaml --for=jsonpath={.webhooks[0].clientConfig.caBundle} --timeout=5s'
 
     step "Waiting for ptp-operator rollout"
     run_quiet_with_log_dump_on_failure "kubectl-rollout-status" kubectl rollout status deployment ptp-operator -n openshift-ptp


### PR DESCRIPTION
The deployment had a race condition where make deploy-all created the ValidatingWebhookConfiguration before any TLS certificate existed. Until fix-certs.sh manually patched the caBundle, all admission requests failed — blocking linuxptp-daemon DaemonSet creation.

Fix by reordering the deployment and using cert-manager's built-in CA injection:

- Add cert-manager.io/inject-ca-from annotation to the webhook configuration so cert-manager auto-populates caBundle (coexists with the OpenShift annotation for production clusters).

- Apply certs.yaml and wait for Certificates to be Ready before deploying the operator, so the TLS secret is already mounted when the pod starts.

- Remove fix-certs.sh retry loop, sleep, and pod restart — no longer needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment reliability by applying required certificates and waiting for them to become Ready before deploying operator manifests.
  * Added local kind support for webhook CA injection to ensure validating webhook configuration is correctly populated.
  * Streamlined the certificate and webhook initialization sequence to improve consistency across deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->