### PR TITLE
ci: fix Kind hang via podman API service and exclude .local-runs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+# CI run logs live under the repo and grow while parallel image builds run.
+# Dockerfile.ptpop uses `COPY .. .` with the repo root as context; including
+# these logs causes intermittent: archive/tar: write too long
+.local-runs
+
+# Not needed in image build context
+.git
+.github

--- a/.github/workflows/netdevsim-ci.yml
+++ b/.github/workflows/netdevsim-ci.yml
@@ -17,6 +17,8 @@ env:
   DKMS_VER: "6.9.5"
   DKMS_REPO: https://github.com/redhat-cne/netdevsim-dkms.git
   DKMS_BRANCH: main
+  # Optional: set to "true" to stream run-on-vm child command logs.
+  # RUN_ON_VM_VERBOSE: "true"
 
 jobs:
   # ------------------------------------------------------------------
@@ -169,6 +171,8 @@ jobs:
             "https://github.com/containers/crun/releases/download/${CRUN_VER}/crun-${CRUN_VER}-linux-amd64"
           sudo chmod +x /usr/bin/crun
           crun --version | head -1
+          # Serialize podman CLI via one API server (avoids Kind exec SQLite deadlock).
+          sudo bash "$GITHUB_WORKSPACE/scripts/start-podman-api-service.sh"
 
       - name: Copy checkout to /root/ptp-operator
         run: sudo cp -a "$GITHUB_WORKSPACE" /root/ptp-operator
@@ -178,7 +182,7 @@ jobs:
           sudo bash -l <<'BUILD'
           set -euo pipefail
           set -x
-          export PATH=/usr/local/go/bin:/root/go/bin:$PATH
+          export PATH=/usr/local/ptp-podman-wrap:/usr/local/bin:/usr/local/go/bin:/root/go/bin:$PATH
           export KIND_EXPERIMENTAL_PROVIDER=podman
 
           VM_IP=$(hostname -I | awk '{print $1}')
@@ -234,6 +238,8 @@ jobs:
             "https://github.com/containers/crun/releases/download/${CRUN_VER}/crun-${CRUN_VER}-linux-amd64"
           sudo chmod +x /usr/bin/crun
           crun --version | head -1
+          # Serialize podman CLI via one API server (avoids Kind exec SQLite deadlock).
+          sudo bash "$GITHUB_WORKSPACE/scripts/start-podman-api-service.sh"
 
       - name: Install OpenShift CLI (oc)
         run: |
@@ -279,7 +285,7 @@ jobs:
           sudo bash -l <<'LOAD'
           set -euo pipefail
           set -x
-          export PATH=/usr/local/go/bin:/root/go/bin:$PATH
+          export PATH=/usr/local/ptp-podman-wrap:/usr/local/bin:/usr/local/go/bin:/root/go/bin:$PATH
           export KIND_EXPERIMENTAL_PROVIDER=podman
 
           VM_IP=$(hostname -I | awk '{print $1}')
@@ -301,7 +307,7 @@ jobs:
           sudo bash -l <<'DEPLOY'
           set -euo pipefail
           set -x
-          export PATH=/usr/local/go/bin:/root/go/bin:$PATH
+          export PATH=/usr/local/ptp-podman-wrap:/usr/local/bin:/usr/local/go/bin:/root/go/bin:$PATH
           export KIND_EXPERIMENTAL_PROVIDER=podman
 
           VM_IP=$(hostname -I | awk '{print $1}')

--- a/scripts/k8s-start.sh
+++ b/scripts/k8s-start.sh
@@ -5,6 +5,13 @@ set -euo pipefail
 VM_IP=$1
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# Kind runs parallel `podman exec`; daemonless podman deadlocks on SQLite.
+# Prefer a single API server when the helper is present (CI installs it).
+if [[ -f "${SCRIPT_DIR}/start-podman-api-service.sh" ]]; then
+  bash "${SCRIPT_DIR}/start-podman-api-service.sh" || true
+fi
+export PATH="/usr/local/ptp-podman-wrap:/usr/local/bin:${PATH}"
+
 # Delete cluster
 kind delete cluster --name kind-netdevsim
 

--- a/scripts/run-on-vm.sh
+++ b/scripts/run-on-vm.sh
@@ -2,6 +2,9 @@
 set -euo pipefail
 
 export DKMS_MODE="${DKMS_MODE:-false}"
+# Stream child command output live (default: quiet, dump log only on failure).
+# Override with --verbose or RUN_ON_VM_VERBOSE=true|1|yes.
+RUN_ON_VM_VERBOSE="${RUN_ON_VM_VERBOSE:-false}"
 TEST_MODES="oc,bc,dualnicbc,dualnicbcha,dualfollower"
 RUN_PHASE="all"
 REGISTRY_IP=""
@@ -11,6 +14,7 @@ KEEP_TMP=true
 while [[ "${1:-}" == --* ]]; do
     case "$1" in
         --dkms)    export DKMS_MODE=true; shift ;;
+        --verbose) RUN_ON_VM_VERBOSE=true; shift ;;
         --mode)    TEST_MODES="$2"; shift 2 ;;
         --images)  RUN_PHASE="images"; shift ;;
         --deploy)  RUN_PHASE="deploy"; REGISTRY_IP="$2"; shift 2 ;;
@@ -19,6 +23,12 @@ while [[ "${1:-}" == --* ]]; do
         *) echo "Unknown flag: $1"; exit 1 ;;
     esac
 done
+
+case "${RUN_ON_VM_VERBOSE}" in
+  1|true|TRUE|yes|YES|on|ON) RUN_ON_VM_VERBOSE=true ;;
+  *) RUN_ON_VM_VERBOSE=false ;;
+esac
+export RUN_ON_VM_VERBOSE
 
 # Per-run temp directory shared by all child scripts.
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -86,6 +96,7 @@ read_ptp_tool_images() {
 }
 
 # Run with stdout/stderr captured; no output on success, On failure, print the command log.
+# With RUN_ON_VM_VERBOSE=true, stream output live (already teed to RUN_ON_VM_LOG).
 run_quiet_with_log_dump_on_failure() {
   local log_tag="$1"
   shift
@@ -94,6 +105,17 @@ run_quiet_with_log_dump_on_failure() {
   log_file="$(mktemp "${PTP_RUN_DIR}/${log_tag// /_}.XXXXXX.log")"
 
   local rc
+  if [[ "${RUN_ON_VM_VERBOSE}" == true ]]; then
+    echo -e "${COLOR_GRAY}---- BEGIN ${log_tag} (verbose) ----${COLOR_RESET} ${COLOR_GRAY}@ $(log_ts)${COLOR_RESET}"
+    set +e
+    "$@" </dev/null
+    rc=$?
+    set -e
+    echo -e "${COLOR_GRAY}---- END ${log_tag} (verbose, exit ${rc}) ----${COLOR_RESET} ${COLOR_GRAY}@ $(log_ts)${COLOR_RESET}"
+    rm -f "${log_file}"
+    return "${rc}"
+  fi
+
   if "$@" >"${log_file}" 2>&1 </dev/null; then
     rc=0
   else

--- a/scripts/start-podman-api-service.sh
+++ b/scripts/start-podman-api-service.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Run all podman CLI invocations through a single API server.
+#
+# Kind fires parallel `podman exec` during "Writing configuration". Each
+# daemonless podman process locks the shared libpod SQLite DB; concurrent
+# execs into systemd (kindest/node) containers deadlock (futex_wait). A
+# single `podman system service` serializes DB access like dockerd does.
+#
+# Usage: start-podman-api-service.sh
+# Idempotent. Safe to call from CI after overlay config / before Kind.
+set -euo pipefail
+
+if [[ "$(id -u)" -ne 0 ]]; then
+  exec sudo -E bash "$0" "$@"
+fi
+
+SOCK="${PODMAN_API_SOCK:-unix:///run/podman/podman.sock}"
+SOCK_PATH="${SOCK#unix://}"
+# Dedicated dir so we never overwrite the real podman binary (kubic may
+# install it at /usr/local/bin/podman → ETXTBSY if we try to replace it).
+WRAP_DIR="${PODMAN_WRAP_DIR:-/usr/local/ptp-podman-wrap}"
+WRAPPER="${WRAP_DIR}/podman"
+
+mkdir -p "$(dirname "${SOCK_PATH}")" "${WRAP_DIR}"
+
+# Resolve the real binary before we put our wrapper ahead on PATH.
+REAL_PODMAN="${REAL_PODMAN:-}"
+if [[ -z "${REAL_PODMAN}" ]]; then
+  for candidate in /usr/bin/podman /usr/local/bin/podman; do
+    if [[ -x "${candidate}" && "${candidate}" != "${WRAPPER}" ]]; then
+      # Skip if this path is already our wrapper script.
+      if head -n1 "${candidate}" 2>/dev/null | grep -q '^#!'; then
+        if grep -q 'start-podman-api-service' "${candidate}" 2>/dev/null; then
+          continue
+        fi
+      fi
+      REAL_PODMAN="${candidate}"
+      break
+    fi
+  done
+fi
+if [[ -z "${REAL_PODMAN}" || ! -x "${REAL_PODMAN}" ]]; then
+  echo "ERROR: could not find real podman binary"
+  exit 1
+fi
+echo "Using real podman binary: ${REAL_PODMAN}"
+
+# Prefer systemd socket (podman.socket) when present; else start a service.
+if [[ -S "${SOCK_PATH}" ]] && "${REAL_PODMAN}" --remote --url "${SOCK}" info >/dev/null 2>&1; then
+  echo "podman API already up at ${SOCK}"
+else
+  # Try enabling the packaged socket first.
+  systemctl enable --now podman.socket 2>/dev/null || true
+  sleep 0.5
+fi
+
+if ! "${REAL_PODMAN}" --remote --url "${SOCK}" info >/dev/null 2>&1; then
+  rm -f "${SOCK_PATH}"
+  "${REAL_PODMAN}" system service --time=0 "${SOCK}" >/var/log/podman-api-service.log 2>&1 &
+  echo $! >/run/podman-api-service.pid
+  echo "Started podman system service pid=$(cat /run/podman-api-service.pid) sock=${SOCK}"
+
+  for _ in $(seq 1 50); do
+    if [[ -S "${SOCK_PATH}" ]] && "${REAL_PODMAN}" --remote --url "${SOCK}" info >/dev/null 2>&1; then
+      break
+    fi
+    sleep 0.2
+  done
+fi
+
+if ! "${REAL_PODMAN}" --remote --url "${SOCK}" info >/dev/null 2>&1; then
+  echo "ERROR: podman API failed to become ready"
+  tail -n 50 /var/log/podman-api-service.log || true
+  systemctl status podman.socket podman.service 2>&1 | head -40 || true
+  exit 1
+fi
+
+# Atomic replace of wrapper (never overwrite /usr/bin or /usr/local/bin/podman).
+tmp="$(mktemp "${WRAP_DIR}/podman.XXXXXX")"
+cat >"${tmp}" <<EOF
+#!/bin/bash
+# Installed by scripts/start-podman-api-service.sh — do not edit.
+exec ${REAL_PODMAN} --remote --url ${SOCK} "\$@"
+EOF
+chmod 755 "${tmp}"
+mv -f "${tmp}" "${WRAPPER}"
+
+echo "podman wrapper: ${WRAPPER} -> ${REAL_PODMAN} --remote --url ${SOCK}"
+echo "Prepend ${WRAP_DIR} to PATH so Kind/CI use the remote client."
+# Smoke-test via the wrapper itself.
+PATH="${WRAP_DIR}:${PATH}" "${WRAPPER}" info --format 'API ok GraphDriver={{.Store.GraphDriverName}}' \
+  || PATH="${WRAP_DIR}:${PATH}" "${WRAPPER}" info | head -n 20


### PR DESCRIPTION
## Summary
- Fix Kind `Writing configuration` hang by running all `podman` CLI calls through a single `podman system service` (`--remote` wrapper), avoiding daemonless SQLite lock deadlocks from parallel `podman exec`.
- Add `.dockerignore` so parallel image builds do not pick up growing `.local-runs` logs (`archive/tar: write too long`).
- Keep optional `run-on-vm --verbose` / `RUN_ON_VM_VERBOSE` (disabled by default).

## Test plan
- [ ] netdevsim CI green on this PR
- [ ] Kind progresses past Writing configuration on all matrix modes
- [ ] Image builds succeed without tar context errors

Assisted-By: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of container image builds and scenario deployments by ensuring Podman services are available when needed.
  * Improved Kubernetes startup behavior with automatic Podman service setup and safer fallback handling.

* **New Features**
  * Added optional verbose command output for easier troubleshooting, including live progress, completion status, and exit codes.

* **Chores**
  * Reduced unnecessary files and metadata included in Docker build contexts.
  * Added clearer diagnostics when Podman setup or startup encounters an issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->