### PR TITLE
fix: pin kube-rbac-proxy and build krp with Go 1.26.3

### DIFF
--- a/ptp-tools/Dockerfile.krp
+++ b/ptp-tools/Dockerfile.krp
@@ -1,6 +1,8 @@
-FROM docker.io/golang:1.25.7 AS builder
+FROM docker.io/golang:1.26.3 AS builder
 WORKDIR /go/src/github.com/brancz/kube-rbac-proxy
-RUN git clone https://github.com/openshift/kube-rbac-proxy.git /go/src/github.com/brancz/kube-rbac-proxy
+# Pin to v0.22.1 downstream merge (openshift/kube-rbac-proxy#146); requires Go >= 1.26.3.
+RUN git clone https://github.com/openshift/kube-rbac-proxy.git /go/src/github.com/brancz/kube-rbac-proxy && \
+    git -C /go/src/github.com/brancz/kube-rbac-proxy checkout 6580efaf6d4f29e6c1d8c7fbe16a8627c7c75049
 ENV GO111MODULE=on
 ENV GOMAXPROCS=16
 


### PR DESCRIPTION
## Summary
- `openshift/kube-rbac-proxy` master now requires Go >= 1.26.3 after the [v0.22.1 downstream merge](https://github.com/openshift/kube-rbac-proxy/pull/146).
- `ptp-tools/Dockerfile.krp` cloned unpinned HEAD on `golang:1.25.7` with `GOTOOLCHAIN=local`, which fails netdevsim `ptp-images` (including [linuxptp-daemon#269](https://github.com/k8snetworkplumbingwg/linuxptp-daemon/pull/269)):
  `go.mod requires go >= 1.26.3 (running go 1.25.7; GOTOOLCHAIN=local)`
- Pin the clone to `6580efaf6d4f` and build with `golang:1.26.3` so a later master toolchain bump cannot break CI the same way.

## Test plan
- [ ] netdevsim CI `ptp-images` builds `krp`
- [ ] linuxptp-daemon netdevsim CI can clone this `main` and build images

Assisted-By: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build environment to newer Go tooling.
  * Pinned the kube-rbac-proxy source to a specific downstream release commit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->