### PR TITLE
test: add BC reverse-sync OsClockSyncState FREERUN/LOCKED coverage

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -17,7 +17,7 @@ To run the conformance tests, first set the following environment variables:
 - **MAX_OFFSET_IN_NS**: maximum offset in nanoseconds between a master and a slave clock when testing clock accuracy. Also used as LocalMaxHoldoverOffset for E810 plugin. Default is 100
 - **MIN_OFFSET_IN_NS**: minimum offset in nanoseconds between a master and a slave clock when testing clock accuracy. Default is -100
 - **MAX_IN_SPEC_OFFSET_NS**: maximum in-spec offset in nanoseconds for E810 plugin holdover specification threshold. Default is 100
-- **ENABLE_PTP_EVENT**: enable event based tests.
+- **ENABLE_PTP_EVENT**: enable event based tests (required for OsClockSyncStateChange consumer asserts; CLOCK_REALTIME metric asserts still run without it).
 - **EVENT_API_VERSION**: passes the default REST-API version for the event based tests. Set this to "2.0" for 4.16+ PUT, "1.0" for 4.15 and earlier. If this is not set, default value "2.0" is used.
 - **ENABLE_V1_REGRESSION**: enable V1 regression for event based tests. For 4.16 and 4.17, event based tests will be repeated the second time with v1 REST-API. These tests are marked with "v1 regression".
 - **EXTERNAL_GM**: enables external grandmaster scenarios
@@ -34,6 +34,13 @@ So for instance to run in discovery mode the command line could look like this:
 ```
 KUBECONFIG="/home/user/.kube/config" PTP_TEST_MODE=Discovery make functests
 ```
+
+To exercise BC reverse-sync `os-clock-sync-state` FREERUN (serial outage recovery test) with events:
+```
+KUBECONFIG="/home/user/.kube/config" PTP_TEST_MODE=BC ENABLE_PTP_EVENT=true SKIP_INTERFACES="eno1,ens2f1" make functests
+```
+(`DualNICBC` is also valid; DualNICBCHA is skipped for this It. Needs a cloud-event-proxy build with reverse-sync FREERUN detection.
+Kind/netdevsim CI skips this It: `DisableAllSlaveRTUpdate` strips `-a -r`, and workers share host `CLOCK_REALTIME`.)
 
 To run all the tests
 ```

--- a/test/conformance/serial/ptp.go
+++ b/test/conformance/serial/ptp.go
@@ -2302,13 +2302,14 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 			// (PHC ← CLOCK_REALTIME) and stop emitting CLOCK_REALTIME phc offset.
 			// cloud-event-proxy must publish os-clock-sync-state FREERUN.
 			//
-			// Run with: PTP_TEST_MODE=BC (or DualNICBC) ENABLE_PTP_EVENT=true SKIP_INTERFACES=<mgmt,...>
+			// Run with: PTP_TEST_MODE=BC|DualNICBC|TBC (or Discovery of those) ENABLE_PTP_EVENT=true SKIP_INTERFACES=<mgmt,...>
 			// Requires a cloud-event-proxy build that includes reverse-sync FREERUN detection.
 			// Skips on Kind/netdevsim when phc2sysOpts lacks -a -r or CLOCK_REALTIME metric is absent.
 			It("OsClockSyncState goes FREERUN on BC upstream loss and recovers to LOCKED", func() {
 				if fullConfig.PtpModeDiscovered != testconfig.BoundaryClock &&
-					fullConfig.PtpModeDiscovered != testconfig.DualNICBoundaryClock {
-					Skip("test only valid for BC and DualNICBC (not DualNICBCHA HA)")
+					fullConfig.PtpModeDiscovered != testconfig.DualNICBoundaryClock &&
+					fullConfig.PtpModeDiscovered != testconfig.TelcoBoundaryClock {
+					Skip("test only valid for BC, DualNICBC, and T-BC (not DualNICBCHA HA)")
 				}
 				if !bcProfileHasNetworkDisciplinedOsClock((*ptpv1.PtpConfig)(fullConfig.DiscoveredClockUnderTestPtpConfig)) {
 					Skip("requires phc2sysOpts with -a -r for CLOCK_REALTIME reverse-sync; " +

--- a/test/conformance/serial/ptp.go
+++ b/test/conformance/serial/ptp.go
@@ -2294,6 +2294,115 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 				logrus.Info("Successfully verified T-BC clock class recovery after upstream link outage")
 			})
 
+			// OsClockSyncState goes FREERUN when BC upstream is lost (reverse phc2sys)
+			// and recovers to LOCKED when the link is restored.
+			//
+			// Reproduces Case 04504543 / reverse-sync regression after OCPBUGS-88369:
+			// with phc2sysOpts -a -r, losing the BC slave causes phc2sys to reverse
+			// (PHC ← CLOCK_REALTIME) and stop emitting CLOCK_REALTIME phc offset.
+			// cloud-event-proxy must publish os-clock-sync-state FREERUN.
+			//
+			// Run with: PTP_TEST_MODE=BC (or DualNICBC) ENABLE_PTP_EVENT=true SKIP_INTERFACES=<mgmt,...>
+			// Requires a cloud-event-proxy build that includes reverse-sync FREERUN detection.
+			// Skips on Kind/netdevsim when phc2sysOpts lacks -a -r or CLOCK_REALTIME metric is absent.
+			It("OsClockSyncState goes FREERUN on BC upstream loss and recovers to LOCKED", func() {
+				if fullConfig.PtpModeDiscovered != testconfig.BoundaryClock &&
+					fullConfig.PtpModeDiscovered != testconfig.DualNICBoundaryClock {
+					Skip("test only valid for BC and DualNICBC (not DualNICBCHA HA)")
+				}
+				if !bcProfileHasNetworkDisciplinedOsClock((*ptpv1.PtpConfig)(fullConfig.DiscoveredClockUnderTestPtpConfig)) {
+					Skip("requires phc2sysOpts with -a -r for CLOCK_REALTIME reverse-sync; " +
+						"skipped on Kind/netdevsim where DisableAllSlaveRTUpdate strips RT sync " +
+						"(shared host CLOCK_REALTIME)")
+				}
+
+				skippedInterfacesStr, isSet := os.LookupEnv("SKIP_INTERFACES")
+				if !isSet {
+					Skip("Mandatory to provide skipped interface to avoid making a node disconnected from the cluster")
+				}
+				skipInterfaces := make(map[string]bool)
+				for _, val := range strings.Split(skippedInterfacesStr, ",") {
+					skipInterfaces[val] = true
+				}
+
+				slaveIf := ptpv1.GetInterfaces((ptpv1.PtpConfig)(*fullConfig.DiscoveredClockUnderTestPtpConfig), ptpv1.Slave)
+				if fullConfig.PtpModeDiscovered == testconfig.DualNICBoundaryClock {
+					Expect(fullConfig.DiscoveredClockUnderTestSecondaryPtpConfig).NotTo(BeNil(),
+						"secondary PtpConfig required for dual-NIC BC outage tests")
+					secondarySlaveIf := ptpv1.GetInterfaces((ptpv1.PtpConfig)(*fullConfig.DiscoveredClockUnderTestSecondaryPtpConfig), ptpv1.Slave)
+					slaveIf = append(slaveIf, secondarySlaveIf...)
+				}
+				Expect(slaveIf).ToNot(BeEmpty(), "no slave interfaces found in the clock-under-test PtpConfig(s)")
+
+				nodeName := fullConfig.DiscoveredClockUnderTestPod.Spec.NodeName
+
+				By("Probing CLOCK_REALTIME/phc2sys metric availability")
+				if !clockRealTimeMetricAvailable(nodeName, 30*time.Second) {
+					Skip("openshift_ptp_clock_state{iface=CLOCK_REALTIME,process=phc2sys} not available; " +
+						"Kind/netdevsim typically omits or neuters phc2sys because workers share host CLOCK_REALTIME")
+				}
+
+				portEngine.Initialize(fullConfig.DiscoveredClockUnderTestPod, slaveIf)
+				DeferCleanup(func() {
+					ptptesthelper.DeletePtpTestPrivilegedDaemonSet(
+						pkg.RecoveryNetworkOutageDaemonSetName,
+						pkg.RecoveryNetworkOutageDaemonSetNamespace,
+					)
+				})
+
+				evCtx := setupOsClockSyncStateEvents(nodeName)
+
+				By("Checking initial CLOCK_REALTIME / OsClockSyncState is LOCKED")
+				Eventually(func() error {
+					return metrics.CheckClockRealTimeState(metrics.MetricClockStateLocked, &nodeName)
+				}, pkg.TimeoutIn5Minutes, pkg.Timeout10Seconds).Should(Succeed(),
+					"CLOCK_REALTIME must be LOCKED before outage")
+				if evCtx.available {
+					Expect(event.PushInitialEvent(string(ptpEvent.OsClockSyncStateChange), 30*time.Second)).To(Succeed())
+					waitForOsClockSyncState(evCtx.ch, ptpEvent.LOCKED, pkg.TimeoutIn3Minutes)
+				}
+
+				By("Taking all BC slave interfaces down to force phc2sys reverse-sync")
+				outageStart := time.Now()
+				err := portEngine.TurnAllPortsDown(skipInterfaces)
+				Expect(err).To(BeNil())
+				DeferCleanup(func() {
+					_ = portEngine.TurnAllPortsUp()
+				})
+
+				By("Correlating phc2sys reverse-sync log signals (best-effort)")
+				correlatePhc2sysReverseSync(fullConfig.DiscoveredClockUnderTestPod, outageStart)
+
+				By("Checking CLOCK_REALTIME metric is FREERUN after upstream loss")
+				Eventually(func() error {
+					return metrics.CheckClockRealTimeState(metrics.MetricClockStateFreeRun, &nodeName)
+				}, pkg.TimeoutIn5Minutes, pkg.Timeout10Seconds).Should(Succeed(),
+					"CLOCK_REALTIME must go FREERUN when BC upstream is lost (reverse phc2sys); "+
+						"stuck LOCKED indicates missing reverse-sync detection in cloud-event-proxy")
+
+				if evCtx.available {
+					By("Checking OsClockSyncStateChange event is FREERUN")
+					waitForOsClockSyncState(evCtx.ch, ptpEvent.FREERUN, pkg.TimeoutIn5Minutes)
+				}
+
+				By("Restoring all BC slave interfaces")
+				err = portEngine.TurnAllPortsUp()
+				Expect(err).To(BeNil())
+
+				By("Checking CLOCK_REALTIME metric recovers to LOCKED")
+				Eventually(func() error {
+					return metrics.CheckClockRealTimeState(metrics.MetricClockStateLocked, &nodeName)
+				}, pkg.TimeoutIn5Minutes, pkg.Timeout10Seconds).Should(Succeed(),
+					"CLOCK_REALTIME must return to LOCKED after upstream recovers")
+
+				if evCtx.available {
+					By("Checking OsClockSyncStateChange event recovers to LOCKED")
+					waitForOsClockSyncState(evCtx.ch, ptpEvent.LOCKED, pkg.TimeoutIn5Minutes)
+				}
+
+				logrus.Info("Successfully verified OsClockSyncState FREERUN/LOCKED around BC reverse-sync outage")
+			})
+
 			It("Should restart ptp4l with no socket errors after SIGTERM", func() {
 				verifyProcessRestartNoSocketErrors(fullConfig, "ptp4l")
 			})
@@ -4206,6 +4315,160 @@ func waitForStateAndCC(subs event.Subscriptions, state ptpEvent.SyncState, cc in
 type bcEventContext struct {
 	subs      event.Subscriptions
 	available bool
+}
+
+// bcProfileHasNetworkDisciplinedOsClock reports whether a BC PtpConfig runs
+// phc2sys in automatic mode with CLOCK_REALTIME updates (-a -r). Kind/netdevsim
+// CI sets DisableAllSlaveRTUpdate, which replaces those opts with "-v".
+func bcProfileHasNetworkDisciplinedOsClock(ptpConfig *ptpv1.PtpConfig) bool {
+	if ptpConfig == nil {
+		return false
+	}
+	for i := range ptpConfig.Spec.Profile {
+		opts := ptpConfig.Spec.Profile[i].Phc2sysOpts
+		if opts == nil || *opts == "" {
+			continue
+		}
+		// Field-split so "-r" matches a real flag, not a substring of another opt.
+		hasA, hasR := false, false
+		for _, f := range strings.Fields(*opts) {
+			switch f {
+			case "-a":
+				hasA = true
+			case "-r":
+				hasR = true
+			}
+		}
+		if hasA && hasR {
+			return true
+		}
+	}
+	return false
+}
+
+// clockRealTimeMetricAvailable returns true if CLOCK_REALTIME/phc2sys clock_state
+// is present with any recognized state within timeout.
+func clockRealTimeMetricAvailable(nodeName string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	states := []metrics.MetricClockState{
+		metrics.MetricClockStateLocked,
+		metrics.MetricClockStateFreeRun,
+		metrics.MetricClockStateHoldOver,
+	}
+	for time.Now().Before(deadline) {
+		for _, st := range states {
+			if err := metrics.CheckClockRealTimeState(st, &nodeName); err == nil {
+				return true
+			}
+		}
+		time.Sleep(2 * time.Second)
+	}
+	return false
+}
+
+// osClockEventContext holds an OsClockSyncStateChange subscription for BC
+// reverse-sync outage tests.
+type osClockEventContext struct {
+	ch        <-chan exports.StoredEvent
+	available bool
+}
+
+// setupOsClockSyncStateEvents deploys the consumer, subscribes to
+// OsClockSyncStateChange, and starts log monitoring. When ENABLE_PTP_EVENT
+// is unset or setup fails, available is false and callers rely on metrics.
+func setupOsClockSyncStateEvents(nodeName string) osClockEventContext {
+	ctx := osClockEventContext{}
+	if !event.Enable() {
+		logrus.Info("ENABLE_PTP_EVENT not set; OsClockSyncStateChange checks will be skipped (metric asserts still run)")
+		return ctx
+	}
+	logrus.Info("Deploy consumer app for OsClockSyncStateChange monitoring")
+	if createErr := event.CreateConsumerApp(nodeName); createErr != nil {
+		logrus.Warnf("PTP events not available: %s; skipping OsClockSyncStateChange checks", createErr)
+		return ctx
+	}
+	if waitErr := event.WaitForConsumerReady(nodeName); waitErr != nil {
+		logrus.Warnf("Consumer app not ready: %s; skipping OsClockSyncStateChange checks", waitErr)
+		return ctx
+	}
+	event.InitPubSub()
+	const incomingEventsBuffer = 100
+	ch, subscriberID := event.PubSub.Subscribe(string(ptpEvent.OsClockSyncStateChange), incomingEventsBuffer)
+	termMonitor, monErr := event.MonitorPodLogsRegex()
+	if monErr != nil {
+		logrus.Warnf("Could not start event monitoring: %s; skipping OsClockSyncStateChange checks", monErr)
+		event.PubSub.Unsubscribe(string(ptpEvent.OsClockSyncStateChange), subscriberID)
+		event.PubSub.Close()
+		if deleteErr := event.DeleteConsumerNamespace(); deleteErr != nil {
+			logrus.Debugf("Deleting consumer namespace failed: %s", deleteErr)
+		}
+		return ctx
+	}
+	ctx.ch = ch
+	ctx.available = true
+	DeferCleanup(func() {
+		stopMonitor(termMonitor)
+		event.PubSub.Unsubscribe(string(ptpEvent.OsClockSyncStateChange), subscriberID)
+		event.PubSub.Close()
+		if deleteErr := event.DeleteConsumerNamespace(); deleteErr != nil {
+			logrus.Debugf("Deleting consumer namespace failed: %s", deleteErr)
+		}
+	})
+	return ctx
+}
+
+// waitForOsClockSyncState waits until an OsClockSyncStateChange notification
+// matches the expected sync state.
+func waitForOsClockSyncState(ch <-chan exports.StoredEvent, expected ptpEvent.SyncState, timeout time.Duration) {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	for {
+		select {
+		case <-timer.C:
+			Fail(fmt.Sprintf("Timed out waiting for OsClockSyncStateChange %s", expected))
+			return
+		case ev := <-ch:
+			res, ok := processEvent(ptpEvent.OsClockSyncStateChange, ev)
+			if !ok {
+				continue
+			}
+			stateVal, ok := event.ValueByDataType(res.Values, "notification")
+			if !ok {
+				continue
+			}
+			state, ok := stateVal.(string)
+			if ok && state == string(expected) {
+				fmt.Fprintf(GinkgoWriter, "OsClockSyncStateChange %s verified via Event API\n", expected)
+				return
+			}
+		}
+	}
+}
+
+// correlatePhc2sysReverseSync best-effort checks daemon logs for reverse-sync
+// signals after an outage. Hard assertions remain on CLOCK_REALTIME metrics/events.
+func correlatePhc2sysReverseSync(pod *v1core.Pod, since time.Time) {
+	if pod == nil {
+		return
+	}
+	// Match linuxptp 4.4 phc2sys reverse-sync signals: reconfigure, selecting
+	// <iface> for synchronization, dual-port "already selected", or sys offset.
+	const reverseSyncPattern = `phc2sys(?m).*?(?:reconfiguring after port state change|sys offset|selecting \S+ for synchronization|already selected)`
+	matches, err := pods.GetPodLogsRegexSince(
+		pod.Namespace,
+		pod.Name,
+		pkg.PtpContainerName,
+		reverseSyncPattern,
+		false,
+		pkg.TimeoutIn1Minute,
+		since,
+	)
+	if err != nil || len(matches) == 0 {
+		logrus.Warnf("phc2sys reverse-sync log correlate: no reconfiguring/selection/sys offset lines yet (logReduce may hide them): err=%v", err)
+		return
+	}
+	logrus.Infof("phc2sys reverse-sync correlate: saw %d matching log line(s), last=%q",
+		len(matches), matches[len(matches)-1][0])
 }
 
 // setupBCClockClassEvents creates the consumer app, initializes PubSub,

--- a/test/pkg/metrics/metrics.go
+++ b/test/pkg/metrics/metrics.go
@@ -135,6 +135,53 @@ func CheckClockState(state MetricClockState, aIf string, nodeName *string) (err 
 	return nil
 }
 
+// CheckClockRealTimeState verifies openshift_ptp_clock_state for
+// iface=CLOCK_REALTIME, process=phc2sys on the given node.
+func CheckClockRealTimeState(state MetricClockState, nodeName *string) error {
+	if nodeName == nil || *nodeName == "" {
+		return fmt.Errorf("nodeName is required")
+	}
+	ptpPods, err := client.Client.CoreV1().Pods(pkg.PtpLinuxDaemonNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: "app=linuxptp-daemon"})
+	if err != nil {
+		return err
+	}
+	for index := range ptpPods.Items {
+		if ptpPods.Items[index].Spec.NodeName != *nodeName {
+			continue
+		}
+		buf, _, err := pods.ExecCommand(client.Client, false, &ptpPods.Items[index], ptpPods.Items[index].Spec.Containers[0].Name, []string{"curl", "-s", metricsEndPoint})
+		if err != nil {
+			return fmt.Errorf("error fetching metrics for CLOCK_REALTIME: %w", err)
+		}
+		metricsText := buf.String()
+		for _, line := range strings.Split(metricsText, "\n") {
+			if !strings.HasPrefix(line, OpenshiftPtpClockState+"{") {
+				continue
+			}
+			if !strings.Contains(line, `iface="CLOCK_REALTIME"`) ||
+				!strings.Contains(line, `process="phc2sys"`) ||
+				!strings.Contains(line, fmt.Sprintf(`node="%s"`, *nodeName)) {
+				continue
+			}
+			parts := strings.Fields(line)
+			if len(parts) != 2 {
+				continue
+			}
+			clockStateInt, err := strconv.Atoi(parts[1])
+			if err != nil {
+				return fmt.Errorf("error strconv for CLOCK_REALTIME clock state %q: %w", parts[1], err)
+			}
+			if MetricClockState(clockStateInt) != state {
+				return fmt.Errorf("CLOCK_REALTIME clock state expected=%d(%s) observed=%d(%s)",
+					state, state.String(), clockStateInt, MetricClockState(clockStateInt).String())
+			}
+			return nil
+		}
+		return fmt.Errorf("openshift_ptp_clock_state iface=CLOCK_REALTIME process=phc2sys not found on node %s", *nodeName)
+	}
+	return fmt.Errorf("linuxptp-daemon pod not found on node %s", *nodeName)
+}
+
 // This method checks the state of the clock with specified interface
 func CheckClockRole(roles []MetricRole, Ifs []string, nodeName *string) (err error) {
 	if len(roles) != len(Ifs) {

--- a/test/pkg/testconfig/testconfig.go
+++ b/test/pkg/testconfig/testconfig.go
@@ -2212,6 +2212,17 @@ func discoverMode(ptpConfigClockUnderTest []*ptpv1.PtpConfig) {
 		allMasterIfs = append(allMasterIfs, masterIfStrings...)
 		allFollowerIfs = append(allFollowerIfs, followerIfStrings...)
 
+		logrus.Infof("ptptConfig: %s, masterIfCount: %d, slaveIfCount: %d", ptpConfig.Name, masterIfCount, slaveIfCount)
+
+		// T-BC before OC/DualFollower: TR profile alone looks like a single-slave OC.
+		if isTelcoBoundaryClockConfig(ptpConfig) {
+			GlobalConfig.DiscoveredClockUnderTestPtpConfig = (*ptpDiscoveryRes)(ptpConfig)
+			GlobalConfig.PtpModeDiscovered = TelcoBoundaryClock
+			GlobalConfig.Status = DiscoverySuccessStatus
+			logrus.Info("Detected T-BC configuration with receiver/transmitter profiles")
+			continue
+		}
+
 		// OC
 		if masterIfCount == 0 && slaveIfCount == 1 && len(ptpConfigClockUnderTest) == 1 {
 			GlobalConfig.PtpModeDiscovered = OrdinaryClock
@@ -2226,7 +2237,6 @@ func discoverMode(ptpConfigClockUnderTest []*ptpv1.PtpConfig) {
 			GlobalConfig.DiscoveredClockUnderTestPtpConfig = (*ptpDiscoveryRes)(ptpConfig)
 			break
 		}
-		logrus.Infof("ptptConfig: %s, masterIfCount: %d, slaveIfCount: %d", ptpConfig.Name, masterIfCount, slaveIfCount)
 		// BC, Dual NIC BC and Dual NIC BC HA
 		if masterIfCount >= 1 && slaveIfCount >= 1 {
 			if numBc == 0 {
@@ -2241,29 +2251,6 @@ func discoverMode(ptpConfigClockUnderTest []*ptpv1.PtpConfig) {
 			}
 		} else if ptphelper.ConfigIsPhc2SysHa(ptpConfig) {
 			numPhc2SysHa++
-		}
-
-		// T-BC state: Check for two profiles (tbc-tr and tbc-tt)
-		if len(ptpConfig.Spec.Profile) == 2 {
-			hasTbcTr := false
-			hasTbcTt := false
-			for _, profile := range ptpConfig.Spec.Profile {
-				if profile.Name != nil {
-					q := ptphelper.QualifyProfileName(ptpConfig.Name, *profile.Name)
-					if q == ptphelper.QualifyProfileName(ptpConfig.Name, "tbc-tr") {
-						hasTbcTr = true
-					} else if q == ptphelper.QualifyProfileName(ptpConfig.Name, "tbc-tt") {
-						hasTbcTt = true
-					}
-				}
-			}
-			if hasTbcTr && hasTbcTt {
-				GlobalConfig.DiscoveredClockUnderTestPtpConfig = (*ptpDiscoveryRes)(ptpConfig)
-				GlobalConfig.PtpModeDiscovered = TelcoBoundaryClock
-				GlobalConfig.Status = DiscoverySuccessStatus
-				logrus.Info("Detected T-BC configuration with tbc-tr and tbc-tt profiles")
-				continue
-			}
 		}
 
 		//WPC GM state
@@ -2301,6 +2288,39 @@ func discoverMode(ptpConfigClockUnderTest []*ptpv1.PtpConfig) {
 	GlobalConfig.DiscoveredClockUnderTestPod = pod
 	GlobalConfig.DiscoveredFollowerInterfaces = allFollowerIfs
 	GlobalConfig.DiscoveredMasterInterfaces = allMasterIfs
+}
+
+// isTelcoBoundaryClockConfig reports whether a PtpConfig is a T-BC with paired
+// receiver/transmitter profiles. Accepts factory names (tbc-tr/tbc-tt),
+// qualified names (<cr>_tbc-tr), and dated suffixes (…-tr/…-tt), or clockType=T-BC.
+func isTelcoBoundaryClockConfig(ptpConfig *ptpv1.PtpConfig) bool {
+	if ptpConfig == nil || len(ptpConfig.Spec.Profile) != 2 {
+		return false
+	}
+	hasTbcTr, hasTbcTt, hasClockTypeTBC := false, false, false
+	for _, profile := range ptpConfig.Spec.Profile {
+		if profile.PtpSettings != nil && strings.EqualFold(profile.PtpSettings["clockType"], "T-BC") {
+			hasClockTypeTBC = true
+		}
+		if profile.Name == nil {
+			continue
+		}
+		name := *profile.Name
+		q := ptphelper.QualifyProfileName(ptpConfig.Name, name)
+		switch {
+		case q == ptphelper.QualifyProfileName(ptpConfig.Name, "tbc-tr"),
+			name == "tbc-tr",
+			strings.HasSuffix(name, "_tbc-tr"),
+			strings.HasSuffix(name, "-tr"):
+			hasTbcTr = true
+		case q == ptphelper.QualifyProfileName(ptpConfig.Name, "tbc-tt"),
+			name == "tbc-tt",
+			strings.HasSuffix(name, "_tbc-tt"),
+			strings.HasSuffix(name, "-tt"):
+			hasTbcTt = true
+		}
+	}
+	return (hasTbcTr && hasTbcTt) || hasClockTypeTBC
 }
 
 func GetPodsRunningPTP4l(fullConfig *TestConfig) (podList []*v1core.Pod, err error) {


### PR DESCRIPTION
## Summary
- Add serial e2e coverage for BC reverse sync under `phc2sysOpts: -a -r`: assert `OsClockSyncState` goes FREERUN on upstream loss and recovers to LOCKED
- Correlate linuxptp 4.4 phc2sys selection log signals used by the cloud-event-proxy reverse-sync detector
- Companion fix: https://github.com/redhat-cne/cloud-event-proxy/pull/731 (OCPBUGS-105425)

## Test plan
- [x] Serial e2e BC reverse-sync outage run (`run_2026-08-07_12-03-41`): FREERUN then LOCKED recovery observed

Assisted-By: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added conformance coverage for BC reverse-sync outages, validating `CLOCK_REALTIME` transitions between LOCKED and FREERUN states during failures and recovery.
  * Added validation for `phc2sys` clock-state metrics, with clearer diagnostics for unavailable or invalid metric data.
  * Improved detection of Telco Boundary Clock configurations across supported profile naming formats.

* **Documentation**
  * Clarified event requirements for clock synchronization assertions.
  * Added an example command for testing reverse-sync recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->