### PR TITLE
test: allow software GM in T-BC topology

### DIFF
--- a/test/pkg/testconfig/testconfig.go
+++ b/test/pkg/testconfig/testconfig.go
@@ -700,14 +700,15 @@ func initAndSolveProblems() {
 			{int(solver.StepSameNic), 2, 0, 1}}, //        and on the same NIC
 	}
 
-	// T-BC with local GM: WPC NIC required, receiver, two transmitters on same NIC, local GM
+	// T-BC with local software GM: WPC receiver + two transmitters on the same NIC.
+	// CUT is the T-BC. GM is a regular ptp4l grandmaster (not WPC), other node,
+	// same LAN as the receiver. PtpConfigTelcoBC already deploys CreatePtpConfigGrandMaster.
 	data.problems[AlgoTelcoBCString] = &[][][]int{
 		{{int(solver.StepIsWPCNic), 1, 0}},   // step1: T-BC receiver must be on WPC NIC
 		{{int(solver.StepSameNic), 2, 0, 1}}, // step2: transmitter 1 on same NIC as receiver
 		{{int(solver.StepSameNic), 2, 0, 2}}, // step3: transmitter 2 on same NIC as receiver
 		{{int(solver.StepSameLan2), 2, 0, 3}, // step4: local grandmaster on same LAN as receiver
 			{int(solver.StepSameNode), 2, 0, 3, solver.Negative}}, // but NOT on the same node
-		{{int(solver.StepIsWPCNic), 1, 3}}, // step5: local grandmaster is a WPC NIC
 	}
 
 	// T-BC with external GM: WPC NIC required, PTP receiver, two transmitters on same NIC


### PR DESCRIPTION
## Summary
- Remove the T-BC solver constraint that the local grandmaster interface must be a WPC NIC.
- T-BC still requires a WPC receiver (and two more ports on that NIC). The GM is the software `ptp4l` grandmaster `PtpConfigTelcoBC` already creates, on another node on the receiver LAN.

This unblocks T-BC on labs with a single Westport Channel card (current telco5g PTP nightlies fail with `no T-BC solution found for TBC`).

## Test plan
- [ ] Telco5g PTP T-BC mode places a solution on a 1-WPC cluster (`ptpcimno`)
- [ ] T-BC still requires WPC on the clock-under-test receiver
- [ ] Existing T-GM / TGMOC / TGMBC WPC-GM constraints are unchanged

Assisted-By: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Telco Boundary Clock solver configuration guidance to describe a local software grandmaster.
  * Clarified network requirements: the receiver and transmitters share a NIC, while the local grandmaster resides on a separate node on the same LAN.
  * Removed the requirement for the local grandmaster interface to use a WPC NIC.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->