### PR TITLE
Makefile: add -f and --retry to curl downloads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ $(KUSTOMIZE): $(LOCALBIN)
 		echo "$(LOCALBIN)/kustomize version is not expected $(KUSTOMIZE_VERSION). Removing it before installing."; \
 		rm -rf $(LOCALBIN)/kustomize; \
 	fi
-	test -s $(LOCALBIN)/kustomize || { curl -Ss $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN); }
+	test -s $(LOCALBIN)/kustomize || { curl -fSs --retry 7 --retry-all-errors $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN); }
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary. If wrong version is installed, it will be overwritten.
@@ -208,9 +208,9 @@ operator-sdk: ## Download operator-sdk locally if necessary.
 ifneq ($(OPERATOR_SDK_VERSION),$(OPERATOR_SDK_VERSION_INSTALLED))
 ifeq ($(OS), Darwin)
 	mkdir -p $(LOCALBIN)/x86_64/
-	curl -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/operator-sdk/4.17.0/operator-sdk-v1.36.1-ocp-darwin-x86_64.tar.gz? | tar -xz -C bin/
+	curl -fL --retry 7 --retry-all-errors https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/operator-sdk/4.17.0/operator-sdk-v1.36.1-ocp-darwin-x86_64.tar.gz? | tar -xz -C bin/
 else
-	curl -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/operator-sdk/4.17.0/operator-sdk-v1.36.1-ocp-linux-x86_64.tar.gz? | tar -xz -C bin/
+	curl -fL --retry 7 --retry-all-errors https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/operator-sdk/4.17.0/operator-sdk-v1.36.1-ocp-linux-x86_64.tar.gz? | tar -xz -C bin/
 endif
 endif
 
@@ -286,7 +286,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
 	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.60.0/$${OS}-$${ARCH}-opm ;\
+	curl -fsSLo --retry 7 --retry-all-errors $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.60.0/$${OS}-$${ARCH}-opm ;\
 	chmod +x $(OPM) ;\
 	}
 else


### PR DESCRIPTION
## Summary
- All four `curl` calls in the Makefile (kustomize, operator-sdk darwin/linux, opm) lacked the `-f` flag and any retry logic
- When GitHub or mirror CDNs return 503 or drop connections (common from Actions runner IPs due to rate limiting), curl silently passes error HTML to bash/tar, causing confusing failures like `gzip: stdin: not in gzip format`
- Add `-f` (fail on HTTP errors instead of silently succeeding) and `--retry 7 --retry-all-errors` (exponential backoff, ~2 min max) to all Makefile curl invocations

## Test plan
- [x] Verified Makefile syntax is valid
- [ ] CI passes (kustomize/operator-sdk/opm downloads succeed with retry)

Assisted-By: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of downloading Kustomize, Operator SDK, and OPM tools by adding automatic retries and transient-error handling.
  * Downloads now fail more clearly when requests cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->