### PR TITLE
test: pass PMC command as single arg in getClockIDViaPMC

### DIFF
--- a/test/pkg/ptphelper/ptphelper.go
+++ b/test/pkg/ptphelper/ptphelper.go
@@ -141,7 +141,7 @@ func configFileFromLogID(logID string) string {
 func getClockIDViaPMC(pod *corev1.Pod, configFile, field string) (string, error) {
 	re := regexp.MustCompile(`(?m)` + regexp.QuoteMeta(field) + `\s+(\S+)`)
 	buf, _, err := pods.ExecCommand(client.Client, true, pod,
-		pkg.PtpContainerName, []string{"pmc", "-b", "0", "-u", "-f", configFile, "GET", "PARENT_DATA_SET"})
+		pkg.PtpContainerName, []string{"pmc", "-b", "0", "-u", "-f", configFile, "GET PARENT_DATA_SET"})
 	if err != nil {
 		return "", fmt.Errorf("pmc GET PARENT_DATA_SET on %s: %v", configFile, err)
 	}

--- a/test/pkg/testconfig/testconfig.go
+++ b/test/pkg/testconfig/testconfig.go
@@ -702,11 +702,12 @@ func initAndSolveProblems() {
 
 	// T-BC with local GM: WPC NIC required, receiver, two transmitters on same NIC, local GM
 	data.problems[AlgoTelcoBCString] = &[][][]int{
-		{{int(solver.StepIsWPCNic), 1, 0}},    // step1: T-BC receiver must be on WPC NIC
-		{{int(solver.StepSameNic), 2, 0, 1}},  // step3: transmitter 1 on same NIC as receiver
-		{{int(solver.StepSameNic), 2, 0, 2}},  // step4: transmitter 2 on same NIC as receiver
-		{{int(solver.StepSameLan2), 2, 0, 3}}, // step5: local grandmaster on same LAN as receiver
-		{{int(solver.StepIsWPCNic), 1, 3}},    // step6: local grandmaster is a WPC NIC
+		{{int(solver.StepIsWPCNic), 1, 0}},   // step1: T-BC receiver must be on WPC NIC
+		{{int(solver.StepSameNic), 2, 0, 1}}, // step2: transmitter 1 on same NIC as receiver
+		{{int(solver.StepSameNic), 2, 0, 2}}, // step3: transmitter 2 on same NIC as receiver
+		{{int(solver.StepSameLan2), 2, 0, 3}, // step4: local grandmaster on same LAN as receiver
+			{int(solver.StepSameNode), 2, 0, 3, solver.Negative}}, // but NOT on the same node
+		{{int(solver.StepIsWPCNic), 1, 3}}, // step5: local grandmaster is a WPC NIC
 	}
 
 	// T-BC with external GM: WPC NIC required, PTP receiver, two transmitters on same NIC
@@ -726,7 +727,8 @@ func initAndSolveProblems() {
 		{{int(solver.StepIsWPCNic), 1, 1}},    // step4: T-BC receiver must be on WPC NIC
 		{{int(solver.StepSameNic), 2, 1, 2}},  // step5: transmitter 1 on same NIC as receiver
 		{{int(solver.StepSameNic), 2, 1, 3}},  // step6: transmitter 2 on same NIC as receiver
-		{{int(solver.StepSameLan2), 2, 1, 4}}, // step7: local grandmaster on same LAN as receiver
+		{{int(solver.StepSameLan2), 2, 1, 4}, // step7: local grandmaster on same LAN as receiver
+			{int(solver.StepSameNode), 2, 1, 4, solver.Negative}}, // but NOT on the same node
 	}
 
 	// T-BC with slaves and external GM: WPC NIC required, slave, receiver, two transmitters on same NIC
@@ -1365,11 +1367,12 @@ func PtpConfigOC(isExtGM bool) error {
 	logrus.Infof("Configuring best solution= %s", BestSolution)
 	switch BestSolution {
 	case AlgoOCString:
+		solutionIdx := preferDiffNodeSolution(BestSolution, Grandmaster, Slave1)
 		grandmaster = (*data.testClockRolesAlgoMapping[BestSolution])[Grandmaster]
 		slave1 = (*data.testClockRolesAlgoMapping[BestSolution])[Slave1]
 
-		gmIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[FirstSolution][grandmaster]]
-		slave1If := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[FirstSolution][slave1]]
+		gmIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[solutionIdx][grandmaster]]
+		slave1If := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[solutionIdx][slave1]]
 
 		err := CreatePtpConfigGrandMaster(gmIf.NodeName,
 			gmIf.IfName)
@@ -1419,12 +1422,13 @@ func PtpConfigDualFollower(isExtGM bool) error {
 	logrus.Infof("Configuring best solution= %s", BestSolution)
 	switch BestSolution {
 	case AlgoDualFollowerString:
+		solutionIdx := preferDiffNodeSolution(BestSolution, Grandmaster, Slave1)
 		grandmaster = (*data.testClockRolesAlgoMapping[BestSolution])[Grandmaster]
 		slave1 = (*data.testClockRolesAlgoMapping[BestSolution])[Slave1]
 		slave2 = (*data.testClockRolesAlgoMapping[BestSolution])[Slave2]
-		gmIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[FirstSolution][grandmaster]]
-		slave1If := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[FirstSolution][slave1]]
-		slave2If := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[FirstSolution][slave2]]
+		gmIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[solutionIdx][grandmaster]]
+		slave1If := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[solutionIdx][slave1]]
+		slave2If := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[solutionIdx][slave2]]
 
 		err := CreatePtpConfigGrandMaster(gmIf.NodeName,
 			gmIf.IfName)
@@ -1486,15 +1490,16 @@ func PtpConfigBC(isExtGM bool) error {
 	logrus.Infof("Configuring best solution= %s", BestSolution)
 	switch BestSolution {
 	case AlgoBCWithSlavesString:
+		solutionIdx := preferDiffNodeSolution(BestSolution, Grandmaster, BC1Slave, Slave1)
 		grandmaster = (*data.testClockRolesAlgoMapping[BestSolution])[Grandmaster]
 		bc1Master = (*data.testClockRolesAlgoMapping[BestSolution])[BC1Master]
 		bc1Slave = (*data.testClockRolesAlgoMapping[BestSolution])[BC1Slave]
 		slave1 = (*data.testClockRolesAlgoMapping[BestSolution])[Slave1]
 
-		gmIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[FirstSolution][grandmaster]]
-		bc1MasterIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[FirstSolution][bc1Master]]
-		bc1SlaveIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[FirstSolution][bc1Slave]]
-		slave1If := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[FirstSolution][slave1]]
+		gmIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[solutionIdx][grandmaster]]
+		bc1MasterIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[solutionIdx][bc1Master]]
+		bc1SlaveIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[solutionIdx][bc1Slave]]
+		slave1If := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[solutionIdx][slave1]]
 
 		err := CreatePtpConfigGrandMaster(gmIf.NodeName,
 			gmIf.IfName)
@@ -1515,13 +1520,14 @@ func PtpConfigBC(isExtGM bool) error {
 		}
 
 	case AlgoBCString:
+		solutionIdx := preferDiffNodeSolution(BestSolution, Grandmaster, BC1Slave)
 		grandmaster = (*data.testClockRolesAlgoMapping[BestSolution])[Grandmaster]
 		bc1Master = (*data.testClockRolesAlgoMapping[BestSolution])[BC1Master]
 		bc1Slave = (*data.testClockRolesAlgoMapping[BestSolution])[BC1Slave]
 
-		gmIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[FirstSolution][grandmaster]]
-		bc1MasterIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[FirstSolution][bc1Master]]
-		bc1SlaveIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[FirstSolution][bc1Slave]]
+		gmIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[solutionIdx][grandmaster]]
+		bc1MasterIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[solutionIdx][bc1Master]]
+		bc1SlaveIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[solutionIdx][bc1Slave]]
 
 		err := CreatePtpConfigGrandMaster(gmIf.NodeName,
 			gmIf.IfName)
@@ -1693,6 +1699,7 @@ func PtpConfigDualNicBC(isExtGM bool, phc2SysHaEnabled bool) error {
 	logrus.Infof("Configuring best solution= %s", BestSolution)
 	switch BestSolution {
 	case AlgoDualNicBCWithSlavesString:
+		solutionIdx := preferDiffNodeSolution(BestSolution, Grandmaster, BC1Slave, Slave1)
 		grandmaster = (*data.testClockRolesAlgoMapping[BestSolution])[Grandmaster]
 		bc1Master = (*data.testClockRolesAlgoMapping[BestSolution])[BC1Master]
 		bc1Slave = (*data.testClockRolesAlgoMapping[BestSolution])[BC1Slave]
@@ -1701,13 +1708,13 @@ func PtpConfigDualNicBC(isExtGM bool, phc2SysHaEnabled bool) error {
 		bc2Slave = (*data.testClockRolesAlgoMapping[BestSolution])[BC2Slave]
 		slave2 = (*data.testClockRolesAlgoMapping[BestSolution])[Slave2]
 
-		gmIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[FirstSolution][grandmaster]]
-		bc1MasterIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[FirstSolution][bc1Master]]
-		bc1SlaveIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[FirstSolution][bc1Slave]]
-		slave1If := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[FirstSolution][slave1]]
-		bc2MasterIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[FirstSolution][bc2Master]]
-		bc2SlaveIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[FirstSolution][bc2Slave]]
-		slave2If := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[FirstSolution][slave2]]
+		gmIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[solutionIdx][grandmaster]]
+		bc1MasterIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[solutionIdx][bc1Master]]
+		bc1SlaveIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[solutionIdx][bc1Slave]]
+		slave1If := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[solutionIdx][slave1]]
+		bc2MasterIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[solutionIdx][bc2Master]]
+		bc2SlaveIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[solutionIdx][bc2Slave]]
+		slave2If := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[solutionIdx][slave2]]
 
 		err := CreatePtpConfigGrandMaster(gmIf.NodeName,
 			gmIf.IfName)
@@ -1739,17 +1746,18 @@ func PtpConfigDualNicBC(isExtGM bool, phc2SysHaEnabled bool) error {
 		}
 
 	case AlgoDualNicBCString:
+		solutionIdx := preferDiffNodeSolution(BestSolution, Grandmaster, BC1Slave)
 		grandmaster = (*data.testClockRolesAlgoMapping[BestSolution])[Grandmaster]
 		bc1Master = (*data.testClockRolesAlgoMapping[BestSolution])[BC1Master]
 		bc1Slave = (*data.testClockRolesAlgoMapping[BestSolution])[BC1Slave]
 		bc2Master = (*data.testClockRolesAlgoMapping[BestSolution])[BC2Master]
 		bc2Slave = (*data.testClockRolesAlgoMapping[BestSolution])[BC2Slave]
 
-		gmIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[FirstSolution][grandmaster]]
-		bc1MasterIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[FirstSolution][bc1Master]]
-		bc1SlaveIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[FirstSolution][bc1Slave]]
-		bc2MasterIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[FirstSolution][bc2Master]]
-		bc2SlaveIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[FirstSolution][bc2Slave]]
+		gmIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[solutionIdx][grandmaster]]
+		bc1MasterIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[solutionIdx][bc1Master]]
+		bc1SlaveIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[solutionIdx][bc1Slave]]
+		bc2MasterIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[solutionIdx][bc2Master]]
+		bc2SlaveIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[solutionIdx][bc2Slave]]
 
 		err := CreatePtpConfigGrandMaster(gmIf.NodeName,
 			gmIf.IfName)
@@ -1888,6 +1896,51 @@ func PtpConfigTelcoGM(isExtGM bool) error {
 	return nil
 }
 
+// preferDiffNodeSolution selects a solver solution where the given roles are placed on
+// distinct cluster nodes. Running profiles that should be independent (e.g. a Grandmaster
+// and a Boundary Clock) on the same node causes operational issues such as the leap manager
+// losing track of the GM ptp4l config path, or event handlers conflicting.
+//
+// The function iterates through all solutions found by the graph solver for problemName
+// and returns the index of the first solution in which every role in roles maps to a
+// different node. If no such solution exists (e.g. a single-node lab), it falls back to
+// FirstSolution and logs a warning so the test can still run.
+//
+// Usage:
+//
+//	solutionIdx := preferDiffNodeSolution(BestSolution, Grandmaster, BC1Slave)
+//	solutionIdx := preferDiffNodeSolution(BestSolution, Grandmaster, BC1Slave, Slave1)
+func preferDiffNodeSolution(problemName string, roles ...TestIfClockRoles) int {
+	solutions := *data.solutions[problemName]
+	roleMapping := *data.testClockRolesAlgoMapping[problemName]
+	ifList := GlobalConfig.L2Config.GetPtpIfList()
+
+	roleIndices := make([]int, len(roles))
+	for i, r := range roles {
+		roleIndices[i] = roleMapping[int(r)]
+	}
+
+	for idx, sol := range solutions {
+		nodes := make(map[string]bool)
+		allDifferent := true
+		for _, ri := range roleIndices {
+			nodeName := ifList[sol[ri]].NodeName
+			if nodes[nodeName] {
+				allDifferent = false
+				break
+			}
+			nodes[nodeName] = true
+		}
+		if allDifferent {
+			logrus.Infof("%s: selected solution %d with roles on different nodes", problemName, idx)
+			return idx
+		}
+	}
+
+	logrus.Warnf("%s: no solution with all specified roles on different nodes, using first solution as fallback", problemName)
+	return FirstSolution
+}
+
 func PtpConfigTelcoBC(isExtGM bool) error {
 	// Select the appropriate solution based on whether external GM is used
 	BestSolution := AlgoTelcoBCString
@@ -1899,14 +1952,18 @@ func PtpConfigTelcoBC(isExtGM bool) error {
 		return fmt.Errorf("no T-BC solution found for %s", BestSolution)
 	}
 
+	// The solver's StepSameNode/Negative constraint already guarantees that the
+	// T-BC receiver and local GM are on different nodes, so no soft preference needed.
+	solutionIdx := FirstSolution
+
 	// Get interface indices
 	bc1Slave := (*data.testClockRolesAlgoMapping[BestSolution])[BC1Slave]
 	bc1Master := (*data.testClockRolesAlgoMapping[BestSolution])[BC1Master]
 	bc2Master := (*data.testClockRolesAlgoMapping[BestSolution])[BC2Master]
 
-	bc1SlaveIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[FirstSolution][bc1Slave]]
-	bc1MasterIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[FirstSolution][bc1Master]]
-	bc2MasterIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[FirstSolution][bc2Master]]
+	bc1SlaveIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[solutionIdx][bc1Slave]]
+	bc1MasterIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[solutionIdx][bc1Master]]
+	bc2MasterIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[solutionIdx][bc2Master]]
 
 	// Ensure the leading (first) interface is on the same NIC as the slave interface,
 	// using PTP capabilities collected by l2discovery-lib.
@@ -1937,7 +1994,7 @@ func PtpConfigTelcoBC(isExtGM bool) error {
 	// Create local Grandmaster if not using external GM
 	if !isExtGM {
 		grandmaster := (*data.testClockRolesAlgoMapping[BestSolution])[Grandmaster]
-		gmIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[FirstSolution][grandmaster]]
+		gmIf := GlobalConfig.L2Config.GetPtpIfList()[(*data.solutions[BestSolution])[solutionIdx][grandmaster]]
 		err = CreatePtpConfigGrandMaster(gmIf.NodeName, gmIf.IfName)
 		if err != nil {
 			logrus.Errorf("Error creating local Grandmaster ptpconfig: %s", err)

--- a/test/pkg/testconfig/testconfig_test.go
+++ b/test/pkg/testconfig/testconfig_test.go
@@ -9,10 +9,211 @@ import (
 	ptpv1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v1"
 	"github.com/k8snetworkplumbingwg/ptp-operator/test/pkg"
 	testclient "github.com/k8snetworkplumbingwg/ptp-operator/test/pkg/client"
+	l2lib "github.com/redhat-cne/l2discovery-lib"
+	"github.com/redhat-cne/l2discovery-lib/exports"
 	corev1 "k8s.io/api/core/v1"
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
+
+// mockL2Info implements l2lib.L2Info for unit testing preferDiffNodeSolution.
+type mockL2Info struct {
+	ifList []*exports.PtpIf
+}
+
+func (m *mockL2Info) GetPtpIfList() []*exports.PtpIf                    { return m.ifList }
+func (m *mockL2Info) GetPtpIfListUnfiltered() map[string]*exports.PtpIf { return nil }
+func (m *mockL2Info) GetLANs() *[][]int                                 { return nil }
+func (m *mockL2Info) GetPortsGettingPTP() []*exports.PtpIf              { return nil }
+func (m *mockL2Info) SetL2Client(kubernetes.Interface, *rest.Config)    {}
+
+func (m *mockL2Info) GetL2DiscoveryConfig(_, _, _ bool, _ string) (l2lib.L2Info, error) {
+	return m, nil
+}
+
+func makePtpIf(node, iface string) *exports.PtpIf {
+	return &exports.PtpIf{
+		IfClusterIndex: exports.IfClusterIndex{NodeName: node, InterfaceName: iface},
+	}
+}
+
+// setupPreferDiffNode wires up the package-level data and GlobalConfig so
+// preferDiffNodeSolution can run without the full solver/discovery stack.
+func setupPreferDiffNode(ifList []*exports.PtpIf, roleMap []int, solutions [][]int, problem string) {
+	data.solutions = map[string]*[][]int{problem: &solutions}
+	data.testClockRolesAlgoMapping = map[string]*[]int{problem: &roleMap}
+	GlobalConfig.L2Config = &mockL2Info{ifList: ifList}
+}
+
+// ocRoleMap returns the real OC role mapping: Slave1=0, Grandmaster=1
+func ocRoleMap() []int {
+	m := make([]int, NumTestClockRoles)
+	m[int(Slave1)] = 0
+	m[int(Grandmaster)] = 1
+	return m
+}
+
+// bcWithSlavesRoleMap returns the real BC-with-slaves mapping:
+// Slave1=0, BC1Master=1, BC1Slave=2, Grandmaster=3
+func bcWithSlavesRoleMap() []int {
+	m := make([]int, NumTestClockRoles)
+	m[int(Slave1)] = 0
+	m[int(BC1Master)] = 1
+	m[int(BC1Slave)] = 2
+	m[int(Grandmaster)] = 3
+	return m
+}
+
+func TestPreferDiffNodeSolution(t *testing.T) {
+	// Two-node lab topology modeled after real PTP CI clusters.
+	// Each node has an E810 NIC with two ports on the same PCI device.
+	twoNodeIfList := []*exports.PtpIf{
+		makePtpIf("cnfdg3.ptp.eng.rdu2.dc.redhat.com", "ens5f0"),  // 0
+		makePtpIf("cnfdg3.ptp.eng.rdu2.dc.redhat.com", "ens5f1"),  // 1
+		makePtpIf("cnfdf32.ptp.eng.rdu2.dc.redhat.com", "ens5f0"), // 2
+		makePtpIf("cnfdf32.ptp.eng.rdu2.dc.redhat.com", "ens5f1"), // 3
+	}
+
+	tests := []struct {
+		name      string
+		problem   string
+		ifList    []*exports.PtpIf
+		roleMap   []int
+		solutions [][]int
+		roles     []TestIfClockRoles
+		wantIdx   int
+	}{
+		{
+			// OC: GM on one node, Slave on another — first solution already good
+			name:    "OC with GM and Slave on different nodes picks first solution",
+			problem: AlgoOCString,
+			ifList:  twoNodeIfList,
+			roleMap: ocRoleMap(),
+			solutions: [][]int{
+				{2, 0}, // sol 0: Slave1->cnfdf32/ens5f0, GM->cnfdg3/ens5f0 — different nodes
+				{3, 1}, // sol 1: Slave1->cnfdf32/ens5f1, GM->cnfdg3/ens5f1 — different nodes
+			},
+			roles:   []TestIfClockRoles{Grandmaster, Slave1},
+			wantIdx: 0,
+		},
+		{
+			// OC: first solution has GM and Slave co-located, second splits them
+			name:    "OC skips same-node solution for GM and Slave",
+			problem: AlgoOCString,
+			ifList:  twoNodeIfList,
+			roleMap: ocRoleMap(),
+			solutions: [][]int{
+				{0, 1}, // sol 0: Slave1->cnfdg3/ens5f0, GM->cnfdg3/ens5f1 — same node
+				{0, 2}, // sol 1: Slave1->cnfdg3/ens5f0, GM->cnfdf32/ens5f0 — different nodes
+			},
+			roles:   []TestIfClockRoles{Grandmaster, Slave1},
+			wantIdx: 1,
+		},
+		{
+			// BC (without slaves): GM and BC1Slave co-located in first solution,
+			// preferDiffNodeSolution skips to the second.
+			name:    "BC skips same-node solution for GM and BC1Slave",
+			problem: AlgoBCString,
+			ifList:  twoNodeIfList,
+			roleMap: func() []int {
+				m := make([]int, NumTestClockRoles)
+				m[int(BC1Slave)] = 0
+				m[int(BC1Master)] = 1
+				m[int(Grandmaster)] = 2
+				return m
+			}(),
+			solutions: [][]int{
+				// sol 0: BC1Slave=cnfdg3, BC1Master=cnfdg3, GM=cnfdg3 — all same node
+				{0, 1, 1},
+				// sol 1: BC1Slave=cnfdg3, BC1Master=cnfdg3, GM=cnfdf32 — GM on different node
+				{0, 1, 2},
+			},
+			roles:   []TestIfClockRoles{Grandmaster, BC1Slave},
+			wantIdx: 1,
+		},
+		{
+			// OC single-node lab: only one node available. OC has no hard same-node
+			// constraint, so the solver may produce same-node solutions.
+			// preferDiffNodeSolution falls back to FirstSolution.
+			name:    "OC single-node lab falls back to FirstSolution",
+			problem: AlgoOCString,
+			ifList: []*exports.PtpIf{
+				makePtpIf("cnfdf32.ptp.eng.rdu2.dc.redhat.com", "ens5f0"), // 0
+				makePtpIf("cnfdf32.ptp.eng.rdu2.dc.redhat.com", "ens5f1"), // 1
+			},
+			roleMap: ocRoleMap(),
+			solutions: [][]int{
+				{0, 1}, // sol 0: Slave1=cnfdf32, GM=cnfdf32 — same node
+				{1, 0}, // sol 1: Slave1=cnfdf32, GM=cnfdf32 — same node
+			},
+			roles:   []TestIfClockRoles{Grandmaster, Slave1},
+			wantIdx: FirstSolution,
+		},
+		{
+			// BC with slaves: 3 roles across a two-node cluster.
+			// With only 2 nodes and 3 checked roles, no solution can split all three,
+			// so it falls back to FirstSolution.
+			name:    "BC with slaves falls back when 3 roles cannot span 2 nodes",
+			problem: AlgoBCWithSlavesString,
+			ifList:  twoNodeIfList,
+			roleMap: bcWithSlavesRoleMap(),
+			solutions: [][]int{
+				// sol 0: Slave1=cnfdg3, BC1Master=cnfdg3, BC1Slave=cnfdg3, GM=cnfdf32
+				//   GM differs from BC1Slave, but Slave1 == BC1Slave node
+				{0, 1, 0, 2},
+				// sol 1: Slave1=cnfdf32, BC1Master=cnfdf32, BC1Slave=cnfdf32, GM=cnfdg3
+				{2, 3, 2, 0},
+			},
+			roles:   []TestIfClockRoles{Grandmaster, BC1Slave, Slave1},
+			wantIdx: FirstSolution,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupPreferDiffNode(tt.ifList, tt.roleMap, tt.solutions, tt.problem)
+			got := preferDiffNodeSolution(tt.problem, tt.roles...)
+			if got != tt.wantIdx {
+				t.Errorf("preferDiffNodeSolution() = %d, want %d", got, tt.wantIdx)
+			}
+		})
+	}
+}
+
+// TestPreferDiffNodeSolution_ThreeNodeCluster models a 3-node lab where all
+// roles can land on distinct nodes. This is the ideal multi-node scenario for
+// BC-with-slaves (Grandmaster, BC1Slave, Slave1 each on a separate node).
+func TestPreferDiffNodeSolution_ThreeNodeCluster(t *testing.T) {
+	ifList := []*exports.PtpIf{
+		makePtpIf("cnfdg3.ptp.eng.rdu2.dc.redhat.com", "ens5f0"),  // 0
+		makePtpIf("cnfdg3.ptp.eng.rdu2.dc.redhat.com", "ens5f1"),  // 1
+		makePtpIf("cnfdf32.ptp.eng.rdu2.dc.redhat.com", "ens5f0"), // 2
+		makePtpIf("cnfdf32.ptp.eng.rdu2.dc.redhat.com", "ens5f1"), // 3
+		makePtpIf("cnfdf33.ptp.eng.rdu2.dc.redhat.com", "ens5f0"), // 4
+		makePtpIf("cnfdf33.ptp.eng.rdu2.dc.redhat.com", "ens5f1"), // 5
+	}
+
+	roleMap := bcWithSlavesRoleMap()
+
+	solutions := [][]int{
+		// sol 0: Slave1=cnfdg3, BC1Master=cnfdg3, BC1Slave=cnfdg3, GM=cnfdf32
+		//   Slave1 and BC1Slave on same node (cnfdg3)
+		{0, 1, 0, 2},
+		// sol 1: Slave1=cnfdf33, BC1Master=cnfdf32, BC1Slave=cnfdf32, GM=cnfdg3
+		//   BC1Slave and Slave1 on different nodes, but BC1Master and BC1Slave share cnfdf32
+		//   (BC1Master is not in the checked roles, so this is fine)
+		//   GM=cnfdg3, BC1Slave=cnfdf32, Slave1=cnfdf33 — all checked roles on different nodes
+		{4, 3, 2, 0},
+	}
+
+	setupPreferDiffNode(ifList, roleMap, solutions, AlgoBCWithSlavesString)
+	got := preferDiffNodeSolution(AlgoBCWithSlavesString, Grandmaster, BC1Slave, Slave1)
+	if got != 1 {
+		t.Errorf("preferDiffNodeSolution() = %d, want 1", got)
+	}
+}
 
 const (
 	config1    = "config1"


### PR DESCRIPTION
"GET" and "PARENT_DATA_SET" were passed as separate elements in the exec command slice. Since Kubernetes exec passes each element as a separate argument, pmc treated them as two independent (invalid) commands, producing "bad command: GET" / "bad command: PARENT_DATA_SET".

Combine into a single "GET PARENT_DATA_SET" element to match how pmc expects its command input, consistent with other PMC call sites (e.g. pmc.queryPmc, GetClockClassViaPMC).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the `pmc` command invocation so `GET PARENT_DATA_SET` is processed as a single request.
  * Improved PTP configuration selection to prefer solutions that assign clock roles to distinct nodes, with a fallback when no such solution is available.
  * Applied the improved selection across supported clock configurations, including local-grandmaster Telco BC setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->