### PR TITLE
test: fix event keying to use composite resource/dataType keys

### DIFF
--- a/test/conformance/parallel/ptp.go
+++ b/test/conformance/parallel/ptp.go
@@ -411,8 +411,10 @@ func testSyncState(soakTestConfig ptptestconfig.SoakTestConfig, fullConfig testc
 			logrus.Debugf("got %v\n", singleEvent)
 			// get event values
 			values, _ := singleEvent[exports.EventValues].(exports.StoredEventValues)
-			state, _ := values["notification"].(string)
-			clockOffset, _ := values["metric"].(float64)
+			stateVal, _ := event.ValueByDataType(values, "notification")
+			state, _ := stateVal.(string)
+			offsetVal, _ := event.ValueByDataType(values, "metric")
+			clockOffset, _ := offsetVal.(float64)
 			// create a pseudo value mapping a state to an integer (for visualization)
 			eventString := fmt.Sprintf("%s,%s,%f,%s,%d\n", singleEvent[exports.EventTimeStamp], ptpEvent.OsClockSyncStateChange, clockOffset, state, exports.ToLockStateValue[state])
 			// start counting loss of LOCK only after the clock was locked once

--- a/test/conformance/serial/ptp.go
+++ b/test/conformance/serial/ptp.go
@@ -4137,8 +4137,8 @@ func getGMEvents(
 // verifyEvent looks for a particular state (string) inside a slice of StoredEventValues
 func verifyEvent(events exports.StoredEventValues, expectedState ptpEvent.SyncState) {
 	found := false
-	if state, ok := events["notification"].(string); ok {
-		if state == string(expectedState) {
+	if stateVal, ok := event.ValueByDataType(events, "notification"); ok {
+		if state, ok := stateVal.(string); ok && state == string(expectedState) {
 			found = true
 		}
 	}
@@ -4149,8 +4149,8 @@ func verifyEvent(events exports.StoredEventValues, expectedState ptpEvent.SyncSt
 // verifyMetricThreshold checks if any event has metric within a range
 func verifyMetric(events exports.StoredEventValues, value float64) {
 	found := false
-	if metricValue, ok := events["metric"].(float64); ok {
-		if metricValue == value {
+	if metricVal, ok := event.ValueByDataType(events, "metric"); ok {
+		if metricValue, ok := metricVal.(float64); ok && metricValue == value {
 			found = true
 		}
 	}

--- a/test/pkg/event/event.go
+++ b/test/pkg/event/event.go
@@ -688,6 +688,32 @@ func PushInitialEvents(eventTypes []string, timeout time.Duration) (missing []st
 	}
 	return missing, nil
 }
+
+// compositeEventKey builds a unique map key from ResourceAddress and DataType.
+// This avoids collisions when multiple values share the same ResourceAddress
+// (e.g., OsClockSyncStateChange has both "notification" and "metric" for
+// the same CLOCK_REALTIME resource) or the same DataType (e.g., future BC
+// clock class events with metrics for different ptp4l instances).
+func compositeEventKey(resource, dataType string) string {
+	if resource == "" {
+		return dataType
+	}
+	return resource + "/" + dataType
+}
+
+// ValueByDataType finds the first value in a StoredEventValues map whose key
+// ends with "/{dataType}" or equals dataType exactly (for legacy events with
+// empty ResourceAddress).
+func ValueByDataType(values exports.StoredEventValues, dataType string) (interface{}, bool) {
+	suffix := "/" + dataType
+	for key, val := range values {
+		if strings.HasSuffix(key, suffix) || key == dataType {
+			return val, true
+		}
+	}
+	return nil, false
+}
+
 func createStoredEvent(data []byte) (aStoredEvent exports.StoredEvent, aType string, err error) {
 	apiVersion := ptphelper.PtpEventEnabled()
 	if apiVersion == 1 {
@@ -709,10 +735,7 @@ func createStoredEvent(data []byte) (aStoredEvent exports.StoredEvent, aType str
 
 		values := exports.StoredEventValues{}
 		for _, v := range e.Data.Values {
-			key := v.Resource
-			if key == "" {
-				key = string(v.DataType)
-			}
+			key := compositeEventKey(v.Resource, string(v.DataType))
 			values[key] = v.Value
 		}
 		return exports.StoredEvent{exports.EventTimeStamp: e.Time, exports.EventType: e.Type, exports.EventSource: e.Source, exports.EventValues: values}, e.Type, nil
@@ -741,13 +764,7 @@ func createStoredEvent(data []byte) (aStoredEvent exports.StoredEvent, aType str
 	}
 	values := exports.StoredEventValues{}
 	for _, v := range d.Values {
-		// Use ResourceAddress as key to avoid collisions when multiple
-		// values share the same data_type (e.g., BC mode clock class
-		// events have two "metric" values for different ptp4l instances).
-		key := v.Resource
-		if key == "" {
-			key = string(v.DataType)
-		}
+		key := compositeEventKey(v.Resource, string(v.DataType))
 		values[key] = v.Value
 	}
 	aType = e.Context.GetType()

--- a/test/pkg/event/event_test.go
+++ b/test/pkg/event/event_test.go
@@ -9,6 +9,83 @@ import (
 	"time"
 )
 
+func Test_compositeEventKey(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource string
+		dataType string
+		want     string
+	}{
+		{
+			name:     "both resource and dataType",
+			resource: "/cluster/node/master0/CLOCK_REALTIME",
+			dataType: "notification",
+			want:     "/cluster/node/master0/CLOCK_REALTIME/notification",
+		},
+		{
+			name:     "empty resource falls back to dataType",
+			resource: "",
+			dataType: "metric",
+			want:     "metric",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := compositeEventKey(tt.resource, tt.dataType)
+			if got != tt.want {
+				t.Errorf("compositeEventKey() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValueByDataType(t *testing.T) {
+	values := exports.StoredEventValues{
+		"/cluster/node/master0/CLOCK_REALTIME/notification": "LOCKED",
+		"/cluster/node/master0/CLOCK_REALTIME/metric":       float64(-4),
+	}
+
+	t.Run("finds notification by suffix", func(t *testing.T) {
+		val, ok := ValueByDataType(values, "notification")
+		if !ok {
+			t.Fatal("expected to find notification")
+		}
+		if val != "LOCKED" {
+			t.Errorf("got %v, want LOCKED", val)
+		}
+	})
+
+	t.Run("finds metric by suffix", func(t *testing.T) {
+		val, ok := ValueByDataType(values, "metric")
+		if !ok {
+			t.Fatal("expected to find metric")
+		}
+		if val != float64(-4) {
+			t.Errorf("got %v, want -4", val)
+		}
+	})
+
+	t.Run("returns false for missing dataType", func(t *testing.T) {
+		_, ok := ValueByDataType(values, "nonexistent")
+		if ok {
+			t.Error("expected not found")
+		}
+	})
+
+	t.Run("works with legacy empty-resource keys", func(t *testing.T) {
+		legacy := exports.StoredEventValues{
+			"notification": "FREERUN",
+		}
+		val, ok := ValueByDataType(legacy, "notification")
+		if !ok {
+			t.Fatal("expected to find notification")
+		}
+		if val != "FREERUN" {
+			t.Errorf("got %v, want FREERUN", val)
+		}
+	})
+}
+
 func Test_createStoredEvent(t *testing.T) {
 	type args struct {
 		data []byte
@@ -25,7 +102,7 @@ func Test_createStoredEvent(t *testing.T) {
 	}{
 		{args: args{data: []byte("{\\\"specversion\\\":\\\"0.3\\\",\\\"id\\\":\\\"f078751e-2712-4176-a66b-e8f6fc8f13ff\\\",\\\"source\\\":\\\"/cluster/node/master0/sync/sync-status/os-clock-sync-state\\\",\\\"type\\\":\\\"event.sync.sync-status.os-clock-sync-state-change\\\",\\\"subject\\\":\\\"/cluster/node/master0/sync/sync-status/os-clock-sync-state\\\",\\\"datacontenttype\\\":\\\"application/json\\\",\\\"time\\\":\\\"2023-05-10T20:25:54.453849118Z\\\",\\\"data\\\":{\\\"version\\\":\\\"v1\\\",\\\"values\\\":[{\\\"resource\\\":\\\"/cluster/node/master0/CLOCK_REALTIME\\\",\\\"dataType\\\":\\\"notification\\\",\\\"valueType\\\":\\\"enumeration\\\",\\\"value\\\":\\\"LOCKED\\\"},{\\\"resource\\\":\\\"/cluster/node/master0/CLOCK_REALTIME\\\",\\\"dataType\\\":\\\"metric\\\",\\\"valueType\\\":\\\"decimal64.3\\\",\\\"value\\\":\\\"-4\\\"}]}}")},
 			name:             "ok",
-			wantAStoredEvent: exports.StoredEvent{exports.EventTimeStamp: interface{}(&ts), exports.EventType: interface{}("event.sync.sync-status.os-clock-sync-state-change"), exports.EventSource: "/cluster/node/master0/sync/sync-status/os-clock-sync-state", exports.EventValues: exports.StoredEventValues{"notification": "LOCKED", "metric": float64(-4)}},
+			wantAStoredEvent: exports.StoredEvent{exports.EventTimeStamp: interface{}(&ts), exports.EventType: interface{}("event.sync.sync-status.os-clock-sync-state-change"), exports.EventSource: "/cluster/node/master0/sync/sync-status/os-clock-sync-state", exports.EventValues: exports.StoredEventValues{"/cluster/node/master0/CLOCK_REALTIME/notification": "LOCKED", "/cluster/node/master0/CLOCK_REALTIME/metric": float64(-4)}},
 			wantAType:        "event.sync.sync-status.os-clock-sync-state-change",
 			wantErr:          false,
 		},


### PR DESCRIPTION
The createStoredEvent function was using ResourceAddress as the sole map key, causing collisions when an event contains multiple DataValues with the same ResourceAddress but different DataTypes (e.g., OsClockSyncStateChange events have both "notification" and "metric" for CLOCK_REALTIME). The metric value would overwrite the notification, so testSyncState could never observe "LOCKED" state, leading to timeouts.

Switch to composite keys (resource/dataType) which are unique regardless of whether values share a ResourceAddress or a DataType. Add a ValueByDataType helper for consumers that look up values by DataType.

Generated-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event value lookup so state and metric data are matched more reliably, including cases with composite keys and empty resources.
  * Conformance checks now read event data more consistently during synchronization validation.

* **Tests**
  * Added coverage for new event key handling and legacy lookup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->