### PR TITLE
Fix race in Upstream CI cluster config

### DIFF
--- a/scripts/prepare-kind.sh
+++ b/scripts/prepare-kind.sh
@@ -10,3 +10,8 @@ kubectl label node kind-netdevsim-worker3 node-role.kubernetes.io/master= --over
 kubectl label node kind-netdevsim-worker node-role.kubernetes.io/worker= --overwrite
 kubectl label node kind-netdevsim-worker2 node-role.kubernetes.io/worker= --overwrite
 kubectl label node kind-netdevsim-worker3 node-role.kubernetes.io/worker= --overwrite
+
+# Required by config/samples/ptp_v1_ptpoperatorconfig.yaml daemonNodeSelector.
+kubectl label node kind-netdevsim-worker feature.node.kubernetes.io/ptp-capable=yes --overwrite
+kubectl label node kind-netdevsim-worker2 feature.node.kubernetes.io/ptp-capable=yes --overwrite
+kubectl label node kind-netdevsim-worker3 feature.node.kubernetes.io/ptp-capable=yes --overwrite

--- a/scripts/run-on-vm.sh
+++ b/scripts/run-on-vm.sh
@@ -395,6 +395,12 @@ if [[ "$RUN_PHASE" == "all" || "$RUN_PHASE" == "deploy" ]]; then
     step "Waiting for ptp-operator rollout"
     run_quiet_with_log_dump_on_failure "kubectl-rollout-status" kubectl rollout status deployment ptp-operator -n openshift-ptp
 
+    # deploy-all may fail to create default while the webhook has no CA yet; the
+    # operator's one-shot createDefault also does not retry. Re-apply after CA
+    # injection so the patch below has an object to update.
+    step "Ensuring default ptpoperatorconfig exists"
+    run_quiet_with_log_dump_on_failure "retry-apply-ptpoperatorconfig" ./retry.sh 60 5 kubectl apply -n openshift-ptp -f ../config/samples/ptp_v1_ptpoperatorconfig.yaml
+
     # Patch ptpoperatorconfig to start events (in case it is not configured yet )
     step "Patching ptpoperatorconfig for event publishing"
     run_quiet_with_log_dump_on_failure "retry-patch-ptpoperatorconfig" ./retry.sh 60 5 kubectl patch ptpoperatorconfig default -nopenshift-ptp --type=merge --patch '{"spec": {"ptpEventConfig": {"enableEventPublisher": true, "transportHost": "http://ptp-event-publisher-service-NODE_NAME.openshift-ptp.svc.cluster.local:9043", "storageType": "local-sc"}, "daemonNodeSelector": {"node-role.kubernetes.io/worker": ""}}}'


### PR DESCRIPTION
After PR #270 reordered the Kind deployment to use cert-manager CA injection, two residual race conditions remain that cause intermittent test failures:

ptpoperatorconfig creation fails silently: make deploy-all and the operator's one-shot createDefault() can both attempt to create the default PtpOperatorConfig before cert-manager has injected the caBundle into the ValidatingWebhookConfiguration. When this happens, the admission webhook rejects the request and neither path retries, leaving no ptpoperatorconfig object for the subsequent event-publishing patch to update.

linuxptp-daemon DaemonSet stays at Desired=0: The sample PtpOperatorConfig (config/samples/ptp_v1_ptpoperatorconfig.yaml) includes daemonNodeSelector: feature.node.kubernetes.io/ptp-capable: "yes", but Kind worker nodes are never labeled with this key. Even when the config object exists, linuxptp-daemon pods are never scheduled.

Changes
scripts/run-on-vm.sh: After the operator rollout, retry-apply the sample ptpoperatorconfig until the webhook accepts it. This ensures the object exists before the event-publishing patch runs, regardless of cert-manager timing.

scripts/prepare-kind.sh: Label all Kind worker nodes with feature.node.kubernetes.io/ptp-capable=yes so the daemonNodeSelector matches and linuxptp-daemon pods are scheduled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment setup by ensuring the default PTP operator configuration is created before additional configuration is applied.
  * Added PTP capability labels to applicable development worker nodes, improving node selection during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->