### PR TITLE
ci: add per-node virtual CLOCK_REALTIME for netdevsim DKMS CI

### DIFF
--- a/ptp-tools/Dockerfile.lptpd
+++ b/ptp-tools/Dockerfile.lptpd
@@ -20,6 +20,17 @@ RUN if [ -n "${LINUXPTP_RPM}" ]; then \
       && rm -rf /tmp/extra; \
     fi
 
+# CI stand-in virtual CLOCK_REALTIME: phc2sys wrapper + LD_PRELOAD shim.
+# Active only when /var/run/vrt/device (or PTP_VRT_PHC) points at a mock PHC.
+COPY scripts/ptp-vrt/ /tmp/ptp-vrt/
+RUN yum -y install gcc make && \
+    make -C /tmp/ptp-vrt && \
+    install -m 755 /tmp/ptp-vrt/libptp_vrt_shim.so /usr/local/lib/ && \
+    mv /usr/sbin/phc2sys /usr/sbin/phc2sys.real && \
+    install -m 755 /tmp/ptp-vrt/phc2sys-wrapper /usr/sbin/phc2sys && \
+    rm -rf /tmp/ptp-vrt && \
+    yum -y remove gcc make && yum clean all
+
 RUN ln -sf /usr/bin/gpspipe /usr/local/bin/gpspipe && \
     ln -sf /usr/sbin/gpsd /usr/local/sbin/gpsd && \
     ln -sf /usr/bin/ubxtool /usr/local/bin/ubxtool

--- a/scripts/create-vrt-clocks.sh
+++ b/scripts/create-vrt-clocks.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# Create per-node stand-in mock PHCs that act as virtual CLOCK_REALTIME targets
+# for Kind/netdevsim CI (used with the phc2sys LD_PRELOAD shim).
+#
+# Usage:
+#   ./create-vrt-clocks.sh [node1] [node2] [node3]
+# Defaults: kind-netdevsim-worker kind-netdevsim-worker2 kind-netdevsim-worker3
+#
+# For each node, creates a 1-port netdevsim device with a unique logical clock,
+# writes /var/run/ptp/vrt/device inside that Kind node (seen by linuxptp pods as
+# /var/run/vrt/device via the existing hostPath mount).
+
+set -euo pipefail
+
+if [[ $# -eq 0 ]]; then
+	NODES=(kind-netdevsim-worker kind-netdevsim-worker2 kind-netdevsim-worker3)
+else
+	NODES=("$@")
+fi
+
+ARCH=$(uname -m)
+if [[ "$ARCH" == "x86_64" ]]; then
+	PCI_PREFIX="0000:1f"
+elif [[ "$ARCH" == "aarch64" ]]; then
+	PCI_PREFIX="0001:1f"
+else
+	echo "Unsupported architecture: $ARCH" >&2
+	exit 1
+fi
+
+NSIM_NEW=/sys/bus/netdevsim/new_device
+NSIM_DEL=/sys/bus/netdevsim/del_device
+
+# Reserved IDs well above the topology devices (1..18) in configSwitch2.sh.
+BASE_ID=90
+# PCI function slot 0x10+ also above topology (0x01..0x0f).
+BASE_FUNC=0x10
+
+runtime_exec() {
+	local name=$1
+	shift
+	if podman inspect "$name" &>/dev/null; then
+		podman exec "$name" "$@"
+	elif docker inspect "$name" &>/dev/null; then
+		docker exec "$name" "$@"
+	else
+		echo "Error: Kind node container '$name' not found" >&2
+		return 1
+	fi
+}
+
+# PCI-backed netdevsim (dkms) exposes netdevs under /sys/bus/pci/devices/<pci>/net.
+# Upstream-style netdevsim uses /sys/bus/netdevsim/devices/netdevsim<id>/net.
+iface_for_nsim() {
+	local nsim_id=$1
+	local pci=$2
+	local netdir iface
+
+	for netdir in "/sys/bus/pci/devices/${pci}/net" \
+		"/sys/bus/netdevsim/devices/netdevsim${nsim_id}/net"; do
+		[[ -d "$netdir" ]] || continue
+		iface=$(find "$netdir" -maxdepth 1 -mindepth 1 -type d -printf '%f\n' | head -1)
+		if [[ -n "$iface" ]]; then
+			echo "$iface"
+			return 0
+		fi
+	done
+	return 1
+}
+
+phc_index_for_iface() {
+	local nsim_id=$1
+	local iface=$2
+	local idx
+	idx=$(ethtool -T "$iface" 2>/dev/null | awk '/PTP Hardware Clock:/ {print $4}')
+	if [[ -z "$idx" || "$idx" == "none" ]]; then
+		echo "Error: no PHC on $iface (netdevsim${nsim_id})" >&2
+		return 1
+	fi
+	echo "$idx"
+}
+
+i=0
+for node in "${NODES[@]}"; do
+	id=$((BASE_ID + i))
+	clk=$id
+	func=$((BASE_FUNC + i))
+	pci=$(printf '%s:%02x.0' "$PCI_PREFIX" "$func")
+
+	# Replace any previous VRT device with this id.
+	echo "$id" >"$NSIM_DEL" 2>/dev/null || true
+	# Match configpair.sh: id pci clk (port_count defaults to 1 in the driver).
+	if ! echo "$id $pci $clk" >"$NSIM_NEW"; then
+		echo "Error: failed to create netdevsim id=$id pci=$pci" >&2
+		exit 1
+	fi
+	udevadm settle 2>/dev/null || sleep 0.5
+
+	iface=$(iface_for_nsim "$id" "$pci") || {
+		echo "Error: no netdev for netdevsim${id} (pci=$pci)" >&2
+		exit 1
+	}
+	phc=$(phc_index_for_iface "$id" "$iface")
+	dev="/dev/ptp${phc}"
+	if [[ ! -e "$dev" ]]; then
+		echo "Error: $dev does not exist after creating netdevsim${id}" >&2
+		exit 1
+	fi
+	# Restrict to owner/group; privileged linuxptp-daemon can still open it.
+	# Avoid world-writable /dev/nsim_ptp* so unprivileged processes cannot skew VRT.
+	chmod 660 "$dev" 2>/dev/null || true
+
+	# Keep the unused netdev down; only the PHC chardev is needed.
+	ip link set dev "$iface" down 2>/dev/null || true
+
+	# Node-local path under the hostPath root used by linuxptp-daemon (/var/run/ptp).
+	runtime_exec "$node" mkdir -p /var/run/ptp/vrt
+	runtime_exec "$node" bash -c "echo -n '$dev' > /var/run/ptp/vrt/device"
+	runtime_exec "$node" bash -c "ln -sfn '$dev' /var/run/ptp/vrt/ptpRT"
+
+	echo "VRT: node=$node nsim=$id pci=$pci clk=$clk iface=$iface phc=$dev"
+	i=$((i + 1))
+done
+
+echo "Created ${i} virtual RT stand-in PHC(s)"

--- a/scripts/deploy-prometheus.sh
+++ b/scripts/deploy-prometheus.sh
@@ -5,11 +5,20 @@ set -euo pipefail
 VM_IP=$1
 
 # Create a "3.4.2" registry tag for the prometheus image.
-# `podman tag` + `podman push` doesn't work when the image was built as a
-# manifest list (the default for non-CI builds) because podman may have pruned
-# the underlying image blobs that the manifest index references.
-skopeo copy --src-tls-verify=false --dest-tls-verify=false \
-    "docker://${VM_IP}/test:prometheus" "docker://${VM_IP}/test:3.4.2"
+# Prefer skopeo: `podman tag` + `podman push` can fail when the image was built
+# as a manifest list (non-CI default) if podman pruned the underlying blobs.
+if command -v skopeo >/dev/null 2>&1; then
+    skopeo copy --src-tls-verify=false --dest-tls-verify=false \
+        "docker://${VM_IP}/test:prometheus" "docker://${VM_IP}/test:3.4.2"
+elif command -v podman >/dev/null 2>&1; then
+    echo "skopeo not found; falling back to podman pull/tag/push"
+    podman pull --tls-verify=false "${VM_IP}/test:prometheus"
+    podman tag "${VM_IP}/test:prometheus" "${VM_IP}/test:3.4.2"
+    podman push --tls-verify=false "${VM_IP}/test:3.4.2"
+else
+    echo "ERROR: need skopeo or podman to retag prometheus image" >&2
+    exit 127
+fi
 
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm repo add stable https://charts.helm.sh/stable

--- a/scripts/install-tools.sh
+++ b/scripts/install-tools.sh
@@ -33,6 +33,9 @@ if [[ "${DKMS_MODE:-}" == "true" ]]; then
         # non-running kernels, which fails if the DKMS module can't build
         # against that kernel. Allow apt-get to exit non-zero from the DKMS
         # hook, but verify every required package actually installed.
+        # Keep skopeo out of the required set: on Ubuntu CI it can pull
+        # containers-common with unmet oci-runtime deps and abort the whole
+        # apt transaction (leaving openvswitch-switch uninstalled).
         REQUIRED_PKGS=(podman pciutils openvswitch-switch git openssl)
         apt-get install --fix-broken -y "${REQUIRED_PKGS[@]}" || true
         for pkg in "${REQUIRED_PKGS[@]}"; do
@@ -42,8 +45,13 @@ if [[ "${DKMS_MODE:-}" == "true" ]]; then
                 exit 1
             fi
         done
+        # Optional: deploy-prometheus falls back to podman when skopeo is absent.
+        apt-get install --fix-broken -y skopeo || \
+            echo "WARNING: skopeo not installed; deploy-prometheus will use podman fallback"
     else
         dnf install -y podman pciutils openvswitch git openssl
+        dnf install -y skopeo || \
+            echo "WARNING: skopeo not installed; deploy-prometheus will use podman fallback"
     fi
 
     # kubectl

--- a/scripts/k8s-start.sh
+++ b/scripts/k8s-start.sh
@@ -58,3 +58,8 @@ kubectl create namespace openshift-ptp
 
 # Configure openvswitch and netdevsim interfaces 
 ./configSwitch2.sh "$VM_IP"
+
+# Per-node stand-in mock PHCs for virtual CLOCK_REALTIME (phc2sys shim).
+if [[ "${DKMS_MODE:-}" == "true" && "${PTP_VRT_ENABLE:-true}" == "true" ]]; then
+    ./create-vrt-clocks.sh
+fi

--- a/scripts/ptp-vrt/.gitignore
+++ b/scripts/ptp-vrt/.gitignore
@@ -1,0 +1,2 @@
+*.so
+test_vrt_cli

--- a/scripts/ptp-vrt/Makefile
+++ b/scripts/ptp-vrt/Makefile
@@ -1,0 +1,25 @@
+CC ?= gcc
+CFLAGS ?= -O2 -fPIC -Wall -Wextra
+LDFLAGS ?= -shared -ldl -lpthread
+
+LIB = libptp_vrt_shim.so
+TESTCLI = test_vrt_cli
+
+.PHONY: all clean install
+
+all: $(LIB) $(TESTCLI)
+
+$(LIB): ptp_vrt_shim.c
+	$(CC) $(CFLAGS) -o $@ $< $(LDFLAGS)
+
+$(TESTCLI): test_vrt_cli.c
+	$(CC) -O2 -Wall -Wextra -o $@ $<
+
+clean:
+	rm -f $(LIB) $(TESTCLI)
+
+install: $(LIB)
+	install -d $(DESTDIR)/usr/local/lib
+	install -m 755 $(LIB) $(DESTDIR)/usr/local/lib/
+	install -d $(DESTDIR)/usr/local/sbin
+	install -m 755 phc2sys-wrapper $(DESTDIR)/usr/local/sbin/phc2sys-wrapper

--- a/scripts/ptp-vrt/README.md
+++ b/scripts/ptp-vrt/README.md
@@ -1,0 +1,24 @@
+# phc2sys virtual CLOCK_REALTIME shim (CI only)
+
+Kind workers share one host `CLOCK_REALTIME`. This LD_PRELOAD library makes
+`phc2sys -a -r` discipline a **per-node stand-in mock PHC** instead, while
+keeping log lines as `CLOCK_REALTIME` so cloud-event-proxy metrics/events work.
+
+## Components
+
+| File | Role |
+|------|------|
+| `ptp_vrt_shim.c` | Redirects `clock_gettime/settime/adjtime(CLOCK_REALTIME)` and `adjtimex` to the stand-in PHC; fakes `PTP_SYS_OFFSET*` against that PHC |
+| `phc2sys-wrapper` | Installed as `/usr/sbin/phc2sys`; enables preload when `/var/run/vrt/device` exists |
+| `../create-vrt-clocks.sh` | Creates one netdevsim mock PHC per Kind worker and writes the device path into each node |
+
+## Activation
+
+1. Build/load netdevsim-dkms modules.
+2. Bring up Kind + topology (`configSwitch2.sh`).
+3. Run `create-vrt-clocks.sh` (writes `/var/run/ptp/vrt/device` per node → pod path `/var/run/vrt/device`).
+4. linuxptp image must contain the shim + wrapper (see `../../ptp-tools/Dockerfile.lptpd`).
+5. Tests: `run-tests.sh` sets `DisableAllSlaveRTUpdate: false` when `DKMS_MODE=true`
+   or when `/var/run/vrt/device` already exists on the cluster (prior VRT install).
+
+This is **not** a second kernel realtime clock. Host `date` is unchanged.

--- a/scripts/ptp-vrt/phc2sys-wrapper
+++ b/scripts/ptp-vrt/phc2sys-wrapper
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Wrapper installed as /usr/sbin/phc2sys in the linuxptp-daemon image.
+# When a per-node VRT device file is present, preload the stand-in RT shim.
+# Fail closed if VRT is configured but the device or shim is unusable so
+# phc2sys -a -r cannot fall back to the shared host CLOCK_REALTIME.
+set -euo pipefail
+
+REAL_PHC2SYS="${PTP_VRT_REAL_PHC2SYS:-/usr/sbin/phc2sys.real}"
+SHIM="${PTP_VRT_SHIM:-/usr/local/lib/libptp_vrt_shim.so}"
+DEVICE_FILE="${PTP_VRT_DEVICE_FILE:-/var/run/vrt/device}"
+
+vrt_configured=false
+if [[ -n "${PTP_VRT_PHC:-}" ]]; then
+	vrt_configured=true
+elif [[ -f "$DEVICE_FILE" ]]; then
+	vrt_configured=true
+	PTP_VRT_PHC="$(tr -d '[:space:]' <"$DEVICE_FILE")"
+	export PTP_VRT_PHC
+fi
+
+if [[ "$vrt_configured" == true ]]; then
+	if [[ -z "${PTP_VRT_PHC:-}" ]]; then
+		echo "phc2sys-wrapper: VRT configured but device path is empty ($DEVICE_FILE)" >&2
+		exit 1
+	fi
+	if [[ ! -e "$PTP_VRT_PHC" ]]; then
+		echo "phc2sys-wrapper: VRT device '$PTP_VRT_PHC' not found" >&2
+		exit 1
+	fi
+	if [[ ! -f "$SHIM" ]]; then
+		echo "phc2sys-wrapper: VRT shim '$SHIM' not found" >&2
+		exit 1
+	fi
+	export PTP_VRT_PHC
+	if [[ -n "${LD_PRELOAD:-}" ]]; then
+		export LD_PRELOAD="${SHIM}:${LD_PRELOAD}"
+	else
+		export LD_PRELOAD="${SHIM}"
+	fi
+fi
+
+# Keep argv0 as "phc2sys" so logs/metrics use process="phc2sys", not "phc2sys.real".
+exec -a phc2sys "$REAL_PHC2SYS" "$@"

--- a/scripts/ptp-vrt/ptp_vrt_shim.c
+++ b/scripts/ptp-vrt/ptp_vrt_shim.c
@@ -1,0 +1,258 @@
+/*
+ * CI-only LD_PRELOAD shim: redirect CLOCK_REALTIME ops from phc2sys onto a
+ * per-node stand-in mock PHC, and rewrite PTP_SYS_OFFSET* so measurement uses
+ * that virtual RT instead of the shared host CLOCK_REALTIME.
+ *
+ * Activation: set PTP_VRT_PHC=/dev/ptpN (or PTP_VRT_DEVICE_FILE pointing at a
+ * file that contains that path). Inactive when unset/missing.
+ */
+
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/timex.h>
+#include <time.h>
+#include <unistd.h>
+#include <linux/ptp_clock.h>
+
+#ifndef CLOCKFD
+#define CLOCKFD 3
+#endif
+#ifndef FD_TO_CLOCKID
+#define FD_TO_CLOCKID(fd) ((clockid_t)((((unsigned int)~(fd)) << 3) | CLOCKFD))
+#endif
+
+typedef int (*clock_gettime_fn)(clockid_t, struct timespec *);
+typedef int (*clock_settime_fn)(clockid_t, const struct timespec *);
+typedef int (*clock_adjtime_fn)(clockid_t, struct timex *);
+typedef int (*adjtimex_fn)(struct timex *);
+typedef int (*ioctl_fn)(int, unsigned long, ...);
+
+static clock_gettime_fn real_clock_gettime;
+static clock_settime_fn real_clock_settime;
+static clock_adjtime_fn real_clock_adjtime;
+static adjtimex_fn real_adjtimex;
+static ioctl_fn real_ioctl;
+
+static pthread_once_t once = PTHREAD_ONCE_INIT;
+static int vrt_fd = -1;
+static clockid_t vrt_clk = CLOCK_REALTIME;
+static bool vrt_active;
+
+static void resolve_reals(void)
+{
+	real_clock_gettime = (clock_gettime_fn)dlsym(RTLD_NEXT, "clock_gettime");
+	real_clock_settime = (clock_settime_fn)dlsym(RTLD_NEXT, "clock_settime");
+	real_clock_adjtime = (clock_adjtime_fn)dlsym(RTLD_NEXT, "clock_adjtime");
+	real_adjtimex = (adjtimex_fn)dlsym(RTLD_NEXT, "adjtimex");
+	real_ioctl = (ioctl_fn)dlsym(RTLD_NEXT, "ioctl");
+}
+
+static void init_vrt(void)
+{
+	const char *path = NULL;
+	char buf[256];
+	const char *file;
+
+	resolve_reals();
+
+	path = getenv("PTP_VRT_PHC");
+	if (!path || !path[0]) {
+		file = getenv("PTP_VRT_DEVICE_FILE");
+		if (!file || !file[0])
+			file = "/var/run/vrt/device";
+		FILE *f = fopen(file, "r");
+		if (!f)
+			return;
+		if (!fgets(buf, sizeof(buf), f)) {
+			fclose(f);
+			return;
+		}
+		fclose(f);
+		buf[strcspn(buf, "\r\n")] = '\0';
+		if (!buf[0])
+			return;
+		path = buf;
+	}
+
+	vrt_fd = open(path, O_RDWR);
+	if (vrt_fd < 0)
+		return;
+
+	vrt_clk = FD_TO_CLOCKID(vrt_fd);
+	vrt_active = true;
+}
+
+static void ensure_init(void)
+{
+	pthread_once(&once, init_vrt);
+}
+
+static bool is_rt(clockid_t clk)
+{
+	return clk == CLOCK_REALTIME;
+}
+
+static void ts_to_ptp(const struct timespec *ts, struct ptp_clock_time *pct)
+{
+	pct->sec = ts->tv_sec;
+	pct->nsec = (unsigned int)ts->tv_nsec;
+	pct->reserved = 0;
+}
+
+static int read_vrt(struct timespec *ts)
+{
+	return real_clock_gettime(vrt_clk, ts);
+}
+
+static int read_phc_fd(int fd, struct timespec *ts)
+{
+	clockid_t clk = FD_TO_CLOCKID(fd);
+	return real_clock_gettime(clk, ts);
+}
+
+static int fake_sys_offset(int fd, struct ptp_sys_offset *sysoff)
+{
+	unsigned int i, n;
+	struct timespec ts;
+
+	if (!sysoff)
+		return -1;
+	n = sysoff->n_samples;
+	if (n > PTP_MAX_SAMPLES) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	/* Interleaved sys, phc, ... ending with an extra sys sample. */
+	for (i = 0; i < n; i++) {
+		if (read_vrt(&ts) < 0)
+			return -1;
+		ts_to_ptp(&ts, &sysoff->ts[2 * i]);
+		if (read_phc_fd(fd, &ts) < 0)
+			return -1;
+		ts_to_ptp(&ts, &sysoff->ts[2 * i + 1]);
+	}
+	if (read_vrt(&ts) < 0)
+		return -1;
+	ts_to_ptp(&ts, &sysoff->ts[2 * n]);
+	return 0;
+}
+
+static int fake_sys_offset_extended(int fd, struct ptp_sys_offset_extended *ex)
+{
+	unsigned int i, n;
+	struct timespec pre, mid, post;
+
+	if (!ex)
+		return -1;
+	n = ex->n_samples;
+	if (n > PTP_MAX_SAMPLES) {
+		errno = EINVAL;
+		return -1;
+	}
+	for (i = 0; i < n; i++) {
+		if (read_vrt(&pre) < 0)
+			return -1;
+		if (read_phc_fd(fd, &mid) < 0)
+			return -1;
+		if (read_vrt(&post) < 0)
+			return -1;
+		ts_to_ptp(&pre, &ex->ts[i][0]);
+		ts_to_ptp(&mid, &ex->ts[i][1]);
+		ts_to_ptp(&post, &ex->ts[i][2]);
+	}
+	return 0;
+}
+
+static int fake_sys_offset_precise(int fd, struct ptp_sys_offset_precise *pr)
+{
+	struct timespec dev, sys;
+
+	if (!pr)
+		return -1;
+	if (read_phc_fd(fd, &dev) < 0)
+		return -1;
+	if (read_vrt(&sys) < 0)
+		return -1;
+	ts_to_ptp(&dev, &pr->device);
+	ts_to_ptp(&sys, &pr->sys_realtime);
+	/* sys_monoraw unused by phc2sys RT path; leave zeroed. */
+	memset(&pr->sys_monoraw, 0, sizeof(pr->sys_monoraw));
+	return 0;
+}
+
+int clock_gettime(clockid_t clk, struct timespec *tp)
+{
+	ensure_init();
+	if (vrt_active && is_rt(clk))
+		return real_clock_gettime(vrt_clk, tp);
+	return real_clock_gettime(clk, tp);
+}
+
+int clock_settime(clockid_t clk, const struct timespec *tp)
+{
+	ensure_init();
+	if (vrt_active && is_rt(clk))
+		return real_clock_settime(vrt_clk, tp);
+	return real_clock_settime(clk, tp);
+}
+
+int clock_adjtime(clockid_t clk, struct timex *buf)
+{
+	ensure_init();
+	if (vrt_active && is_rt(clk))
+		return real_clock_adjtime(vrt_clk, buf);
+	return real_clock_adjtime(clk, buf);
+}
+
+int adjtimex(struct timex *buf)
+{
+	ensure_init();
+	if (vrt_active)
+		return real_clock_adjtime(vrt_clk, buf);
+	return real_adjtimex(buf);
+}
+
+int ioctl(int fd, unsigned long request, ...)
+{
+	va_list ap;
+	void *arg;
+	int rc;
+
+	ensure_init();
+
+	va_start(ap, request);
+	arg = va_arg(ap, void *);
+	va_end(ap);
+
+	if (vrt_active && fd >= 0 && fd != vrt_fd) {
+		switch (request) {
+		case PTP_SYS_OFFSET:
+		case PTP_SYS_OFFSET2:
+			rc = fake_sys_offset(fd, arg);
+			return rc;
+		case PTP_SYS_OFFSET_EXTENDED:
+		case PTP_SYS_OFFSET_EXTENDED2:
+			rc = fake_sys_offset_extended(fd, arg);
+			return rc;
+		case PTP_SYS_OFFSET_PRECISE:
+		case PTP_SYS_OFFSET_PRECISE2:
+			rc = fake_sys_offset_precise(fd, arg);
+			return rc;
+		default:
+			break;
+		}
+	}
+
+	return real_ioctl(fd, request, arg);
+}

--- a/scripts/ptp-vrt/test-shim-smoke.sh
+++ b/scripts/ptp-vrt/test-shim-smoke.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Smoke-test the VRT shim against a mock PHC (requires loaded netdevsim-dkms).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+make -C "$ROOT" all
+
+NSIM_NEW=/sys/bus/netdevsim/new_device
+NSIM_DEL=/sys/bus/netdevsim/del_device
+ID=99
+ARCH=$(uname -m)
+if [[ "$ARCH" == "x86_64" ]]; then
+	PCI="0000:1f:1f.0"
+elif [[ "$ARCH" == "aarch64" ]]; then
+	PCI="0001:1f:1f.0"
+else
+	echo "skip: unsupported arch $ARCH"
+	exit 0
+fi
+
+if [[ ! -w "$NSIM_NEW" ]]; then
+	echo "skip: netdevsim not available (need root + modules)"
+	exit 0
+fi
+
+cleanup() { echo "$ID" >"$NSIM_DEL" 2>/dev/null || true; }
+trap cleanup EXIT
+
+echo "$ID" >"$NSIM_DEL" 2>/dev/null || true
+echo "$ID $PCI $ID 1" >"$NSIM_NEW"
+udevadm settle 2>/dev/null || sleep 0.5
+
+IFACE=""
+for netdir in "/sys/bus/pci/devices/${PCI}/net" \
+	"/sys/bus/netdevsim/devices/netdevsim${ID}/net"; do
+	[[ -d "$netdir" ]] || continue
+	IFACE=$(find "$netdir" -maxdepth 1 -mindepth 1 -type d -printf '%f\n' | head -1)
+	[[ -n "$IFACE" ]] && break
+done
+[[ -n "$IFACE" ]]
+PHC=$(ethtool -T "$IFACE" | awk '/PTP Hardware Clock:/ {print $4}')
+DEV="/dev/ptp${PHC}"
+[[ -e "$DEV" ]]
+# Restrict to owner/group; this smoke test runs as root.
+chmod 660 "$DEV" 2>/dev/null || true
+
+export PTP_VRT_PHC="$DEV"
+export LD_PRELOAD="$ROOT/libptp_vrt_shim.so"
+
+# Host CLOCK_REALTIME must be read without the shim (env -u LD_PRELOAD).
+HOST_BEFORE=$(env -u LD_PRELOAD date +%s.%N)
+BEFORE=$("$ROOT/test_vrt_cli" gettime)
+"$ROOT/test_vrt_cli" step >/dev/null
+AFTER=$("$ROOT/test_vrt_cli" gettime)
+HOST_AFTER=$(env -u LD_PRELOAD date +%s.%N)
+
+echo "vrt_before=$BEFORE vrt_after=$AFTER host_before=$HOST_BEFORE host_after=$HOST_AFTER"
+python3 - <<PY
+b=float("$BEFORE"); a=float("$AFTER")
+hb=float("$HOST_BEFORE"); ha=float("$HOST_AFTER")
+# CLI steps the stand-in PHC by +1s; allow small runtime jitter.
+assert abs((a - b) - 1.0) < 0.25, (b, a, a - b)
+# Unshimmed host realtime must not follow the VRT step.
+assert abs(ha - hb) < 0.5, (hb, ha, ha - hb)
+assert abs(b - hb) < 120, (b, hb)  # stand-in starts near realtime
+print("OK: shim steers stand-in PHC", "$DEV")
+PY

--- a/scripts/ptp-vrt/test_vrt_cli.c
+++ b/scripts/ptp-vrt/test_vrt_cli.c
@@ -1,0 +1,42 @@
+/* Minimal CLI to verify LD_PRELOAD redirects CLOCK_REALTIME to PTP_VRT_PHC. */
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <string.h>
+#include <sys/timex.h>
+#include <time.h>
+#include <unistd.h>
+
+int main(int argc, char **argv)
+{
+	struct timespec ts, ts2;
+	struct timex tx;
+	const char *cmd = argc > 1 ? argv[1] : "gettime";
+
+	if (strcmp(cmd, "gettime") == 0) {
+		if (clock_gettime(CLOCK_REALTIME, &ts) != 0) {
+			perror("clock_gettime");
+			return 1;
+		}
+		printf("%ld.%09ld\n", (long)ts.tv_sec, ts.tv_nsec);
+		return 0;
+	}
+	if (strcmp(cmd, "step") == 0) {
+		memset(&tx, 0, sizeof(tx));
+		tx.modes = ADJ_SETOFFSET | ADJ_NANO;
+		/* +1s so smoke tests can detect VRT-only steps vs host RT. */
+		tx.time.tv_sec = 1;
+		tx.time.tv_usec = 0;
+		if (clock_adjtime(CLOCK_REALTIME, &tx) < 0) {
+			perror("clock_adjtime");
+			return 1;
+		}
+		if (clock_gettime(CLOCK_REALTIME, &ts2) != 0) {
+			perror("clock_gettime");
+			return 1;
+		}
+		printf("after_step %ld.%09ld\n", (long)ts2.tv_sec, ts2.tv_nsec);
+		return 0;
+	}
+	fprintf(stderr, "usage: %s [gettime|step]\n", argv[0]);
+	return 2;
+}

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -8,6 +8,7 @@
 #
 # Optional flags:
 #   --loglevel <level>              PTP log level (default: info)
+#   --focus <regex>                 Pass through to ginkgo --focus (run matching specs only)
 #   --linuxptp-daemon-image <url>   Full image URL for the linuxptp-daemon test pod.
 #                                   When omitted, pmc pod tests are skipped.
 #   --must-gather-image <url>       Full image URL for the ptp must-gather image.
@@ -19,7 +20,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GINKGO_HEADLINE_REWRITE="${SCRIPT_DIR}/ginkgo-headline-rewrite.sh"
 
 usage() {
-  echo "Usage: $0 --kind <serial|parallel|both> --mode <modes> [--loglevel <level>] [--linuxptp-daemon-image <url>] [--must-gather-image <url>]"
+  echo "Usage: $0 --kind <serial|parallel|both> --mode <modes> [--focus <regex>] [--loglevel <level>] [--linuxptp-daemon-image <url>] [--must-gather-image <url>]"
   exit 1
 }
 
@@ -28,6 +29,7 @@ TEST_MODES_RAW=""
 PTP_LOG_LEVEL="info"
 LINUXPTP_DAEMON_IMAGE=""
 MUST_GATHER_IMAGE=""
+GINKGO_FOCUS=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -37,6 +39,9 @@ while [[ $# -gt 0 ]]; do
       TEST_MODES_RAW="$2"; shift 2 ;;
     --loglevel)
       PTP_LOG_LEVEL="$2"; shift 2 ;;
+    --focus)
+      [[ $# -ge 2 ]] || usage
+      GINKGO_FOCUS="$2"; shift 2 ;;
     --linuxptp-daemon-image)
       LINUXPTP_DAEMON_IMAGE="$2"; shift 2 ;;
     --must-gather-image)
@@ -67,13 +72,53 @@ export MIN_OFFSET_IN_NS="${MIN_OFFSET_IN_NS:--10000}"
 export COLLECT_POD_LOGS="${COLLECT_POD_LOGS:-true}"
 export LOG_ARTIFACTS_DIR="${LOG_ARTIFACTS_DIR:-${JUNIT_OUTPUT_DIR}/pod-logs}"
 
+# With VRT, each Kind worker disciplines its own stand-in mock PHC instead of
+# the shared host CLOCK_REALTIME, so slave phc2sys -a -r is safe.
+# Enable RT update when:
+#   - DISABLE_SLAVE_RT_UPDATE is set explicitly, or
+#   - PTP_VRT_ENABLE=false → keep disabled, or
+#   - DKMS_MODE=true (install/CI path), or
+#   - VRT device files already exist from a prior cluster install
+#     (re-running ./run-tests.sh without DKMS_MODE).
+vrt_already_present() {
+  local pod ns=openshift-ptp
+  while read -r pod; do
+    [[ -z "$pod" ]] && continue
+    if kubectl exec -n "$ns" "$pod" -c linuxptp-daemon-container -- \
+        test -s /var/run/vrt/device &>/dev/null; then
+      return 0
+    fi
+  done < <(kubectl get pods -n "$ns" -l app=linuxptp-daemon \
+      -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true)
+
+  local node
+  for node in kind-netdevsim-worker kind-netdevsim-worker2 kind-netdevsim-worker3; do
+    if podman exec "$node" test -s /var/run/ptp/vrt/device &>/dev/null ||
+      docker exec "$node" test -s /var/run/ptp/vrt/device &>/dev/null; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+if [[ -n "${DISABLE_SLAVE_RT_UPDATE:-}" ]]; then
+  :
+elif [[ "${PTP_VRT_ENABLE:-true}" != "true" ]]; then
+  DISABLE_SLAVE_RT_UPDATE=true
+elif [[ "${DKMS_MODE:-}" == "true" ]] || vrt_already_present; then
+  DISABLE_SLAVE_RT_UPDATE=false
+else
+  DISABLE_SLAVE_RT_UPDATE=true
+fi
+echo "DisableAllSlaveRTUpdate=${DISABLE_SLAVE_RT_UPDATE}"
+
 CONFIG_YAML="$(mktemp "${PTP_RUN_DIR:-/tmp}/ptp-config.XXXXXX.yaml")"
 cat <<EOF >"${CONFIG_YAML}"
 global:
   maxoffset: $MAX_OFFSET_IN_NS
   minoffset: $MIN_OFFSET_IN_NS
   holdover_timeout: 5
-  DisableAllSlaveRTUpdate: true
+  DisableAllSlaveRTUpdate: ${DISABLE_SLAVE_RT_UPDATE}
 EOF
 export USE_CONTAINER_CMDS=
 export PTP_TEST_CONFIG_FILE="${CONFIG_YAML}"
@@ -187,6 +232,10 @@ run_ginkgo_suite() {
     --junit-report="${junit_base}_${mode}_${suite_kind}.xml"
     -v
   )
+
+  if [[ -n "${GINKGO_FOCUS}" ]]; then
+    ginkgo_args+=(--focus="${GINKGO_FOCUS}")
+  fi
 
   for skip in "${SKIP_PATTERNS[@]}"; do
     ginkgo_args+=(--skip="${skip}")

--- a/test/README.md
+++ b/test/README.md
@@ -17,9 +17,9 @@ To run the conformance tests, first set the following environment variables:
 - **MAX_OFFSET_IN_NS**: maximum offset in nanoseconds between a master and a slave clock when testing clock accuracy. Also used as LocalMaxHoldoverOffset for E810 plugin. Default is 100
 - **MIN_OFFSET_IN_NS**: minimum offset in nanoseconds between a master and a slave clock when testing clock accuracy. Default is -100
 - **MAX_IN_SPEC_OFFSET_NS**: maximum in-spec offset in nanoseconds for E810 plugin holdover specification threshold. Default is 100
-- **ENABLE_PTP_EVENT**: enable event based tests.
-- **EVENT_API_VERSION**: passes the default REST-API version for the event based tests. Set this to "2.0" for 4.16+ PUT, "1.0" for 4.15 and earlier. If this is not set, default value "2.0" is used.
-- **ENABLE_V1_REGRESSION**: enable V1 regression for event based tests. For 4.16 and 4.17, event based tests will be repeated the second time with v1 REST-API. These tests are marked with "v1 regression".
+- **ENABLE_PTP_EVENT**: enable event-based tests (required for OsClockSyncStateChange consumer assertions; CLOCK_REALTIME metric asserts still run without it).
+- **EVENT_API_VERSION**: passes the default REST-API version for the event-based tests. Set this to "2.0" for 4.16+ PUT, "1.0" for 4.15 and earlier. If this is not set, default value "2.0" is used.
+- **ENABLE_V1_REGRESSION**: enable V1 regression for event-based tests. For 4.16 and 4.17, event-based tests will be repeated the second time with v1 REST-API. These tests are marked with "v1 regression".
 - **EXTERNAL_GM**: enables external grandmaster scenarios
 - **PTP_TEST_CONFIG_FILE**: configuration file to set for instance min/max offsets in ptpconfig. Example is at[link](test/conformance/config/ptptestconfig.yaml)
 - **COLLECT_POD_LOGS**: enable automatic collection of raw container logs during test execution (default: false). See [Pod Log Collection](#pod-log-collection) section for details.
@@ -34,6 +34,13 @@ So for instance to run in discovery mode the command line could look like this:
 ```
 KUBECONFIG="/home/user/.kube/config" PTP_TEST_MODE=Discovery make functests
 ```
+
+To exercise BC reverse-sync `os-clock-sync-state` FREERUN (serial outage recovery test) with events:
+```bash
+KUBECONFIG="/home/user/.kube/config" PTP_TEST_MODE=BC ENABLE_PTP_EVENT=true SKIP_INTERFACES="eno1,ens2f1" make functests
+```
+(`DualNICBC` is also valid; DualNICBCHA is skipped for this It. Needs a cloud-event-proxy build with reverse-sync FREERUN detection.
+On Kind/netdevsim this It runs when VRT is present (`run-tests.sh` sets `DisableAllSlaveRTUpdate: false` if `DKMS_MODE=true` or VRT device files already exist); otherwise it skips because `-a -r` is stripped and workers share host `CLOCK_REALTIME`.)
 
 To run all the tests
 ```
@@ -485,6 +492,22 @@ note: parameter0 ... parameterN are integers representing an interface. 0 means 
 
 
 # Running PTP tests on amazon EC2 or local VM
+## Virtual CLOCK_REALTIME on Kind/netdevsim
+
+Kind workers share the host `CLOCK_REALTIME`. For DKMS CI, each worker gets a
+stand-in mock PHC (`scripts/create-vrt-clocks.sh`) and the linuxptp image wraps
+`phc2sys` with an LD_PRELOAD shim (`scripts/ptp-vrt/`) so `-a -r` steers that
+PHC while logs still say `CLOCK_REALTIME`.
+
+- Created at cluster install when `DKMS_MODE=true` and `PTP_VRT_ENABLE=true` (default).
+- `PTP_VRT_ENABLE=false` takes precedence over `DKMS_MODE=true` and keeps
+  `DisableAllSlaveRTUpdate: true`, so local DKMS runs with VRT disabled do not
+  expect slave RT updates.
+- `run-tests.sh` sets `DisableAllSlaveRTUpdate: false` when `DKMS_MODE=true` or when
+  VRT device files are already present (so re-runs need not pass `DKMS_MODE`),
+  unless `PTP_VRT_ENABLE=false`.
+- Host `date` / real RT are not moved. See `scripts/ptp-vrt/README.md`.
+
 ## Using netdevsim framework to simulate PHC
 Existing netdevsim framework defines simulated clocks (not truly functional), supports virtual interfaces capable of transmitting frames. See: [link](https://developers.redhat.com/blog/2018/10/22/introduction-to-linux-interfaces-for-virtual-networking?source=sso#netdevsim)
 Maciek Machnikowski(Nvidia)/Milena Olech (intel) video describes a simple netdevsim kernel patch to add real simulated clocks (phc_mock) to simulate ptp: [link]( https://www.youtube.com/watch?v=txgekOBen6c)
@@ -528,6 +551,8 @@ The following diagram shows an example of configuration that can be created in t
 ./run-tests.sh --kind <serial|parallel|both> --mode <modes> [--loglevel <level>] [--linuxptp-daemon-image <url>]
 ```
 - `configSwitch2.sh`: configures virtual Ethernet switch (openvswitch) container
+- `create-vrt-clocks.sh`: per-node stand-in mock PHCs for virtual CLOCK_REALTIME (DKMS CI)
+- `ptp-vrt/`: phc2sys LD_PRELOAD shim + wrapper (baked into linuxptp-daemon image)
 - `fix-certs.sh`: Fix certificates for the linuxptp-daemon in Kind
 - `install-tools.sh`: install tools such as ginkgo, go, ...
 - `prepare-kind.sh`: basic configuration to make the kind clusted look like a openshift cluster

--- a/test/conformance/serial/ptp.go
+++ b/test/conformance/serial/ptp.go
@@ -2294,6 +2294,116 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 				logrus.Info("Successfully verified T-BC clock class recovery after upstream link outage")
 			})
 
+			// OsClockSyncState goes FREERUN when BC upstream is lost (reverse phc2sys)
+			// and recovers to LOCKED when the link is restored.
+			//
+			// Reproduces Case 04504543 / reverse-sync regression after OCPBUGS-88369:
+			// with phc2sysOpts -a -r, losing the BC slave causes phc2sys to reverse
+			// (PHC ← CLOCK_REALTIME) and stop emitting CLOCK_REALTIME phc offset.
+			// cloud-event-proxy must publish os-clock-sync-state FREERUN.
+			//
+			// Run with: PTP_TEST_MODE=BC (or DualNICBC) ENABLE_PTP_EVENT=true SKIP_INTERFACES=<mgmt,...>
+			// Requires a cloud-event-proxy build that includes reverse-sync FREERUN detection.
+			// Skips when phc2sysOpts lacks -a -r or CLOCK_REALTIME metric is absent.
+			// Kind/netdevsim: runs when VRT is present (DisableAllSlaveRTUpdate=false); otherwise skips.
+			It("OsClockSyncState goes FREERUN on BC upstream loss and recovers to LOCKED", func() {
+				if fullConfig.PtpModeDiscovered != testconfig.BoundaryClock &&
+					fullConfig.PtpModeDiscovered != testconfig.DualNICBoundaryClock {
+					Skip("test only valid for BC and DualNICBC (not DualNICBCHA HA)")
+				}
+				if !bcProfileHasNetworkDisciplinedOsClock((*ptpv1.PtpConfig)(fullConfig.DiscoveredClockUnderTestPtpConfig)) {
+					Skip("requires phc2sysOpts with -a -r for CLOCK_REALTIME reverse-sync; " +
+						"on Kind/netdevsim ensure VRT is present so run-tests.sh sets " +
+						"DisableAllSlaveRTUpdate=false")
+				}
+
+				skippedInterfacesStr, isSet := os.LookupEnv("SKIP_INTERFACES")
+				if !isSet {
+					Skip("Mandatory to provide skipped interface to avoid making a node disconnected from the cluster")
+				}
+				skipInterfaces := make(map[string]bool)
+				for _, val := range strings.Split(skippedInterfacesStr, ",") {
+					skipInterfaces[val] = true
+				}
+
+				slaveIf := ptpv1.GetInterfaces((ptpv1.PtpConfig)(*fullConfig.DiscoveredClockUnderTestPtpConfig), ptpv1.Slave)
+				if fullConfig.PtpModeDiscovered == testconfig.DualNICBoundaryClock {
+					Expect(fullConfig.DiscoveredClockUnderTestSecondaryPtpConfig).NotTo(BeNil(),
+						"secondary PtpConfig required for dual-NIC BC outage tests")
+					secondarySlaveIf := ptpv1.GetInterfaces((ptpv1.PtpConfig)(*fullConfig.DiscoveredClockUnderTestSecondaryPtpConfig), ptpv1.Slave)
+					slaveIf = append(slaveIf, secondarySlaveIf...)
+				}
+				Expect(slaveIf).ToNot(BeEmpty(), "no slave interfaces found in the clock-under-test PtpConfig(s)")
+
+				nodeName := fullConfig.DiscoveredClockUnderTestPod.Spec.NodeName
+
+				By("Probing CLOCK_REALTIME/phc2sys metric availability")
+				if !clockRealTimeMetricAvailable(nodeName, 30*time.Second) {
+					Skip("openshift_ptp_clock_state{iface=CLOCK_REALTIME,process=phc2sys} not available; " +
+						"on Kind/netdevsim enable VRT so each worker has a stand-in CLOCK_REALTIME PHC")
+				}
+
+				portEngine.Initialize(fullConfig.DiscoveredClockUnderTestPod, slaveIf)
+				DeferCleanup(func() {
+					ptptesthelper.DeletePtpTestPrivilegedDaemonSet(
+						pkg.RecoveryNetworkOutageDaemonSetName,
+						pkg.RecoveryNetworkOutageDaemonSetNamespace,
+					)
+				})
+
+				evCtx := setupOsClockSyncStateEvents(nodeName)
+
+				By("Checking initial CLOCK_REALTIME / OsClockSyncState is LOCKED")
+				Eventually(func() error {
+					return metrics.CheckClockRealTimeState(metrics.MetricClockStateLocked, &nodeName)
+				}, pkg.TimeoutIn5Minutes, pkg.Timeout10Seconds).Should(Succeed(),
+					"CLOCK_REALTIME must be LOCKED before outage")
+				if evCtx.available {
+					Expect(event.PushInitialEvent(string(ptpEvent.OsClockSyncStateChange), 30*time.Second)).To(Succeed())
+					waitForOsClockSyncState(evCtx.ch, ptpEvent.LOCKED, pkg.TimeoutIn3Minutes)
+				}
+
+				By("Taking all BC slave interfaces down to force phc2sys reverse-sync")
+				outageStart := time.Now()
+				err := portEngine.TurnAllPortsDown(skipInterfaces)
+				Expect(err).To(BeNil())
+				DeferCleanup(func() {
+					_ = portEngine.TurnAllPortsUp()
+				})
+
+				By("Correlating phc2sys reverse-sync log signals (best-effort)")
+				correlatePhc2sysReverseSync(fullConfig.DiscoveredClockUnderTestPod, outageStart)
+
+				By("Checking CLOCK_REALTIME metric is FREERUN after upstream loss")
+				Eventually(func() error {
+					return metrics.CheckClockRealTimeState(metrics.MetricClockStateFreeRun, &nodeName)
+				}, pkg.TimeoutIn5Minutes, pkg.Timeout10Seconds).Should(Succeed(),
+					"CLOCK_REALTIME must go FREERUN when BC upstream is lost (reverse phc2sys); "+
+						"stuck LOCKED indicates missing reverse-sync detection in cloud-event-proxy")
+
+				if evCtx.available {
+					By("Checking OsClockSyncStateChange event is FREERUN")
+					waitForOsClockSyncState(evCtx.ch, ptpEvent.FREERUN, pkg.TimeoutIn5Minutes)
+				}
+
+				By("Restoring all BC slave interfaces")
+				err = portEngine.TurnAllPortsUp()
+				Expect(err).To(BeNil())
+
+				By("Checking CLOCK_REALTIME metric recovers to LOCKED")
+				Eventually(func() error {
+					return metrics.CheckClockRealTimeState(metrics.MetricClockStateLocked, &nodeName)
+				}, pkg.TimeoutIn5Minutes, pkg.Timeout10Seconds).Should(Succeed(),
+					"CLOCK_REALTIME must return to LOCKED after upstream recovers")
+
+				if evCtx.available {
+					By("Checking OsClockSyncStateChange event recovers to LOCKED")
+					waitForOsClockSyncState(evCtx.ch, ptpEvent.LOCKED, pkg.TimeoutIn5Minutes)
+				}
+
+				logrus.Info("Successfully verified OsClockSyncState FREERUN/LOCKED around BC reverse-sync outage")
+			})
+
 			It("Should restart ptp4l with no socket errors after SIGTERM", func() {
 				verifyProcessRestartNoSocketErrors(fullConfig, "ptp4l")
 			})
@@ -4206,6 +4316,158 @@ func waitForStateAndCC(subs event.Subscriptions, state ptpEvent.SyncState, cc in
 type bcEventContext struct {
 	subs      event.Subscriptions
 	available bool
+}
+
+// bcProfileHasNetworkDisciplinedOsClock reports whether a BC PtpConfig runs
+// phc2sys in automatic mode with CLOCK_REALTIME updates (-a -r). Without VRT,
+// Kind/netdevsim CI sets DisableAllSlaveRTUpdate and replaces those opts with "-v".
+func bcProfileHasNetworkDisciplinedOsClock(ptpConfig *ptpv1.PtpConfig) bool {
+	if ptpConfig == nil {
+		return false
+	}
+	for i := range ptpConfig.Spec.Profile {
+		opts := ptpConfig.Spec.Profile[i].Phc2sysOpts
+		if opts == nil || *opts == "" {
+			continue
+		}
+		// Field-split so "-r" matches a real flag, not a substring of another opt.
+		hasA, hasR := false, false
+		for _, f := range strings.Fields(*opts) {
+			switch f {
+			case "-a":
+				hasA = true
+			case "-r":
+				hasR = true
+			}
+		}
+		if hasA && hasR {
+			return true
+		}
+	}
+	return false
+}
+
+// clockRealTimeMetricAvailable returns true if CLOCK_REALTIME/phc2sys clock_state
+// is present with any recognized state within timeout.
+func clockRealTimeMetricAvailable(nodeName string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	states := []metrics.MetricClockState{
+		metrics.MetricClockStateLocked,
+		metrics.MetricClockStateFreeRun,
+		metrics.MetricClockStateHoldOver,
+	}
+	for time.Now().Before(deadline) {
+		for _, st := range states {
+			if err := metrics.CheckClockRealTimeState(st, &nodeName); err == nil {
+				return true
+			}
+		}
+		time.Sleep(2 * time.Second)
+	}
+	return false
+}
+
+// osClockEventContext holds an OsClockSyncStateChange subscription for BC
+// reverse-sync outage tests.
+type osClockEventContext struct {
+	ch        <-chan exports.StoredEvent
+	available bool
+}
+
+// setupOsClockSyncStateEvents deploys the consumer, subscribes to
+// OsClockSyncStateChange, and starts log monitoring. When ENABLE_PTP_EVENT
+// is unset or setup fails, available is false and callers rely on metrics.
+func setupOsClockSyncStateEvents(nodeName string) osClockEventContext {
+	ctx := osClockEventContext{}
+	if !event.Enable() {
+		logrus.Info("ENABLE_PTP_EVENT not set; OsClockSyncStateChange checks will be skipped (metric asserts still run)")
+		return ctx
+	}
+	logrus.Info("Deploy consumer app for OsClockSyncStateChange monitoring")
+	if createErr := event.CreateConsumerApp(nodeName); createErr != nil {
+		logrus.Warnf("PTP events not available: %s; skipping OsClockSyncStateChange checks", createErr)
+		return ctx
+	}
+	if waitErr := event.WaitForConsumerReady(nodeName); waitErr != nil {
+		logrus.Warnf("Consumer app not ready: %s; skipping OsClockSyncStateChange checks", waitErr)
+		return ctx
+	}
+	event.InitPubSub()
+	const incomingEventsBuffer = 100
+	ch, subscriberID := event.PubSub.Subscribe(string(ptpEvent.OsClockSyncStateChange), incomingEventsBuffer)
+	termMonitor, monErr := event.MonitorPodLogsRegex()
+	if monErr != nil {
+		logrus.Warnf("Could not start event monitoring: %s; skipping OsClockSyncStateChange checks", monErr)
+		event.PubSub.Unsubscribe(string(ptpEvent.OsClockSyncStateChange), subscriberID)
+		event.PubSub.Close()
+		if deleteErr := event.DeleteConsumerNamespace(); deleteErr != nil {
+			logrus.Debugf("Deleting consumer namespace failed: %s", deleteErr)
+		}
+		return ctx
+	}
+	ctx.ch = ch
+	ctx.available = true
+	DeferCleanup(func() {
+		stopMonitor(termMonitor)
+		event.PubSub.Unsubscribe(string(ptpEvent.OsClockSyncStateChange), subscriberID)
+		event.PubSub.Close()
+		if deleteErr := event.DeleteConsumerNamespace(); deleteErr != nil {
+			logrus.Debugf("Deleting consumer namespace failed: %s", deleteErr)
+		}
+	})
+	return ctx
+}
+
+// waitForOsClockSyncState waits until an OsClockSyncStateChange notification
+// matches the expected sync state.
+func waitForOsClockSyncState(ch <-chan exports.StoredEvent, expected ptpEvent.SyncState, timeout time.Duration) {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	for {
+		select {
+		case <-timer.C:
+			Fail(fmt.Sprintf("Timed out waiting for OsClockSyncStateChange %s", expected))
+			return
+		case ev := <-ch:
+			res, ok := processEvent(ptpEvent.OsClockSyncStateChange, ev)
+			if !ok {
+				continue
+			}
+			stateVal, ok := event.ValueByDataType(res.Values, "notification")
+			if !ok {
+				continue
+			}
+			state, ok := stateVal.(string)
+			if ok && state == string(expected) {
+				fmt.Fprintf(GinkgoWriter, "OsClockSyncStateChange %s verified via Event API\n", expected)
+				return
+			}
+		}
+	}
+}
+
+// correlatePhc2sysReverseSync best-effort checks daemon logs for reverse-sync
+// signals after an outage. Hard assertions remain on CLOCK_REALTIME metrics/events.
+func correlatePhc2sysReverseSync(pod *v1core.Pod, since time.Time) {
+	if pod == nil {
+		return
+	}
+	const reverseSyncPattern = `phc2sys(?m).*?(?:reconfiguring after port state change|sys offset)`
+	matches, err := pods.GetPodLogsRegexSince(
+		pod.Namespace,
+		pod.Name,
+		pkg.PtpContainerName,
+		reverseSyncPattern,
+		false,
+		pkg.TimeoutIn1Minute,
+		since,
+	)
+	if err != nil || len(matches) == 0 {
+		logrus.Warnf("phc2sys reverse-sync log correlate: no reconfiguring/sys offset lines yet (logReduce may hide them): err=%v", err)
+		return
+	}
+	logrus.Infof("phc2sys reverse-sync correlate: saw %d matching log line(s), last=%q",
+		len(matches), matches[len(matches)-1][0])
 }
 
 // setupBCClockClassEvents creates the consumer app, initializes PubSub,

--- a/test/pkg/metrics/metrics.go
+++ b/test/pkg/metrics/metrics.go
@@ -135,6 +135,53 @@ func CheckClockState(state MetricClockState, aIf string, nodeName *string) (err 
 	return nil
 }
 
+// CheckClockRealTimeState verifies openshift_ptp_clock_state for
+// iface=CLOCK_REALTIME, process=phc2sys on the given node.
+func CheckClockRealTimeState(state MetricClockState, nodeName *string) error {
+	if nodeName == nil || *nodeName == "" {
+		return fmt.Errorf("nodeName is required")
+	}
+	ptpPods, err := client.Client.CoreV1().Pods(pkg.PtpLinuxDaemonNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: "app=linuxptp-daemon"})
+	if err != nil {
+		return err
+	}
+	for index := range ptpPods.Items {
+		if ptpPods.Items[index].Spec.NodeName != *nodeName {
+			continue
+		}
+		buf, _, err := pods.ExecCommand(client.Client, false, &ptpPods.Items[index], pkg.PtpContainerName, []string{"curl", "-s", metricsEndPoint})
+		if err != nil {
+			return fmt.Errorf("error fetching metrics for CLOCK_REALTIME: %w", err)
+		}
+		metricsText := buf.String()
+		for _, line := range strings.Split(metricsText, "\n") {
+			if !strings.HasPrefix(line, OpenshiftPtpClockState+"{") {
+				continue
+			}
+			if !strings.Contains(line, `iface="CLOCK_REALTIME"`) ||
+				!strings.Contains(line, `process="phc2sys"`) ||
+				!strings.Contains(line, fmt.Sprintf(`node="%s"`, *nodeName)) {
+				continue
+			}
+			parts := strings.Fields(line)
+			if len(parts) != 2 {
+				continue
+			}
+			clockStateInt, err := strconv.Atoi(parts[1])
+			if err != nil {
+				return fmt.Errorf("error strconv for CLOCK_REALTIME clock state %q: %w", parts[1], err)
+			}
+			if MetricClockState(clockStateInt) != state {
+				return fmt.Errorf("CLOCK_REALTIME clock state expected=%d(%s) observed=%d(%s)",
+					state, state.String(), clockStateInt, MetricClockState(clockStateInt).String())
+			}
+			return nil
+		}
+		return fmt.Errorf("openshift_ptp_clock_state iface=CLOCK_REALTIME process=phc2sys not found on node %s", *nodeName)
+	}
+	return fmt.Errorf("linuxptp-daemon pod not found on node %s", *nodeName)
+}
+
 // This method checks the state of the clock with specified interface
 func CheckClockRole(roles []MetricRole, Ifs []string, nodeName *string) (err error) {
 	if len(roles) != len(Ifs) {


### PR DESCRIPTION
## Summary
- Add a CI-only virtual `CLOCK_REALTIME` (VRT) shim so Kind/netdevsim workers can run `phc2sys -a -r` against a **per-node** stand-in mock PHC instead of the shared host clock.
- Wire VRT into DKMS Kind bring-up (`create-vrt-clocks.sh` / `k8s-start.sh`), install shim + `phc2sys` wrapper via `Dockerfile.lptpd`, and keep wrapper argv0 as `phc2sys` so metrics/logs use `process="phc2sys"`.
- Make `run-tests.sh` set `DisableAllSlaveRTUpdate: false` when VRT is already present (or `DKMS_MODE=true`), and add `--focus <regex>` for ginkgo focus passthrough.
- Add BC / DualNICBC serial outage coverage: `OsClockSyncState goes FREERUN on BC upstream loss and recovers to LOCKED` (metric + optional event asserts).
- CI hardening: PCI-backed netdevsim iface discovery, optional skopeo install (avoid breaking openvswitch), prometheus retag fallbacks.

## Related
- DKMS / VRT source companion: [redhat-cne/netdevsim-dkms#7](https://github.com/redhat-cne/netdevsim-dkms/pull/7)
- Dashboard VRT UI / process reporting: [edcdavid/ptp-dashboard#1](https://github.com/edcdavid/ptp-dashboard/pull/1)

## Dependency
**Contingent on [redhat-cne/cloud-event-proxy#731](https://github.com/redhat-cne/cloud-event-proxy/pull/731) being merged.**

The new BC reverse-sync FREERUN/LOCKED It exercises the case where `phc2sysOpts: -a -r` loses upstream, phc2sys reverses (PHC ← CLOCK_REALTIME), and `CLOCK_REALTIME` samples stop. CI / BC clocks need the fixed cloud-event-proxy from that PR to publish `os-clock-sync-state` FREERUN; without it the event/metric path stays stuck LOCKED and the test fails (or only proves the gap).

VRT alone enables safe `-a -r` on Kind; CEP #731 is required for correct reverse-sync detection on BC.

## Test plan
- [ ] `./run-on-vm.sh --dkms ...` completes `create-vrt-clocks.sh` (netdevsim90/91/92)
- [ ] Each worker has `/var/run/vrt/device` → unique `/dev/ptpN` in linuxptp-daemon; logs show `CLOCK_REALTIME phc offset ...` / LOCKED with `process=phc2sys`
- [ ] Re-run without `DKMS_MODE`: `./run-tests.sh --kind serial --mode bc` prints `DisableAllSlaveRTUpdate=false` when VRT device files already exist
- [ ] With CEP built from PR #731:  
  `ENABLE_PTP_EVENT=true ./run-tests.sh --kind serial --mode bc --focus "OsClockSyncState goes FREERUN"`
- [ ] Smoke: `scripts/ptp-vrt/test-shim-smoke.sh` (root + loaded netdevsim-dkms)

Assisted-By: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional virtual realtime clocks for Kind/netdevsim environments, enabling isolated PTP and `CLOCK_REALTIME` testing.
  * Added tooling to create, configure, and validate virtual clock devices across supported container runtimes.
  * Added focused test execution support and improved dynamic PTP test configuration.

* **Bug Fixes**
  * Prometheus deployment now falls back to Podman when `skopeo` is unavailable.

* **Tests**
  * Added smoke and conformance coverage for virtual clocks and reverse-sync recovery.
  * Expanded validation of realtime clock metrics and state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->