### PR TITLE
Enable deploying Cloud Event Proxy v2

### DIFF
--- a/bindata/linuxptp/ptp-daemon.yaml
+++ b/bindata/linuxptp/ptp-daemon.yaml
@@ -33,6 +33,30 @@ spec:
       priorityClassName: "system-node-critical"
       containers:
         {{ if (eq .EnableEventPublisher true) }}
+        {{ if .SideCarV2 }}
+        - name: cloud-event-proxy
+          image: {{ .SideCarV2 }}
+          imagePullPolicy: {{ .ImagePullPolicy }}
+          command: ["/usr/local/bin/cloud-event-proxy"]
+          args:
+            - "--api-port=9043"
+            - "--store-path=/var/run"
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/linuxptp
+            - name: socket-dir
+              mountPath: /var/run
+          ports:
+            - name: api-port
+              containerPort: 9043
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: NAME_SPACE
+              value: {{.Namespace}}
+        {{ else }}
         - name: cloud-event-proxy
           image: {{ .SideCar }}
           imagePullPolicy: {{ .ImagePullPolicy }}
@@ -65,6 +89,7 @@ spec:
                   fieldPath: spec.nodeName
             - name: NAME_SPACE
               value: {{.Namespace}}
+        {{ end }}
         {{ end }}
         - name: kube-rbac-proxy
           image: {{.KubeRbacProxy}}
@@ -122,8 +147,10 @@ spec:
                   fieldPath: metadata.name
             - name: NAME_SPACE
               value: {{.Namespace}}
+            {{ if and (eq .EnableEventPublisher true) (not .SideCarV2) }}
             - name: LOGS_TO_SOCKET
-              value: "{{ .EnableEventPublisher }}"
+              value: "true"
+            {{ end }}
             - name: PLUGINS
               value: "{{ .EnabledPlugins }}"
           volumeMounts:
@@ -133,7 +160,7 @@ spec:
               mountPath: /etc/leap
             - name: socket-dir
               mountPath: /var/run
-            {{ if (eq .EnableEventPublisher true) }}
+            {{ if and (eq .EnableEventPublisher true) (not .SideCarV2) }}
             - name: event-bus-socket
               mountPath: /cloud-native
             {{ end }}
@@ -147,7 +174,7 @@ spec:
         - name: linuxptp-certs
           secret:
             secretName: linuxptp-daemon-secret
-        {{ if (eq .EnableEventPublisher true) }}
+        {{ if and (eq .EnableEventPublisher true) (not .SideCarV2) }}
         - name: pubsubstore
           emptyDir: {}
         - name: event-bus-socket

--- a/bundle/manifests/ptp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ptp-operator.clusterserviceversion.yaml
@@ -61,7 +61,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/openshift/origin-ptp-operator:5.0
-    createdAt: "2026-08-17T07:20:38Z"
+    createdAt: "2026-08-20T13:00:16Z"
     description: This software enables configuration of Precision Time Protocol(PTP)
       on Kubernetes. It detects hardware capable PTP devices on each node, and configures
       linuxptp processes such as ptp4l, phc2sys and timemaster.
@@ -378,6 +378,7 @@ spec:
                   value: quay.io/openshift/origin-kube-rbac-proxy:5.0
                 - name: SIDECAR_EVENT_IMAGE
                   value: quay.io/openshift/origin-cloud-event-proxy:5.0
+                - name: EVENT_PROXY_IMAGE
                 - name: OPERATOR_NAMESPACE
                   valueFrom:
                     fieldRef:

--- a/config/manager/env.yaml
+++ b/config/manager/env.yaml
@@ -19,3 +19,8 @@ spec:
               value: "quay.io/openshift/origin-kube-rbac-proxy:5.0"
             - name: SIDECAR_EVENT_IMAGE
               value: "quay.io/openshift/origin-cloud-event-proxy:5.0"
+            # If this is not empty, this signals to the operator that CEPv2 should be used, and CEPv1 should not be deployed.
+            # The value should be equal to the image location.
+            # The final naming/usage of this should be discussed before release.
+            - name: EVENT_PROXY_IMAGE
+              value: ""

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -75,3 +75,5 @@ spec:
               value: $KUBE_RBAC_PROXY_IMAGE
             - name: SIDECAR_EVENT_IMAGE
               value: $SIDECAR_EVENT_IMAGE
+            - name: EVENT_PROXY_IMAGE
+              value: $EVENT_PROXY_IMAGE

--- a/controllers/ptpoperatorconfig_controller.go
+++ b/controllers/ptpoperatorconfig_controller.go
@@ -235,6 +235,7 @@ func (r *PtpOperatorConfigReconciler) syncLinuxptpDaemon(ctx context.Context, de
 	data.Data["ReleaseVersion"] = os.Getenv("RELEASEVERSION")
 	data.Data["KubeRbacProxy"] = os.Getenv("KUBE_RBAC_PROXY_IMAGE")
 	data.Data["SideCar"] = os.Getenv("SIDECAR_EVENT_IMAGE")
+	data.Data["SideCarV2"] = os.Getenv("EVENT_PROXY_IMAGE")
 	data.Data["NodeName"] = os.Getenv("NODE_NAME")
 	data.Data["StorageType"] = DefaultStorageType
 	data.Data["EventApiVersion"] = DefaultApiVersion

--- a/manifests/stable/ptp-operator.clusterserviceversion.yaml
+++ b/manifests/stable/ptp-operator.clusterserviceversion.yaml
@@ -61,7 +61,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/openshift/origin-ptp-operator:5.0
-    createdAt: "2026-08-17T07:20:38Z"
+    createdAt: "2026-08-20T13:00:16Z"
     description: This software enables configuration of Precision Time Protocol(PTP)
       on Kubernetes. It detects hardware capable PTP devices on each node, and configures
       linuxptp processes such as ptp4l, phc2sys and timemaster.
@@ -378,6 +378,7 @@ spec:
                   value: quay.io/openshift/origin-kube-rbac-proxy:5.0
                 - name: SIDECAR_EVENT_IMAGE
                   value: quay.io/openshift/origin-cloud-event-proxy:5.0
+                - name: EVENT_PROXY_IMAGE
                 - name: OPERATOR_NAMESPACE
                   valueFrom:
                     fieldRef:

--- a/ptp-tools/scripts/customize-env.sh
+++ b/ptp-tools/scripts/customize-env.sh
@@ -2,6 +2,11 @@
 IMG_PREFIX=$1
 ENV_PATH=$2
 
+EVENT_PROXY_IMAGE=""
+if [[ "${ENABLE_CEPV2:-}" == "true" ]]; then
+  EVENT_PROXY_IMAGE="$IMG_PREFIX:cepv2"
+fi
+
 cat <<EOF > $ENV_PATH/env.yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -25,6 +30,8 @@ spec:
               value: "$IMG_PREFIX:krp"
             - name: SIDECAR_EVENT_IMAGE
               value: "$IMG_PREFIX:cep"
+            - name: EVENT_PROXY_IMAGE
+              value: "$EVENT_PROXY_IMAGE"
             - name: IMAGE_PULL_POLICY
               value: "Always"
 EOF


### PR DESCRIPTION
When the EVENT_PROXY_IMAGE env var is set cepv2 will be deployed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added optional SideCarV2 event-proxy support for Linux PTP deployments.
- Added configurable image selection for SideCarV2 in operator-managed and generated deployments.
- Preserved the existing event proxy as a fallback when SideCarV2 is not configured.
- Updated event-publishing storage mounts and log forwarding to match the selected event-proxy configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->