### PR TITLE
fix: match qualified and unqualified PTP profile names in e2e helpers

### DIFF
--- a/test/conformance/serial/ptp.go
+++ b/test/conformance/serial/ptp.go
@@ -356,7 +356,11 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 
 	Describe("PTP e2e tests", func() {
 		var ptpPods *v1core.PodList
-		var fifoPriorities map[string]int64
+		var fifoPriorities []struct {
+			configName  string
+			profileName string
+			priority    int64
+		}
 		var fullConfig testconfig.TestConfig
 		portEngine := ptptesthelper.PortEngine{}
 
@@ -528,10 +532,21 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 				if fullConfig.PtpModeDesired == testconfig.Discovery {
 					Skip("This test needs the ptp-daemon to be rebooted but it is not possible in discovery mode, skipping")
 				}
-				profileSlave := fmt.Sprintf("Profile Name: %s", fullConfig.DiscoveredClockUnderTestPtpConfig.Name)
+				clockUnderTestConfig := (*ptpv1.PtpConfig)(fullConfig.DiscoveredClockUnderTestPtpConfig)
+				profileSlaveName, err := ptphelper.GetProfileName(clockUnderTestConfig, true)
+				Expect(err).NotTo(HaveOccurred(), "could not get clock-under-test profile name")
+				profileSlave := "Profile Name: " + ptphelper.ProfileNameMatchPattern(clockUnderTestConfig.Name, profileSlaveName)
+				if fullConfig.PtpModeDesired == testconfig.TelcoBoundaryClock {
+					profileSlave = "Profile Name: (?:" +
+						ptphelper.ProfileNameMatchPattern(clockUnderTestConfig.Name, "tbc-tr") + "|" +
+						ptphelper.ProfileNameMatchPattern(clockUnderTestConfig.Name, "tbc-tt") + ")"
+				}
 				profileMaster := ""
 				if fullConfig.DiscoveredGrandMasterPtpConfig != nil {
-					profileMaster = fmt.Sprintf("Profile Name: %s", fullConfig.DiscoveredGrandMasterPtpConfig.Name)
+					gmConfig := (*ptpv1.PtpConfig)(fullConfig.DiscoveredGrandMasterPtpConfig)
+					gmProfileName, gmErr := ptphelper.GetProfileName(gmConfig, false)
+					Expect(gmErr).NotTo(HaveOccurred(), "could not get grandmaster profile name")
+					profileMaster = "Profile Name: " + ptphelper.ProfileNameMatchPattern(gmConfig.Name, gmProfileName)
 				}
 
 				for podIndex := range ptpPods.Items {
@@ -544,24 +559,16 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 						Fail(fmt.Sprintf("check Grandmaster clock type, err=%s", err))
 					}
 					if isClockUnderTest {
-						if fullConfig.PtpModeDesired == testconfig.TelcoBoundaryClock {
-							// T-BC daemon profiles are qualified: <configname>_tbc-tr / <configname>_tbc-tt
-							tbcConfigName := fullConfig.DiscoveredClockUnderTestPtpConfig.Name
-							_, err = pods.GetPodLogsRegex(ptpPods.Items[podIndex].Namespace,
-								ptpPods.Items[podIndex].Name, pkg.PtpContainerName,
-								"Profile Name: "+regexp.QuoteMeta(tbcConfigName)+"_tbc-t(r|t)", false, pkg.TimeoutIn3Minutes)
-						} else {
-							_, err = pods.GetPodLogsRegex(ptpPods.Items[podIndex].Namespace,
-								ptpPods.Items[podIndex].Name, pkg.PtpContainerName,
-								profileSlave, true, pkg.TimeoutIn3Minutes)
-						}
+						_, err = pods.GetPodLogsRegex(ptpPods.Items[podIndex].Namespace,
+							ptpPods.Items[podIndex].Name, pkg.PtpContainerName,
+							profileSlave, false, pkg.TimeoutIn3Minutes)
 						if err != nil {
 							Fail(fmt.Sprintf("could not get slave profile name, err=%s", err))
 						}
 					} else if isGrandmaster && fullConfig.DiscoveredGrandMasterPtpConfig != nil {
 						_, err = pods.GetPodLogsRegex(ptpPods.Items[podIndex].Namespace,
 							ptpPods.Items[podIndex].Name, pkg.PtpContainerName,
-							profileMaster, true, pkg.TimeoutIn5Minutes)
+							profileMaster, false, pkg.TimeoutIn5Minutes)
 						if err != nil {
 							Fail(fmt.Sprintf("could not get master profile name, err=%s", err))
 						}
@@ -586,9 +593,11 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 				if fullConfig.L2Config != nil && !isExternalMaster {
 					aLabel := pkg.PtpGrandmasterNodeLabel
 					var aString string
+					Expect(fullConfig.DiscoveredGrandMasterPtpConfig).NotTo(BeNil(), "expected discovered grandmaster config")
+					gmConfigName := (*ptpv1.PtpConfig)(fullConfig.DiscoveredGrandMasterPtpConfig).Name
 					Eventually(func() error {
 						var getErr error
-						aString, getErr = ptphelper.GetClockIDMaster(pkg.PtpGrandMasterPolicyName, &aLabel, nil, true)
+						aString, getErr = ptphelper.GetClockIDMaster(gmConfigName, pkg.PtpGrandMasterPolicyName, &aLabel, nil, true)
 						return getErr
 					}, pkg.TimeoutIn3Minutes, pkg.Timeout10Seconds).Should(BeNil(),
 						"Timeout to get grandmaster clock ID")
@@ -774,9 +783,11 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 				if fullConfig.L2Config != nil && !isExternalMaster {
 					aLabel := pkg.PtpGrandmasterNodeLabel
 					var aString string
+					Expect(fullConfig.DiscoveredGrandMasterPtpConfig).NotTo(BeNil(), "expected discovered grandmaster config")
+					gmConfigName := (*ptpv1.PtpConfig)(fullConfig.DiscoveredGrandMasterPtpConfig).Name
 					Eventually(func() error {
 						var getErr error
-						aString, getErr = ptphelper.GetClockIDMaster(pkg.PtpGrandMasterPolicyName, &aLabel, nil, true)
+						aString, getErr = ptphelper.GetClockIDMaster(gmConfigName, pkg.PtpGrandMasterPolicyName, &aLabel, nil, true)
 						return getErr
 					}, pkg.TimeoutIn3Minutes, pkg.Timeout10Seconds).Should(BeNil(),
 						"Timeout to get grandmaster clock ID")
@@ -890,15 +901,15 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 				}
 				aLabel := pkg.PtpClockUnderTestNodeLabel
 				name := pkg.PtpBcMaster1PolicyName
+				Expect(fullConfig.DiscoveredClockUnderTestPtpConfig).ToNot(BeNil(), "BC mode requires DiscoveredClockUnderTestPtpConfig")
+				bc1ConfigName := (*ptpv1.PtpConfig)(fullConfig.DiscoveredClockUnderTestPtpConfig).Name
 				if fullConfig.PtpModeDiscovered == testconfig.TelcoBoundaryClock {
-					Expect(fullConfig.DiscoveredClockUnderTestPtpConfig).ToNot(BeNil(), "T-BC mode requires DiscoveredClockUnderTestPtpConfig")
-					crName := (*ptpv1.PtpConfig)(fullConfig.DiscoveredClockUnderTestPtpConfig).Name
-					name = ptphelper.QualifyProfileName(crName, "tbc-tr")
+					name = "tbc-tr"
 				}
 				var masterIDBc1 string
 				Eventually(func() error {
 					var getErr error
-					masterIDBc1, getErr = ptphelper.GetClockIDMaster(name, &aLabel, nil, false)
+					masterIDBc1, getErr = ptphelper.GetClockIDMaster(bc1ConfigName, name, &aLabel, nil, false)
 					return getErr
 				}, pkg.TimeoutIn3Minutes, pkg.Timeout10Seconds).Should(BeNil(),
 					"Timeout to get BC master1 clock ID")
@@ -909,9 +920,13 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 					(fullConfig.FoundSolutions[testconfig.AlgoDualNicBCWithSlavesExtGMString] || fullConfig.FoundSolutions[testconfig.AlgoDualNicBCWithSlavesString]) {
 					aLabel := pkg.PtpClockUnderTestNodeLabel
 					var masterIDBc2 string
+					bc2ConfigName := bc1ConfigName
+					if fullConfig.DiscoveredClockUnderTestSecondaryPtpConfig != nil {
+						bc2ConfigName = (*ptpv1.PtpConfig)(fullConfig.DiscoveredClockUnderTestSecondaryPtpConfig).Name
+					}
 					Eventually(func() error {
 						var getErr error
-						masterIDBc2, getErr = ptphelper.GetClockIDMaster(pkg.PtpBcMaster2PolicyName, &aLabel, nil, false)
+						masterIDBc2, getErr = ptphelper.GetClockIDMaster(bc2ConfigName, pkg.PtpBcMaster2PolicyName, &aLabel, nil, false)
 						return getErr
 					}, pkg.TimeoutIn3Minutes, pkg.Timeout10Seconds).Should(BeNil(),
 						"Timeout to get BC master2 clock ID")
@@ -984,7 +999,7 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 				By("Waiting for daemon to load the temp profile", func() {
 					_, err := pods.GetPodLogsRegex(testPtpPod.Namespace,
 						testPtpPod.Name, pkg.PtpContainerName,
-						"Profile Name: "+pkg.PtpTempPolicyName, true, pkg.TimeoutIn3Minutes)
+						"Profile Name: "+ptphelper.ProfileNameMatchPattern(pkg.PtpTempPolicyName, pkg.PtpTempPolicyName), false, pkg.TimeoutIn3Minutes)
 					Expect(err).NotTo(HaveOccurred(), "daemon did not load temp profile in time")
 				})
 
@@ -1000,9 +1015,11 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 					if fullConfig.L2Config != nil && !isExternalMaster {
 						aLabel := pkg.PtpGrandmasterNodeLabel
 						var gmClockID string
+						Expect(fullConfig.DiscoveredGrandMasterPtpConfig).NotTo(BeNil(), "expected discovered grandmaster config")
+						gmConfigName := (*ptpv1.PtpConfig)(fullConfig.DiscoveredGrandMasterPtpConfig).Name
 						Eventually(func() error {
 							var getErr error
-							gmClockID, getErr = ptphelper.GetClockIDMaster(pkg.PtpGrandMasterPolicyName, &aLabel, nil, true)
+							gmClockID, getErr = ptphelper.GetClockIDMaster(gmConfigName, pkg.PtpGrandMasterPolicyName, &aLabel, nil, true)
 							return getErr
 						}, pkg.TimeoutIn3Minutes, pkg.Timeout10Seconds).Should(BeNil(),
 							"Timeout to get grandmaster clock ID")
@@ -1021,7 +1038,7 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 							var slaveMaster string
 							Eventually(func() error {
 								var getErr error
-								slaveMaster, getErr = ptphelper.GetClockIDForeign(profileName, label, node)
+								slaveMaster, getErr = ptphelper.GetClockIDForeign(modifiedPtpConfig.Name, profileName, label, node)
 								if getErr != nil {
 									return getErr
 								}
@@ -1045,17 +1062,22 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 				})
 
 				By("Checking the profile is reverted", func() {
+					profileLogPattern := "Profile Name: " + ptphelper.ProfileNameMatchPattern(policyName, policyName)
+					profileFilePattern := ptphelper.ProfileNameMatchPattern(policyName, policyName)
+					if policyName == pkg.PTPWPCTBCPolicyName {
+						tbcPattern := "(?:" +
+							ptphelper.ProfileNameMatchPattern(policyName, "tbc-tr") + "|" +
+							ptphelper.ProfileNameMatchPattern(policyName, "tbc-tt") + ")"
+						profileLogPattern = "Profile Name: " + tbcPattern
+						profileFilePattern = tbcPattern
+					}
 					_, err := pods.GetPodLogsRegex(testPtpPod.Namespace,
 						testPtpPod.Name, pkg.PtpContainerName,
-						"Profile Name: "+policyName, true, pkg.TimeoutIn3Minutes)
+						profileLogPattern, false, pkg.TimeoutIn3Minutes)
 					if err != nil {
-						profileRegex := policyName
-						if policyName == pkg.PTPWPCTBCPolicyName {
-							profileRegex = "tbc-(tr|tt)"
-						}
 						// Fallback to file-based search to get the profile name
 						// for when logs do not contain the profile.
-						_, err = ptphelper.GetConfigForProfileFromVarRun(profileRegex, &testPtpPod, pkg.PtpContainerName)
+						_, err = ptphelper.GetConfigForProfileFromVarRun(profileFilePattern, &testPtpPod, pkg.PtpContainerName)
 						if err != nil {
 							Fail(fmt.Sprintf("could not get profile name, err=%s", err))
 						}
@@ -1906,12 +1928,16 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 				masterConfigs, slaveConfigs := ptphelper.DiscoveryPTPConfiguration(pkg.PtpLinuxDaemonNamespace)
 				ptpConfigs := append(masterConfigs, slaveConfigs...)
 
-				fifoPriorities = make(map[string]int64)
+				fifoPriorities = nil
 				for _, config := range ptpConfigs {
 					for _, profile := range config.Spec.Profile {
 						if profile.PtpSchedulingPolicy != nil && *profile.PtpSchedulingPolicy == "SCHED_FIFO" {
-							if profile.PtpSchedulingPriority != nil {
-								fifoPriorities[ptphelper.QualifyProfileName(config.Name, *profile.Name)] = *profile.PtpSchedulingPriority
+							if profile.Name != nil && profile.PtpSchedulingPriority != nil {
+								fifoPriorities = append(fifoPriorities, struct {
+									configName  string
+									profileName string
+									priority    int64
+								}{config.Name, *profile.Name, *profile.PtpSchedulingPriority})
 							}
 						}
 					}
@@ -1926,15 +1952,17 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 			})
 			It("Should check whether using fifo scheduling", func() {
 				By("checking for chrt logs")
-				for name, priority := range fifoPriorities {
-					ptp4lLog := fmt.Sprintf("/bin/chrt -f %d /usr/sbin/ptp4l", priority)
+				for i := 0; i < len(fifoPriorities); {
+					fp := fifoPriorities[i]
+					ptp4lLog := fmt.Sprintf("/bin/chrt -f %d /usr/sbin/ptp4l", fp.priority)
+					matched := false
 					for podIndex := range ptpPods.Items {
-						profileName := fmt.Sprintf("Profile Name: %s", name)
+						profileLog := "Profile Name: " + ptphelper.ProfileNameMatchPattern(fp.configName, fp.profileName)
 						_, err := pods.GetPodLogsRegex(ptpPods.Items[podIndex].Namespace,
 							ptpPods.Items[podIndex].Name, pkg.PtpContainerName,
-							profileName, true, pkg.TimeoutIn3Minutes)
+							profileLog, false, pkg.TimeoutIn3Minutes)
 						if err != nil {
-							logrus.Errorf("error getting profile=%s, err=%s ", name, err)
+							logrus.Errorf("error getting profile=%s/%s, err=%s ", fp.configName, fp.profileName, err)
 							continue
 						}
 						_, err = pods.GetPodLogsRegex(ptpPods.Items[podIndex].Namespace,
@@ -1944,7 +1972,13 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 							logrus.Errorf("error getting ptp4l chrt line=%s, err=%s ", ptp4lLog, err)
 							continue
 						}
-						delete(fifoPriorities, name)
+						matched = true
+						break
+					}
+					if matched {
+						fifoPriorities = append(fifoPriorities[:i], fifoPriorities[i+1:]...)
+					} else {
+						i++
 					}
 				}
 				Expect(fifoPriorities).To(HaveLen(0))
@@ -3164,15 +3198,11 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			// Daemon profiles are qualified: <configname>_<profilename>
-			qualifiedTT := ptphelper.QualifyProfileName(originalPtpConfig.Name, "tbc-tt")
-			qualifiedTR := ptphelper.QualifyProfileName(originalPtpConfig.Name, "tbc-tr")
-
 			// Discover TT config (for PMC) and TR config (daemon publishes clock_class metric under receiver)
 			nodeName := fullConfig.DiscoveredClockUnderTestPod.Spec.NodeName
-			cfgName, err := ptphelper.GetConfigForProfile(qualifiedTT, nil, &nodeName)
+			cfgName, err := ptphelper.GetConfigForProfile(originalPtpConfig.Name, "tbc-tt", nil, &nodeName)
 			Expect(err).NotTo(HaveOccurred())
-			trCfgName, err := ptphelper.GetConfigForProfile(qualifiedTR, nil, &nodeName)
+			trCfgName, err := ptphelper.GetConfigForProfile(originalPtpConfig.Name, "tbc-tr", nil, &nodeName)
 			Expect(err).NotTo(HaveOccurred())
 			ttNIC := ptptesthelper.NICInfo{
 				ConfigName:    strings.TrimPrefix(trCfgName, "/var/run/"),

--- a/test/conformance/serial/ptp.go
+++ b/test/conformance/serial/ptp.go
@@ -535,9 +535,9 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 				clockUnderTestConfig := (*ptpv1.PtpConfig)(fullConfig.DiscoveredClockUnderTestPtpConfig)
 				profileSlaveName, err := ptphelper.GetProfileName(clockUnderTestConfig, true)
 				Expect(err).NotTo(HaveOccurred(), "could not get clock-under-test profile name")
-				profileSlave := "Profile Name: " + ptphelper.ProfileNameMatchPattern(clockUnderTestConfig.Name, profileSlaveName)
+				profileSlave := ptphelper.ProfileNameLogPattern(clockUnderTestConfig.Name, profileSlaveName)
 				if fullConfig.PtpModeDesired == testconfig.TelcoBoundaryClock {
-					profileSlave = "Profile Name: (?:" +
+					profileSlave = `(?m)Profile Name: (?:` +
 						ptphelper.ProfileNameMatchPattern(clockUnderTestConfig.Name, "tbc-tr") + "|" +
 						ptphelper.ProfileNameMatchPattern(clockUnderTestConfig.Name, "tbc-tt") + ")"
 				}
@@ -546,7 +546,7 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 					gmConfig := (*ptpv1.PtpConfig)(fullConfig.DiscoveredGrandMasterPtpConfig)
 					gmProfileName, gmErr := ptphelper.GetProfileName(gmConfig, false)
 					Expect(gmErr).NotTo(HaveOccurred(), "could not get grandmaster profile name")
-					profileMaster = "Profile Name: " + ptphelper.ProfileNameMatchPattern(gmConfig.Name, gmProfileName)
+					profileMaster = ptphelper.ProfileNameLogPattern(gmConfig.Name, gmProfileName)
 				}
 
 				for podIndex := range ptpPods.Items {
@@ -999,7 +999,7 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 				By("Waiting for daemon to load the temp profile", func() {
 					_, err := pods.GetPodLogsRegex(testPtpPod.Namespace,
 						testPtpPod.Name, pkg.PtpContainerName,
-						"Profile Name: "+ptphelper.ProfileNameMatchPattern(pkg.PtpTempPolicyName, pkg.PtpTempPolicyName), false, pkg.TimeoutIn3Minutes)
+						ptphelper.ProfileNameLogPattern(pkg.PtpTempPolicyName, pkg.PtpTempPolicyName), false, pkg.TimeoutIn3Minutes)
 					Expect(err).NotTo(HaveOccurred(), "daemon did not load temp profile in time")
 				})
 
@@ -1062,13 +1062,13 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 				})
 
 				By("Checking the profile is reverted", func() {
-					profileLogPattern := "Profile Name: " + ptphelper.ProfileNameMatchPattern(policyName, policyName)
+					profileLogPattern := ptphelper.ProfileNameLogPattern(policyName, policyName)
 					profileFilePattern := ptphelper.ProfileNameMatchPattern(policyName, policyName)
 					if policyName == pkg.PTPWPCTBCPolicyName {
 						tbcPattern := "(?:" +
 							ptphelper.ProfileNameMatchPattern(policyName, "tbc-tr") + "|" +
 							ptphelper.ProfileNameMatchPattern(policyName, "tbc-tt") + ")"
-						profileLogPattern = "Profile Name: " + tbcPattern
+						profileLogPattern = `(?m)Profile Name: ` + tbcPattern
 						profileFilePattern = tbcPattern
 					}
 					_, err := pods.GetPodLogsRegex(testPtpPod.Namespace,
@@ -1957,7 +1957,7 @@ var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, f
 					ptp4lLog := fmt.Sprintf("/bin/chrt -f %d /usr/sbin/ptp4l", fp.priority)
 					matched := false
 					for podIndex := range ptpPods.Items {
-						profileLog := "Profile Name: " + ptphelper.ProfileNameMatchPattern(fp.configName, fp.profileName)
+						profileLog := ptphelper.ProfileNameLogPattern(fp.configName, fp.profileName)
 						_, err := pods.GetPodLogsRegex(ptpPods.Items[podIndex].Namespace,
 							ptpPods.Items[podIndex].Name, pkg.PtpContainerName,
 							profileLog, false, pkg.TimeoutIn3Minutes)

--- a/test/pkg/ptphelper/ptphelper.go
+++ b/test/pkg/ptphelper/ptphelper.go
@@ -81,17 +81,24 @@ func findMatchingPod(label *string, nodeName *string) (*corev1.Pod, error) {
 	}
 }
 
-func GetProfileLogID(ptpConfigName string, label *string, nodeName *string) (string, error) {
+func GetProfileLogID(ptpConfigName string, profileName string, label *string, nodeName *string) (string, error) {
 	const logIDRegex = `(?m).*?Ptp4lConf: #profile: %s(.|\n)*?message_tag \[(.*)\]`
 	const logIDIndex = 2
 
-	renderedRegex := fmt.Sprintf(logIDRegex, ptpConfigName)
+	if ptpConfigName == "" {
+		return "", fmt.Errorf("ptp config name is required")
+	}
+	if profileName == "" {
+		return "", fmt.Errorf("profile name is required")
+	}
+
+	renderedRegex := fmt.Sprintf(logIDRegex, ProfileNameMatchPattern(ptpConfigName, profileName))
 	var lastErr error
 	deadline := time.Now().Add(pkg.TimeoutIn3Minutes)
 	for attempt := 1; ; attempt++ {
 		pod, err := findMatchingPod(label, nodeName)
 		if err != nil {
-			lastErr = fmt.Errorf("finding pod for %s: %w", ptpConfigName, err)
+			lastErr = fmt.Errorf("finding pod for profile %s: %w", profileName, err)
 		} else {
 			matches, err := pods.GetPodLogsRegex(pod.Namespace,
 				pod.Name, pkg.PtpContainerName,
@@ -99,11 +106,11 @@ func GetProfileLogID(ptpConfigName string, label *string, nodeName *string) (str
 			if err != nil {
 				lastErr = fmt.Errorf("could not get any profile line, err=%s", err)
 			} else if len(matches) == 0 || len(matches[len(matches)-1]) <= logIDIndex {
-				lastErr = fmt.Errorf("profile log id not found for %s in pod %s/%s", ptpConfigName, pod.Namespace, pod.Name)
+				lastErr = fmt.Errorf("profile log id not found for %s in pod %s/%s", profileName, pod.Namespace, pod.Name)
 			} else {
 				id := matches[len(matches)-1][logIDIndex]
 				if id == "" {
-					lastErr = fmt.Errorf("empty profile log id for %s in pod %s/%s", ptpConfigName, pod.Namespace, pod.Name)
+					lastErr = fmt.Errorf("empty profile log id for %s in pod %s/%s", profileName, pod.Namespace, pod.Name)
 				} else {
 					return id, nil
 				}
@@ -113,14 +120,14 @@ func GetProfileLogID(ptpConfigName string, label *string, nodeName *string) (str
 		if time.Now().After(deadline) {
 			pod, podErr := findMatchingPod(label, nodeName)
 			if podErr == nil {
-				configPath, fallbackErr := GetConfigForProfileFromVarRun(ptpConfigName, pod, pkg.PtpContainerName)
-				if fallbackErr == nil {
+				configPath, err := GetConfigForProfileFromVarRun(ProfileNameMatchPattern(ptpConfigName, profileName), pod, pkg.PtpContainerName)
+				if err == nil {
 					return filepath.Base(configPath), nil
 				}
 			}
 			return "", lastErr
 		}
-		logrus.Infof("GetProfileLogID attempt %d failed for %s: %v, retrying...", attempt, ptpConfigName, lastErr)
+		logrus.Infof("GetProfileLogID attempt %d failed for profile=%s ptpConfig=%s: %v, retrying...", attempt, profileName, ptpConfigName, lastErr)
 		time.Sleep(pkg.Timeout10Seconds)
 	}
 }
@@ -152,7 +159,7 @@ func getClockIDViaPMC(pod *corev1.Pod, configFile, field string) (string, error)
 	return matches[1], nil
 }
 
-func GetClockIDMaster(ptpConfigName string, label *string, nodeName *string, isGM bool) (string, error) {
+func GetClockIDMaster(ptpConfigName string, profileName string, label *string, nodeName *string, isGM bool) (string, error) {
 	const clockIDGMRegex = `(?m)\[%s\] selected local clock (.*) as best master`
 	const clockIDBCRegex = `(?m)\[%s\] selected best master clock (.*)`
 	const clockIDIndex = 1
@@ -160,7 +167,7 @@ func GetClockIDMaster(ptpConfigName string, label *string, nodeName *string, isG
 	if isGM {
 		clockIDRegex = clockIDGMRegex
 	}
-	logID, err := GetProfileLogID(ptpConfigName, label, nodeName)
+	logID, err := GetProfileLogID(ptpConfigName, profileName, label, nodeName)
 	if err != nil {
 		return "", err
 	}
@@ -179,14 +186,14 @@ func GetClockIDMaster(ptpConfigName string, label *string, nodeName *string, isG
 	if err == nil && len(matches) > 0 && len(matches[len(matches)-1]) > clockIDIndex {
 		return matches[len(matches)-1][clockIDIndex], nil
 	}
-	logrus.Infof("GetClockIDMaster: log parsing failed for %s (isGM=%v), falling back to pmc: %v", ptpConfigName, isGM, err)
+	logrus.Infof("GetClockIDMaster: log parsing failed for %s (isGM=%v), falling back to pmc: %v", profileName, isGM, err)
 	return getClockIDViaPMC(pod, configFile, "grandmasterIdentity")
 }
 
-func GetClockIDForeign(ptpConfigName string, label *string, nodeName *string) (string, error) {
+func GetClockIDForeign(ptpConfigName string, profileName string, label *string, nodeName *string) (string, error) {
 	const clockIDForeignRegex = `(?m)\[%s\].* selected best master clock (.*)`
 	const clockIDForeignIndex = 1
-	logID, err := GetProfileLogID(ptpConfigName, label, nodeName)
+	logID, err := GetProfileLogID(ptpConfigName, profileName, label, nodeName)
 	if err != nil {
 		return "", err
 	}
@@ -205,7 +212,7 @@ func GetClockIDForeign(ptpConfigName string, label *string, nodeName *string) (s
 	if err == nil && len(matches) > 0 && len(matches[len(matches)-1]) > clockIDForeignIndex {
 		return matches[len(matches)-1][clockIDForeignIndex], nil
 	}
-	logrus.Infof("GetClockIDForeign: log parsing failed for %s, falling back to pmc: %v", ptpConfigName, err)
+	logrus.Infof("GetClockIDForeign: log parsing failed for %s, falling back to pmc: %v", profileName, err)
 	return getClockIDViaPMC(pod, configFile, "parentPortIdentity.clockIdentity")
 }
 
@@ -213,8 +220,8 @@ func GetClockIDForeign(ptpConfigName string, label *string, nodeName *string) (s
 // GM clock ID. Unlike GetClockIDForeign (which returns whatever master is in
 // the logs), this waits for the expected master to appear — handling the case
 // where the GM restarted and the slave hasn't re-synced yet.
-func WaitForClockIDForeign(ptpConfigName string, label *string, nodeName *string, expectedGMID string) error {
-	logID, err := GetProfileLogID(ptpConfigName, label, nodeName)
+func WaitForClockIDForeign(ptpConfigName string, profileName string, label *string, nodeName *string, expectedGMID string) error {
+	logID, err := GetProfileLogID(ptpConfigName, profileName, label, nodeName)
 	if err != nil {
 		return fmt.Errorf("could not get profile log ID: %w", err)
 	}
@@ -223,7 +230,7 @@ func WaitForClockIDForeign(ptpConfigName string, label *string, nodeName *string
 	}
 	pod, err := findMatchingPod(label, nodeName)
 	if err != nil {
-		return fmt.Errorf("no matching pod found for profile %s: %w", ptpConfigName, err)
+		return fmt.Errorf("no matching pod found for profile %s: %w", profileName, err)
 	}
 	expectedMasterRegex := fmt.Sprintf(`(?m)\[%s\].* selected best master clock %s`, logID, expectedGMID)
 	_, err = pods.GetPodLogsRegex(pod.Namespace, pod.Name, pkg.PtpContainerName,
@@ -481,11 +488,11 @@ func mutateE810PluginSettings(config *ptpv1.PtpConfig, profileName, nodeName str
 
 // GetConfigForProfile returns the config file path for a given profile name,
 // using the provided label and/or nodeName to locate the target pod.
-func GetConfigForProfile(profileName string, label *string, nodeName *string) (string, error) {
+func GetConfigForProfile(ptpConfigName string, profileName string, label *string, nodeName *string) (string, error) {
 	deadline := time.Now().Add(pkg.TimeoutIn3Minutes)
 	var lastErr error
 	for {
-		runId, err := GetProfileLogID(profileName, label, nodeName)
+		runId, err := GetProfileLogID(ptpConfigName, profileName, label, nodeName)
 		if err == nil && runId != "" {
 			// Normalize message_tag runId like "ptp4l.0.config:{level}"
 			runId = strings.TrimSpace(runId)
@@ -506,7 +513,7 @@ func GetConfigForProfile(profileName string, label *string, nodeName *string) (s
 			if podErr != nil {
 				return "", podErr
 			}
-			configName, fallbackErr := GetConfigForProfileFromVarRun(profileName, pod, pkg.PtpContainerName)
+			configName, fallbackErr := GetConfigForProfileFromVarRun(ProfileNameMatchPattern(ptpConfigName, profileName), pod, pkg.PtpContainerName)
 			if fallbackErr == nil {
 				return configName, nil
 			}
@@ -960,9 +967,15 @@ func QualifyProfileName(crName, profileName string) string {
 	return prefix + profileName
 }
 
-// GetProfileName returns the daemon-qualified profile name from a PtpConfig,
-// matching against the known set of test policy names. This whitelist prevents
-// accidentally selecting unrelated profiles (e.g. operator-internal ones).
+// ProfileNameMatchPattern matches both the CR profile name and the daemon-qualified
+// form (<ptpConfigName>_<profileName>) used in some operator versions.
+func ProfileNameMatchPattern(ptpConfigName, profileName string) string {
+	return fmt.Sprintf("(?:%s_)?%s", regexp.QuoteMeta(ptpConfigName), regexp.QuoteMeta(profileName))
+}
+
+// GetProfileName returns the profile name from a PtpConfig, matching against
+// the known set of test policy names. This whitelist prevents accidentally
+// selecting unrelated profiles (e.g. operator-internal ones).
 func GetProfileName(config *ptpv1.PtpConfig, receiverOnly bool) (string, error) {
 	if config == nil {
 		return "", fmt.Errorf("ptp config is nil")
@@ -982,11 +995,10 @@ func GetProfileName(config *ptpv1.PtpConfig, receiverOnly bool) (string, error) 
 			"tbc-tr",
 			"tbc-tt":
 
-			qualified := QualifyProfileName(config.Name, *profile.Name)
-			if receiverOnly && qualified == QualifyProfileName(config.Name, "tbc-tt") {
+			if receiverOnly && *profile.Name == "tbc-tt" {
 				continue
 			}
-			return qualified, nil
+			return *profile.Name, nil
 		}
 	}
 	return "", fmt.Errorf("cannot find valid test profile name")

--- a/test/pkg/ptphelper/ptphelper.go
+++ b/test/pkg/ptphelper/ptphelper.go
@@ -973,6 +973,12 @@ func ProfileNameMatchPattern(ptpConfigName, profileName string) string {
 	return fmt.Sprintf("(?:%s_)?%s", regexp.QuoteMeta(ptpConfigName), regexp.QuoteMeta(profileName))
 }
 
+// ProfileNameLogPattern is a daemon log regex for "Profile Name:" lines.
+// It includes (?m) because GetPodLogsRegex appends \s*^ when isLiteralText is false.
+func ProfileNameLogPattern(ptpConfigName, profileName string) string {
+	return `(?m)Profile Name: ` + ProfileNameMatchPattern(ptpConfigName, profileName)
+}
+
 // GetProfileName returns the profile name from a PtpConfig, matching against
 // the known set of test policy names. This whitelist prevents accidentally
 // selecting unrelated profiles (e.g. operator-internal ones).

--- a/test/pkg/ptphelper/ptphelper_test.go
+++ b/test/pkg/ptphelper/ptphelper_test.go
@@ -27,6 +27,32 @@ func TestProfileNameMatchPattern(t *testing.T) {
 	}
 }
 
+func TestProfileNameLogPattern(t *testing.T) {
+	// GetPodLogsRegex appends \s*^ when isLiteralText is false.
+	const matchOnlyFullLines = `\s*^`
+	re, err := regexp.Compile(ProfileNameLogPattern("temp", "temp") + matchOnlyFullLines)
+	if err != nil {
+		t.Fatalf("compile pattern: %v", err)
+	}
+
+	unqualified := "I0819 10:48:18.897 daemon.go:410] Profile Name: temp\nnext line\n"
+	qualified := "I0819 10:48:18.897 daemon.go:410] Profile Name: temp_temp\nnext line\n"
+	if !re.MatchString(unqualified) {
+		t.Errorf("log pattern should match unqualified Profile Name line")
+	}
+	if !re.MatchString(qualified) {
+		t.Errorf("log pattern should match qualified Profile Name line")
+	}
+
+	oldRe, err := regexp.Compile("Profile Name: " + ProfileNameMatchPattern("temp", "temp") + matchOnlyFullLines)
+	if err != nil {
+		t.Fatalf("compile old pattern: %v", err)
+	}
+	if oldRe.MatchString(unqualified) {
+		t.Errorf("pattern without (?m) should not match a klog Profile Name line")
+	}
+}
+
 func TestGetProfileName(t *testing.T) {
 	t.Run("returns CR profile name without qualifying", func(t *testing.T) {
 		profileName := pkg.PtpTempPolicyName

--- a/test/pkg/ptphelper/ptphelper_test.go
+++ b/test/pkg/ptphelper/ptphelper_test.go
@@ -1,0 +1,70 @@
+package ptphelper
+
+import (
+	"regexp"
+	"testing"
+
+	ptpv1 "github.com/k8snetworkplumbingwg/ptp-operator/api/v1"
+	"github.com/k8snetworkplumbingwg/ptp-operator/test/pkg"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestProfileNameMatchPattern(t *testing.T) {
+	pattern := ProfileNameMatchPattern("temp", "temp")
+	re, err := regexp.Compile(`#profile:\s*` + pattern)
+	if err != nil {
+		t.Fatalf("compile pattern: %v", err)
+	}
+
+	if !re.MatchString("#profile: temp") {
+		t.Errorf("pattern %q should match unqualified profile", pattern)
+	}
+	if !re.MatchString("#profile: temp_temp") {
+		t.Errorf("pattern %q should match qualified profile", pattern)
+	}
+	if re.MatchString("#profile: other") {
+		t.Errorf("pattern %q should not match unrelated profile", pattern)
+	}
+}
+
+func TestGetProfileName(t *testing.T) {
+	t.Run("returns CR profile name without qualifying", func(t *testing.T) {
+		profileName := pkg.PtpTempPolicyName
+		config := &ptpv1.PtpConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: pkg.PtpTempPolicyName},
+			Spec: ptpv1.PtpConfigSpec{
+				Profile: []ptpv1.PtpProfile{{Name: &profileName}},
+			},
+		}
+
+		got, err := GetProfileName(config, true)
+		if err != nil {
+			t.Fatalf("GetProfileName: %v", err)
+		}
+		if got != pkg.PtpTempPolicyName {
+			t.Errorf("GetProfileName() = %q, want %q", got, pkg.PtpTempPolicyName)
+		}
+	})
+
+	t.Run("receiverOnly skips tbc-tt", func(t *testing.T) {
+		tt := "tbc-tt"
+		tr := "tbc-tr"
+		config := &ptpv1.PtpConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: pkg.PTPWPCTBCPolicyName},
+			Spec: ptpv1.PtpConfigSpec{
+				Profile: []ptpv1.PtpProfile{
+					{Name: &tt},
+					{Name: &tr},
+				},
+			},
+		}
+
+		got, err := GetProfileName(config, true)
+		if err != nil {
+			t.Fatalf("GetProfileName: %v", err)
+		}
+		if got != "tbc-tr" {
+			t.Errorf("GetProfileName() = %q, want %q", got, "tbc-tr")
+		}
+	})
+}

--- a/test/pkg/ptptesthelper/ptptesthelper.go
+++ b/test/pkg/ptptesthelper/ptptesthelper.go
@@ -60,10 +60,10 @@ func BasicClockSyncCheck(fullConfig testconfig.TestConfig, ptpConfig *ptpv1.PtpC
 	}
 	var slaveMaster string
 	if fullConfig.PtpModeDesired == testconfig.Discovery {
-		slaveMaster, err = ptphelper.GetClockIDForeign(profileName, label, nodeName)
+		slaveMaster, err = ptphelper.GetClockIDForeign(ptpConfig.Name, profileName, label, nodeName)
 	} else {
 		Eventually(func() error {
-			slaveMaster, err = ptphelper.GetClockIDForeign(profileName, label, nodeName)
+			slaveMaster, err = ptphelper.GetClockIDForeign(ptpConfig.Name, profileName, label, nodeName)
 			if err != nil {
 				logrus.Infof("GetClockIDForeign retry due to err: %s", err)
 			}
@@ -91,7 +91,7 @@ func BasicClockSyncCheck(fullConfig testconfig.TestConfig, ptpConfig *ptpv1.PtpC
 	if gmID != nil {
 		if !strings.HasPrefix(slaveMaster, *gmID) {
 			logrus.Infof("slaveMaster=%s does not match expected GM=%s, waiting for re-sync...", slaveMaster, *gmID)
-			if waitErr := ptphelper.WaitForClockIDForeign(profileName, label, nodeName, *gmID); waitErr != nil {
+			if waitErr := ptphelper.WaitForClockIDForeign(ptpConfig.Name, profileName, label, nodeName, *gmID); waitErr != nil {
 				return errors.Errorf("Slave connected to another (incorrect) Master, slaveMaster=%s, gmID=%s, waitErr=%s", slaveMaster, *gmID, waitErr)
 			}
 		}
@@ -198,7 +198,9 @@ func CheckSlaveSyncWithMaster(fullConfig testconfig.TestConfig) {
 	var grandmasterID *string
 	if fullConfig.L2Config != nil && !isExternalMaster {
 		aLabel := pkg.PtpGrandmasterNodeLabel
-		aString, err := ptphelper.GetClockIDMaster(pkg.PtpGrandMasterPolicyName, &aLabel, nil, true)
+		Expect(fullConfig.DiscoveredGrandMasterPtpConfig).NotTo(BeNil(), "expected discovered grandmaster config")
+		gmConfigName := (*ptpv1.PtpConfig)(fullConfig.DiscoveredGrandMasterPtpConfig).Name
+		aString, err := ptphelper.GetClockIDMaster(gmConfigName, pkg.PtpGrandMasterPolicyName, &aLabel, nil, true)
 		grandmasterID = &aString
 		if err != nil {
 			logrus.Warnf("could not determine the Grandmaster ID (probably because the log no longer exists), err=%s", err)
@@ -679,13 +681,13 @@ func WaitForConfigContent(fullConfig testconfig.TestConfig, configFile, expected
 
 // DiscoverPtp4lConfigByProfile uses GetProfileLogID to find the config file
 // name (e.g. "ptp4l.0.config") for a PtpConfig, then returns the full path.
-func DiscoverPtp4lConfigByProfile(ptpConfigName string, nodeName string) (string, error) {
-	logID, err := ptphelper.GetProfileLogID(ptpConfigName, nil, &nodeName)
+func DiscoverPtp4lConfigByProfile(ptpConfigName string, profileName string, nodeName string) (string, error) {
+	logID, err := ptphelper.GetProfileLogID(ptpConfigName, profileName, nil, &nodeName)
 	if err != nil {
-		return "", fmt.Errorf("failed to get profile log ID for %s: %v", ptpConfigName, err)
+		return "", fmt.Errorf("failed to get profile log ID for %s/%s: %v", ptpConfigName, profileName, err)
 	}
 	if logID == "" {
-		return "", fmt.Errorf("empty profile log ID for %s", ptpConfigName)
+		return "", fmt.Errorf("empty profile log ID for %s/%s", ptpConfigName, profileName)
 	}
 	configNameStr := logID
 	if idx := strings.Index(configNameStr, ":"); idx != -1 {
@@ -703,7 +705,9 @@ func DiscoverNICInfo(ptpConfig ptpv1.PtpConfig, nodeName, nicLabel string) NICIn
 	masterIfs := ptpv1.GetInterfaces(ptpConfig, ptpv1.Master)
 	Expect(len(masterIfs)).To(BeNumerically(">=", 1), "%s should have at least one master interface", nicLabel)
 
-	configFile, err := DiscoverPtp4lConfigByProfile(ptpConfig.Name, nodeName)
+	profileName, err := ptphelper.GetProfileName(&ptpConfig, true)
+	Expect(err).NotTo(HaveOccurred(), "Could not determine profile name for %s", nicLabel)
+	configFile, err := DiscoverPtp4lConfigByProfile(ptpConfig.Name, profileName, nodeName)
 	Expect(err).NotTo(HaveOccurred(), "Could not find ptp4l config for %s profile %s", nicLabel, ptpConfig.Name)
 	configName := strings.TrimPrefix(configFile, DefaultConfigDir)
 

--- a/test/pkg/ptptesthelper/ptptesthelper.go
+++ b/test/pkg/ptptesthelper/ptptesthelper.go
@@ -59,19 +59,19 @@ func BasicClockSyncCheck(fullConfig testconfig.TestConfig, ptpConfig *ptpv1.PtpC
 		logrus.Debugf("could not get nodeName because of err: %s", err)
 	}
 	var slaveMaster string
-	if fullConfig.PtpModeDesired == testconfig.Discovery {
-		slaveMaster, err = ptphelper.GetClockIDForeign(ptpConfig.Name, profileName, label, nodeName)
-	} else {
-		Eventually(func() error {
-			slaveMaster, err = ptphelper.GetClockIDForeign(ptpConfig.Name, profileName, label, nodeName)
-			if err != nil {
-				logrus.Infof("GetClockIDForeign retry due to err: %s", err)
-			}
-			return err
-		}, pkg.TimeoutIn3Minutes, pkg.Timeout10Seconds).Should(BeNil(),
-			fmt.Sprintf("Timeout to get foreign clock ID for ptpconfig %s", ptpConfig.Name))
-	}
 	if errProfile == nil {
+		if fullConfig.PtpModeDesired == testconfig.Discovery {
+			slaveMaster, err = ptphelper.GetClockIDForeign(ptpConfig.Name, profileName, label, nodeName)
+		} else {
+			Eventually(func() error {
+				slaveMaster, err = ptphelper.GetClockIDForeign(ptpConfig.Name, profileName, label, nodeName)
+				if err != nil {
+					logrus.Infof("GetClockIDForeign retry due to err: %s", err)
+				}
+				return err
+			}, pkg.TimeoutIn3Minutes, pkg.Timeout10Seconds).Should(BeNil(),
+				fmt.Sprintf("Timeout to get foreign clock ID for ptpconfig %s", ptpConfig.Name))
+		}
 		if fullConfig.PtpModeDesired == testconfig.Discovery {
 			if err != nil {
 				logrus.Infof("slave's Master not detected in log (probably because of log rollover))")
@@ -87,12 +87,12 @@ func BasicClockSyncCheck(fullConfig testconfig.TestConfig, ptpConfig *ptpv1.PtpC
 			}
 			logrus.Infof("slave's Master=%s", slaveMaster)
 		}
-	}
-	if gmID != nil {
-		if !strings.HasPrefix(slaveMaster, *gmID) {
-			logrus.Infof("slaveMaster=%s does not match expected GM=%s, waiting for re-sync...", slaveMaster, *gmID)
-			if waitErr := ptphelper.WaitForClockIDForeign(ptpConfig.Name, profileName, label, nodeName, *gmID); waitErr != nil {
-				return errors.Errorf("Slave connected to another (incorrect) Master, slaveMaster=%s, gmID=%s, waitErr=%s", slaveMaster, *gmID, waitErr)
+		if gmID != nil {
+			if !strings.HasPrefix(slaveMaster, *gmID) {
+				logrus.Infof("slaveMaster=%s does not match expected GM=%s, waiting for re-sync...", slaveMaster, *gmID)
+				if waitErr := ptphelper.WaitForClockIDForeign(ptpConfig.Name, profileName, label, nodeName, *gmID); waitErr != nil {
+					return errors.Errorf("Slave connected to another (incorrect) Master, slaveMaster=%s, gmID=%s, waitErr=%s", slaveMaster, *gmID, waitErr)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Pass PtpConfig and profile names separately through clock-ID and config lookup helpers. GetProfileName returns the CR profile name as-is. Log and ptp4l .config searches use an optional config-name prefix so both 4.20 and current daemon formats match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PTP validation for configuration-specific profiles and clock IDs.
  * Added support for qualified and unqualified profile names, including Telco Boundary Clock variants.
  * Improved clock identification and configuration discovery across multiple profiles.
  * Enhanced matching of multiline daemon logs and profile-specific checks.

* **Tests**
  * Added coverage for profile matching, extraction, synchronization, and receiver-only selection.
  * Improved FIFO scheduling and clock synchronization validation.
  * Added Boundary Clock reverse-sync outage coverage, including lock-state transitions and recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->