### PR TITLE
CNF-26633: migrate scaffolding from operator-sdk go/v3 to go/v4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,6 @@ catalog.Dockerfile
 config/manager/env.yaml.bak
 # Per-run temp artifacts created by scripts/run-on-vm.sh
 .local-runs
+
+# Rendered manifests from `make install/uninstall/deploy/undeploy FREE_RUN=1`
+_free-run/

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ BUNDLE_GEN_FLAGS ?= -q --overwrite --version $(BUNDLE_VERSION) $(BUNDLE_METADATA
 
 # Set the Operator SDK version to use. By default, what is installed on the system is used.
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
-OPERATOR_SDK_VERSION ?= v1.36.1-ocp
+OPERATOR_SDK_VERSION ?= v1.38.0-ocp
 
 # Image URL to use all building/pushing image targets
 IMG ?= ghcr.io/k8snetworkplumbingwg/ptp-operator:$(VERSION)
@@ -151,21 +151,49 @@ docker-push: ## Push docker image with the manager.
 
 ##@ Deployment
 
-install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | kubectl $(KUBECONFIG_OPTS) apply -f -
+# FREE_RUN=1 renders the generated manifests (via kustomize build) to FREE_RUN_DIR instead
+# of applying/deleting them against a live cluster. This lets install/uninstall/deploy/undeploy
+# be exercised to verify the generated output is well-formed without requiring a reachable
+# Kubernetes/OpenShift API server (e.g. in CI or sandboxed dev environments).
+FREE_RUN ?= 0
+FREE_RUN_DIR ?= $(shell pwd)/_free-run
 
-uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | kubectl $(KUBECONFIG_OPTS) delete -f - || true
+ifeq ($(FREE_RUN),1)
+APPLY_CMD = bash -o pipefail -c 'cat > "$(FREE_RUN_DIR)/$(1).yaml"'
+DELETE_CMD = bash -o pipefail -c 'cat > "$(FREE_RUN_DIR)/$(1).yaml"'
+else
+APPLY_CMD = kubectl $(KUBECONFIG_OPTS) apply -f -
+DELETE_CMD = kubectl $(KUBECONFIG_OPTS) delete -f - || true
+endif
 
-deploy: manifests kustomize update-env-yaml ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+.PHONY: install uninstall deploy undeploy
+install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config. Set FREE_RUN=1 to render to FREE_RUN_DIR instead of applying.
+ifeq ($(FREE_RUN),1)
+	@mkdir -p "$(FREE_RUN_DIR)"
+endif
+	$(KUSTOMIZE) build config/crd | $(call APPLY_CMD,install-crd)
+
+uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Set FREE_RUN=1 to render to FREE_RUN_DIR instead of deleting.
+ifeq ($(FREE_RUN),1)
+	@mkdir -p "$(FREE_RUN_DIR)"
+endif
+	$(KUSTOMIZE) build config/crd | $(call DELETE_CMD,uninstall-crd)
+
+deploy: manifests kustomize update-env-yaml ## Deploy controller to the K8s cluster specified in ~/.kube/config. Set FREE_RUN=1 to render to FREE_RUN_DIR instead of applying.
+ifeq ($(FREE_RUN),1)
+	@mkdir -p "$(FREE_RUN_DIR)"
+endif
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default | kubectl $(KUBECONFIG_OPTS) apply -f -
-	$(KUSTOMIZE) build config/custom | kubectl $(KUBECONFIG_OPTS) apply -f -
+	$(KUSTOMIZE) build config/default | $(call APPLY_CMD,deploy-default)
+	$(KUSTOMIZE) build config/custom | $(call APPLY_CMD,deploy-custom)
 	@$(MAKE) restore-env-yaml
 
-undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/default | kubectl $(KUBECONFIG_OPTS) delete -f - || true
-	$(KUSTOMIZE) build config/custom | kubectl $(KUBECONFIG_OPTS) delete -f - || true
+undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Set FREE_RUN=1 to render to FREE_RUN_DIR instead of deleting.
+ifeq ($(FREE_RUN),1)
+	@mkdir -p "$(FREE_RUN_DIR)"
+endif
+	$(KUSTOMIZE) build config/default | $(call DELETE_CMD,undeploy-default)
+	$(KUSTOMIZE) build config/custom | $(call DELETE_CMD,undeploy-custom)
 
 ##@ Build Dependencies
 
@@ -208,9 +236,9 @@ operator-sdk: ## Download operator-sdk locally if necessary.
 ifneq ($(OPERATOR_SDK_VERSION),$(OPERATOR_SDK_VERSION_INSTALLED))
 ifeq ($(OS), Darwin)
 	mkdir -p $(LOCALBIN)/x86_64/
-	curl -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/operator-sdk/4.17.0/operator-sdk-v1.36.1-ocp-darwin-x86_64.tar.gz? | tar -xz -C bin/
+	curl -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/operator-sdk/4.18.22/operator-sdk-v1.38.0-ocp-darwin-x86_64.tar.gz? | tar -xz -C bin/
 else
-	curl -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/operator-sdk/4.17.0/operator-sdk-v1.36.1-ocp-linux-x86_64.tar.gz? | tar -xz -C bin/
+	curl -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/operator-sdk/4.18.22/operator-sdk-v1.38.0-ocp-linux-x86_64.tar.gz? | tar -xz -C bin/
 endif
 endif
 

--- a/PROJECT
+++ b/PROJECT
@@ -1,6 +1,6 @@
 domain: openshift.io
 layout:
-- go.kubebuilder.io/v3
+- go.kubebuilder.io/v4
 plugins:
   manifests.sdk.operatorframework.io/v2: {}
   scorecard.sdk.operatorframework.io/v2: {}
@@ -39,4 +39,13 @@ resources:
   webhooks:
     validation: true
     webhookVersion: v1
+- api:
+    crdVersion: v1
+    namespaced: true
+  controller: true
+  domain: openshift.io
+  group: ptp
+  kind: HardwareConfig
+  path: github.com/k8snetworkplumbingwg/ptp-operator/api/v2alpha1
+  version: v2alpha1
 version: "3"

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,9 +6,9 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=ptp-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.36.1-ocp
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.38.0-ocp
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
-LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
+LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 
 # Labels for testing.
 LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1

--- a/bundle/manifests/ptp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ptp-operator.clusterserviceversion.yaml
@@ -55,13 +55,34 @@ metadata:
             },
             "ptpEventConfig": {}
           }
+        },
+        {
+          "apiVersion": "ptp.openshift.io/v2alpha1",
+          "kind": "HardwareConfig",
+          "metadata": {
+            "name": "example-hardwareconfig"
+          },
+          "spec": {
+            "profile": {
+              "clockChain": {
+                "structure": [
+                  {
+                    "name": "nic1"
+                  }
+                ]
+              },
+              "clockType": "T-GM",
+              "name": "example-profile"
+            },
+            "relatedPtpProfileName": "profile1"
+          }
         }
       ]
     capabilities: Basic Install
     categories: Networking
     certified: "false"
     containerImage: quay.io/openshift/origin-ptp-operator:5.0
-    createdAt: "2026-08-17T16:40:33Z"
+    createdAt: "2026-08-26T10:30:35Z"
     description: This software enables configuration of Precision Time Protocol(PTP)
       on Kubernetes. It detects hardware capable PTP devices on each node, and configures
       linuxptp processes such as ptp4l, phc2sys and timemaster.
@@ -79,8 +100,8 @@ metadata:
     operatorframework.io/suggested-namespace: openshift-ptp
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.openshift.io/must-gather-image: quay.io/openshift/origin-ptp-operator-must-gather:5.0
-    operators.operatorframework.io/builder: operator-sdk-v1.36.1-ocp
-    operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+    operators.operatorframework.io/builder: operator-sdk-v1.38.0-ocp
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     provider: Red Hat
     repository: https://github.com/k8snetworkplumbingwg/ptp-operator
     support: Red Hat
@@ -90,7 +111,9 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - kind: HardwareConfig
+    - description: HardwareConfig is the Schema for the hardwareconfigs API
+      displayName: Hardware Config
+      kind: HardwareConfig
       name: hardwareconfigs.ptp.openshift.io
       version: v2alpha1
     - description: NodePtpDevice is the Schema for the nodeptpdevices API
@@ -339,6 +362,7 @@ spec:
           resources:
           - nodeptpdevices
           verbs:
+          - create
           - get
           - list
           - watch

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,9 +5,9 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: ptp-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.36.1-ocp
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.38.0-ocp
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
-  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
 
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -8,19 +8,19 @@ resources:
 - bases/ptp.openshift.io_hardwareconfigs.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
+patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-#- patches/webhook_in_ptpconfigs.yaml
-#- patches/webhook_in_nodeptpdevices.yaml
-#- patches/webhook_in_ptpoperatorconfigs.yaml
+#- path: patches/webhook_in_ptpconfigs.yaml
+#- path: patches/webhook_in_nodeptpdevices.yaml
+#- path: patches/webhook_in_ptpoperatorconfigs.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-#- patches/cainjection_in_ptpconfigs.yaml
-#- patches/cainjection_in_nodeptpdevices.yaml
-#- patches/cainjection_in_ptpoperatorconfigs.yaml
+#- path: patches/cainjection_in_ptpconfigs.yaml
+#- path: patches/cainjection_in_nodeptpdevices.yaml
+#- path: patches/cainjection_in_ptpoperatorconfigs.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: openshift-ptp
 #commonLabels:
 #  someName: someValue
 
-bases:
+resources:
 - ../crd
 - ../rbac
 - ../manager
@@ -18,7 +18,7 @@ bases:
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
-patchesStrategicMerge:
+patches:
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
@@ -26,16 +26,16 @@ patchesStrategicMerge:
 
 # Mount the controller config file for loading manager configurations
 # through a ComponentConfig type
-#- manager_config_patch.yaml
+#- path: manager_config_patch.yaml
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-- manager_webhook_patch.yaml
+- path: manager_webhook_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection
-- webhookcainjection_patch.yaml
+- path: webhookcainjection_patch.yaml
 
 # the following config is for teaching kustomize how to do var substitution
 vars:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -14,5 +14,5 @@ images:
 - name: controller
   newName: ghcr.io/k8snetworkplumbingwg/ptp-operator
   newTag: "5.0"
-patchesStrategicMerge:
-- env.yaml
+patches:
+- path: env.yaml

--- a/config/manifests/bases/ptp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ptp-operator.clusterserviceversion.yaml
@@ -83,6 +83,11 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
+    - description: HardwareConfig is the Schema for the hardwareconfigs API
+      displayName: Hardware Config
+      kind: HardwareConfig
+      name: hardwareconfigs.ptp.openshift.io
+      version: v2alpha1
     - description: NodePtpDevice is the Schema for the nodeptpdevices API
       displayName: Node Ptp Device
       kind: NodePtpDevice

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -10,7 +10,7 @@ resources:
 # [WEBHOOK] To enable webhooks, uncomment all the sections with [WEBHOOK] prefix.
 # Do NOT uncomment sections with prefix [CERTMANAGER], as OLM does not support cert-manager.
 # These patches remove the unnecessary "cert" volume and its manager container volumeMount.
-#patchesJson6902:
+#patches:
 #- target:
 #    group: apps
 #    version: v1

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -62,6 +62,7 @@ rules:
   resources:
   - nodeptpdevices
   verbs:
+  - create
   - get
   - list
   - watch

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -3,4 +3,5 @@ resources:
 - ptp_v1_ptpconfig.yaml
 - ptp_v1_nodeptpdevice.yaml
 - ptp_v1_ptpoperatorconfig.yaml
+- ptp_v2alpha1_hardwareconfig.yaml
 #+kubebuilder:scaffold:manifestskustomizesamples

--- a/config/samples/ptp_v2alpha1_hardwareconfig.yaml
+++ b/config/samples/ptp_v2alpha1_hardwareconfig.yaml
@@ -1,0 +1,12 @@
+apiVersion: ptp.openshift.io/v2alpha1
+kind: HardwareConfig
+metadata:
+  name: example-hardwareconfig
+spec:
+  relatedPtpProfileName: "profile1"
+  profile:
+    name: "example-profile"
+    clockType: "T-GM"
+    clockChain:
+      structure:
+      - name: "nic1"

--- a/config/scorecard/kustomization.yaml
+++ b/config/scorecard/kustomization.yaml
@@ -1,6 +1,6 @@
 resources:
 - bases/config.yaml
-patchesJson6902:
+patches:
 - path: patches/basic.config.yaml
   target:
     group: scorecard.operatorframework.io

--- a/controllers/ptpconfig_controller.go
+++ b/controllers/ptpconfig_controller.go
@@ -59,7 +59,7 @@ type PtpConfigReconciler struct {
 //+kubebuilder:rbac:groups=ptp.openshift.io,resources=ptpconfigs,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=ptp.openshift.io,resources=ptpconfigs/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=ptp.openshift.io,resources=ptpconfigs/finalizers,verbs=update
-//+kubebuilder:rbac:groups=ptp.openshift.io,resources=nodeptpdevices,verbs=get;list;watch
+//+kubebuilder:rbac:groups=ptp.openshift.io,resources=nodeptpdevices,verbs=get;list;watch;create
 //+kubebuilder:rbac:groups=ptp.openshift.io,resources=hardwareconfigs,verbs=get;list;watch
 //+kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures,verbs=get;list;watch
 

--- a/manifests/stable/ptp-operator.clusterserviceversion.yaml
+++ b/manifests/stable/ptp-operator.clusterserviceversion.yaml
@@ -55,13 +55,34 @@ metadata:
             },
             "ptpEventConfig": {}
           }
+        },
+        {
+          "apiVersion": "ptp.openshift.io/v2alpha1",
+          "kind": "HardwareConfig",
+          "metadata": {
+            "name": "example-hardwareconfig"
+          },
+          "spec": {
+            "profile": {
+              "clockChain": {
+                "structure": [
+                  {
+                    "name": "nic1"
+                  }
+                ]
+              },
+              "clockType": "T-GM",
+              "name": "example-profile"
+            },
+            "relatedPtpProfileName": "profile1"
+          }
         }
       ]
     capabilities: Basic Install
     categories: Networking
     certified: "false"
     containerImage: quay.io/openshift/origin-ptp-operator:5.0
-    createdAt: "2026-08-17T16:40:33Z"
+    createdAt: "2026-08-26T10:30:35Z"
     description: This software enables configuration of Precision Time Protocol(PTP)
       on Kubernetes. It detects hardware capable PTP devices on each node, and configures
       linuxptp processes such as ptp4l, phc2sys and timemaster.
@@ -79,8 +100,8 @@ metadata:
     operatorframework.io/suggested-namespace: openshift-ptp
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.openshift.io/must-gather-image: quay.io/openshift/origin-ptp-operator-must-gather:5.0
-    operators.operatorframework.io/builder: operator-sdk-v1.36.1-ocp
-    operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+    operators.operatorframework.io/builder: operator-sdk-v1.38.0-ocp
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     provider: Red Hat
     repository: https://github.com/k8snetworkplumbingwg/ptp-operator
     support: Red Hat
@@ -90,7 +111,9 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - kind: HardwareConfig
+    - description: HardwareConfig is the Schema for the hardwareconfigs API
+      displayName: Hardware Config
+      kind: HardwareConfig
       name: hardwareconfigs.ptp.openshift.io
       version: v2alpha1
     - description: NodePtpDevice is the Schema for the nodeptpdevices API
@@ -339,6 +362,7 @@ spec:
           resources:
           - nodeptpdevices
           verbs:
+          - create
           - get
           - list
           - watch


### PR DESCRIPTION
- PROJECT: bump layout to go.kubebuilder.io/v4; add missing HardwareConfig (api/v2alpha1) resource entry that was absent despite the type/controller/CRD already existing in the codebase.
- Makefile: bump OPERATOR_SDK_VERSION to v1.38.0-ocp (OCP 4.18.22 client mirror); keep KUSTOMIZE_VERSION at v5.4.2, which already supports non-deprecated syntax. Add FREE_RUN=1 flag to install/uninstall/deploy/undeploy so their generated manifests can be verified without a reachable cluster (renders to FREE_RUN_DIR instead of calling kubectl); default behavior is unchanged.
- config/{crd,default,manager,manifests,scorecard}/kustomization.yaml: convert deprecated bases/patchesStrategicMerge/patchesJson6902 fields to resources/patches.
- config/samples: add ptp_v2alpha1_hardwareconfig.yaml sample, resolving the bundle validate warning "provided API should have an example annotation" for HardwareConfig (it was an owned CRD with no alm-examples entry).

Assisted by Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the namespaced `HardwareConfig` v2alpha1 resource.
  * Included sample configurations with clock profiles and clock-chain settings.
  * Added a free-run mode that renders deployment manifests locally without changing a cluster.
  * Enabled creation of node PTP device resources.

* **Improvements**
  * Updated operator metadata and project configuration for current tooling standards.
  * Modernized manifest customization settings for newer Kustomize versions.
  * Added clearer display names and descriptions for HardwareConfig resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->