### PR TITLE
CNF-26775: Add OS Clock state PtpSettings

### DIFF
--- a/api/v1/ptpconfig_types.go
+++ b/api/v1/ptpconfig_types.go
@@ -137,10 +137,22 @@ type PtpProfile struct {
 	PtpSchedulingPolicy *string `json:"ptpSchedulingPolicy,omitempty"`
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=65
-	PtpSchedulingPriority *int64                         `json:"ptpSchedulingPriority,omitempty"`
-	PtpClockThreshold     *PtpClockThreshold             `json:"ptpClockThreshold,omitempty"`
-	PtpSettings           map[string]string              `json:"ptpSettings,omitempty"`
-	Plugins               map[string]*apiextensions.JSON `json:"plugins,omitempty"`
+	PtpSchedulingPriority *int64             `json:"ptpSchedulingPriority,omitempty"`
+	PtpClockThreshold     *PtpClockThreshold `json:"ptpClockThreshold,omitempty"`
+	// PtpSettings holds free-form, string-typed configuration knobs validated individually
+	// by the PtpConfig admission webhook. Recognized keys include (non-exhaustive):
+	//   - sysOffsetInSyncThreshold: phc2sys-to-CLOCK_REALTIME offset threshold, in
+	//     nanoseconds, that must be met to gate the OS Clock Sync (E3) LOCKED state.
+	//     No default; must be explicitly configured for the parameter to take effect.
+	//   - sysOffsetOutOfSyncThreshold: phc2sys-to-CLOCK_REALTIME offset threshold, in
+	//     nanoseconds, that when exceeded gates the OS Clock Sync (E3) FREERUN state.
+	//     Independent of sysOffsetInSyncThreshold; together they form a hysteresis band.
+	//     No default; must be explicitly configured for the parameter to take effect.
+	//   - sysOffsetSamples: number of consecutive phc2sys samples required for E3
+	//     state transitions in either direction (relative to sysOffsetInSyncThreshold
+	//     for LOCKED, or sysOffsetOutOfSyncThreshold for FREERUN). Default: 10.
+	PtpSettings map[string]string              `json:"ptpSettings,omitempty"`
+	Plugins     map[string]*apiextensions.JSON `json:"plugins,omitempty"`
 }
 
 type PtpClockThreshold struct {

--- a/api/v1/ptpconfig_webhook.go
+++ b/api/v1/ptpconfig_webhook.go
@@ -200,6 +200,21 @@ func (r *PtpConfig) validate() error {
 					if _, err := strconv.ParseUint(v, 10, 32); err != nil {
 						return errors.New("inSyncConditionThreshold='" + v + "' is invalid; must be an unsigned integer")
 					}
+				case k == "sysOffsetThreshold":
+					// Validate sysOffsetThreshold is an unsigned integer
+					if _, err := strconv.ParseUint(v, 10, 32); err != nil {
+						return errors.New("sysOffsetThreshold='" + v + "' is invalid; must be an unsigned integer")
+					}
+				case k == "sysOffsetInSyncSamples":
+					// Validate sysOffsetInSyncSamples is an unsigned integer
+					if _, err := strconv.ParseUint(v, 10, 32); err != nil {
+						return errors.New("sysOffsetInSyncSamples='" + v + "' is invalid; must be an unsigned integer")
+					}
+				case k == "sysOffsetOutOfSyncSamples":
+					// Validate sysOffsetOutOfSyncSamples is an unsigned integer
+					if _, err := strconv.ParseUint(v, 10, 32); err != nil {
+						return errors.New("sysOffsetOutOfSyncSamples='" + v + "' is invalid; must be an unsigned integer")
+					}
 
 				case strings.Contains(k, "clockId"):
 					// Allow explicit clockId

--- a/api/v1/ptpconfig_webhook_test.go
+++ b/api/v1/ptpconfig_webhook_test.go
@@ -40,3 +40,134 @@ func TestPtpConfigValidator_MinOffsetThresholdAccepted(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Empty(t, warnings)
 }
+
+func newTestPtpConfigWithSettings(settings map[string]string) *PtpConfig {
+	profileName := "test-profile"
+	return &PtpConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-ptpconfig",
+			Namespace: "openshift-ptp",
+		},
+		Spec: PtpConfigSpec{
+			Profile: []PtpProfile{
+				{
+					Name:        &profileName,
+					PtpSettings: settings,
+				},
+			},
+		},
+	}
+}
+
+func TestPtpConfigValidator_SysOffsetThreshold(t *testing.T) {
+	validator := &ptpConfigValidator{}
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		value       string
+		expectError bool
+	}{
+		{name: "valid sysOffsetThreshold accepted", value: "200", expectError: false},
+		{name: "non-numeric sysOffsetThreshold rejected", value: "abc", expectError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ptpConfig := newTestPtpConfigWithSettings(map[string]string{"sysOffsetThreshold": tt.value})
+
+			warnings, err := validator.ValidateCreate(ctx, ptpConfig)
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "sysOffsetThreshold")
+				assert.Contains(t, err.Error(), "must be an unsigned integer")
+			} else {
+				assert.NoError(t, err)
+				assert.Empty(t, warnings)
+			}
+
+			warnings, err = validator.ValidateUpdate(ctx, ptpConfig, ptpConfig)
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "sysOffsetThreshold")
+				assert.Contains(t, err.Error(), "must be an unsigned integer")
+			} else {
+				assert.NoError(t, err)
+				assert.Empty(t, warnings)
+			}
+		})
+	}
+}
+
+func TestPtpConfigValidator_SysOffsetSamples(t *testing.T) {
+	validator := &ptpConfigValidator{}
+	ctx := context.Background()
+	sampleKeys := []string{"sysOffsetInSyncSamples", "sysOffsetOutOfSyncSamples"}
+
+	for _, sampleKey := range sampleKeys {
+		t.Run(sampleKey+" accepted independently", func(t *testing.T) {
+			ptpConfig := newTestPtpConfigWithSettings(map[string]string{sampleKey: "10"})
+
+			warnings, err := validator.ValidateCreate(ctx, ptpConfig)
+			assert.NoError(t, err)
+			assert.Empty(t, warnings)
+			assert.Equal(t, "10", ptpConfig.Spec.Profile[0].PtpSettings[sampleKey])
+		})
+	}
+
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{name: "negative value rejected", value: "-5"},
+		{name: "fractional value rejected", value: "3.5"},
+		{name: "non-numeric value rejected", value: "abc"},
+	}
+
+	for _, sampleKey := range sampleKeys {
+		for _, tt := range tests {
+			t.Run(sampleKey+" "+tt.name, func(t *testing.T) {
+				ptpConfig := newTestPtpConfigWithSettings(map[string]string{sampleKey: tt.value})
+
+				_, err := validator.ValidateCreate(ctx, ptpConfig)
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), sampleKey)
+				assert.Contains(t, err.Error(), "must be an unsigned integer")
+			})
+		}
+	}
+}
+
+func TestPtpConfigValidator_SysOffsetSettings_RejectsInvalidUpdate(t *testing.T) {
+	validator := &ptpConfigValidator{}
+	ctx := context.Background()
+
+	oldConfig := newTestPtpConfigWithSettings(map[string]string{"sysOffsetOutOfSyncSamples": "10"})
+	newConfig := newTestPtpConfigWithSettings(map[string]string{"sysOffsetOutOfSyncSamples": "abc"})
+
+	_, err := validator.ValidateUpdate(ctx, oldConfig, newConfig)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "sysOffsetOutOfSyncSamples")
+	assert.Contains(t, err.Error(), "must be an unsigned integer")
+}
+
+func TestPtpConfigValidator_ExistingProfilesUnaffected(t *testing.T) {
+	validator := &ptpConfigValidator{}
+	ctx := context.Background()
+
+	t.Run("nil PtpSettings accepted", func(t *testing.T) {
+		ptpConfig := newTestPtpConfigWithSettings(nil)
+
+		warnings, err := validator.ValidateCreate(ctx, ptpConfig)
+		assert.NoError(t, err)
+		assert.Empty(t, warnings)
+	})
+
+	t.Run("pre-existing key without sysOffset* keys accepted", func(t *testing.T) {
+		ptpConfig := newTestPtpConfigWithSettings(map[string]string{"inSyncConditionThreshold": "500"})
+
+		warnings, err := validator.ValidateCreate(ctx, ptpConfig)
+		assert.NoError(t, err)
+		assert.Empty(t, warnings)
+	})
+}

--- a/bundle/manifests/ptp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ptp-operator.clusterserviceversion.yaml
@@ -67,6 +67,9 @@ metadata:
               "clockChain": {
                 "structure": [
                   {
+                    "dpll": {
+                      "networkInterface": "ens787f1"
+                    },
                     "name": "nic1"
                   }
                 ]
@@ -82,7 +85,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/openshift/origin-ptp-operator:5.0
-    createdAt: "2026-08-26T10:30:35Z"
+    createdAt: "2026-09-02T10:48:35Z"
     description: This software enables configuration of Precision Time Protocol(PTP)
       on Kubernetes. It detects hardware capable PTP devices on each node, and configures
       linuxptp processes such as ptp4l, phc2sys and timemaster.

--- a/bundle/manifests/ptp.openshift.io_ptpconfigs.yaml
+++ b/bundle/manifests/ptp.openshift.io_ptpconfigs.yaml
@@ -155,6 +155,19 @@ spec:
                     ptpSettings:
                       additionalProperties:
                         type: string
+                      description: |-
+                        PtpSettings holds free-form, string-typed configuration knobs validated individually
+                        by the PtpConfig admission webhook. Recognized keys include (non-exhaustive):
+                          - sysOffsetInSyncThreshold: phc2sys-to-CLOCK_REALTIME offset threshold, in
+                            nanoseconds, that must be met to gate the OS Clock Sync (E3) LOCKED state.
+                            No default; must be explicitly configured for the parameter to take effect.
+                          - sysOffsetOutOfSyncThreshold: phc2sys-to-CLOCK_REALTIME offset threshold, in
+                            nanoseconds, that when exceeded gates the OS Clock Sync (E3) FREERUN state.
+                            Independent of sysOffsetInSyncThreshold; together they form a hysteresis band.
+                            No default; must be explicitly configured for the parameter to take effect.
+                          - sysOffsetSamples: number of consecutive phc2sys samples required for E3
+                            state transitions in either direction (relative to sysOffsetInSyncThreshold
+                            for LOCKED, or sysOffsetOutOfSyncThreshold for FREERUN). Default: 10.
                       type: object
                     synce4lConf:
                       type: string

--- a/config/crd/bases/ptp.openshift.io_ptpconfigs.yaml
+++ b/config/crd/bases/ptp.openshift.io_ptpconfigs.yaml
@@ -155,6 +155,19 @@ spec:
                     ptpSettings:
                       additionalProperties:
                         type: string
+                      description: |-
+                        PtpSettings holds free-form, string-typed configuration knobs validated individually
+                        by the PtpConfig admission webhook. Recognized keys include (non-exhaustive):
+                          - sysOffsetInSyncThreshold: phc2sys-to-CLOCK_REALTIME offset threshold, in
+                            nanoseconds, that must be met to gate the OS Clock Sync (E3) LOCKED state.
+                            No default; must be explicitly configured for the parameter to take effect.
+                          - sysOffsetOutOfSyncThreshold: phc2sys-to-CLOCK_REALTIME offset threshold, in
+                            nanoseconds, that when exceeded gates the OS Clock Sync (E3) FREERUN state.
+                            Independent of sysOffsetInSyncThreshold; together they form a hysteresis band.
+                            No default; must be explicitly configured for the parameter to take effect.
+                          - sysOffsetSamples: number of consecutive phc2sys samples required for E3
+                            state transitions in either direction (relative to sysOffsetInSyncThreshold
+                            for LOCKED, or sysOffsetOutOfSyncThreshold for FREERUN). Default: 10.
                       type: object
                     synce4lConf:
                       type: string

--- a/config/manifests/bases/ptp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ptp-operator.clusterserviceversion.yaml
@@ -50,6 +50,30 @@ metadata:
           "spec": {
             "daemonNodeSelector": {}
           }
+        },
+        {
+          "apiVersion": "ptp.openshift.io/v2alpha1",
+          "kind": "HardwareConfig",
+          "metadata": {
+            "name": "example-hardwareconfig"
+          },
+          "spec": {
+            "profile": {
+              "clockChain": {
+                "structure": [
+                  {
+                    "dpll": {
+                      "networkInterface": "ens787f1"
+                    },
+                    "name": "nic1"
+                  }
+                ]
+              },
+              "clockType": "T-GM",
+              "name": "example-profile"
+            },
+            "relatedPtpProfileName": "profile1"
+          }
         }
       ]
     capabilities: Basic Install

--- a/config/samples/ptp_v2alpha1_hardwareconfig.yaml
+++ b/config/samples/ptp_v2alpha1_hardwareconfig.yaml
@@ -10,3 +10,5 @@ spec:
     clockChain:
       structure:
       - name: "nic1"
+        dpll:
+          networkInterface: "ens787f1"

--- a/manifests/stable/ptp-operator.clusterserviceversion.yaml
+++ b/manifests/stable/ptp-operator.clusterserviceversion.yaml
@@ -67,6 +67,9 @@ metadata:
               "clockChain": {
                 "structure": [
                   {
+                    "dpll": {
+                      "networkInterface": "ens787f1"
+                    },
                     "name": "nic1"
                   }
                 ]
@@ -82,7 +85,7 @@ metadata:
     categories: Networking
     certified: "false"
     containerImage: quay.io/openshift/origin-ptp-operator:5.0
-    createdAt: "2026-08-26T10:30:35Z"
+    createdAt: "2026-09-02T10:48:35Z"
     description: This software enables configuration of Precision Time Protocol(PTP)
       on Kubernetes. It detects hardware capable PTP devices on each node, and configures
       linuxptp processes such as ptp4l, phc2sys and timemaster.

--- a/manifests/stable/ptp.openshift.io_ptpconfigs.yaml
+++ b/manifests/stable/ptp.openshift.io_ptpconfigs.yaml
@@ -155,6 +155,19 @@ spec:
                     ptpSettings:
                       additionalProperties:
                         type: string
+                      description: |-
+                        PtpSettings holds free-form, string-typed configuration knobs validated individually
+                        by the PtpConfig admission webhook. Recognized keys include (non-exhaustive):
+                          - sysOffsetInSyncThreshold: phc2sys-to-CLOCK_REALTIME offset threshold, in
+                            nanoseconds, that must be met to gate the OS Clock Sync (E3) LOCKED state.
+                            No default; must be explicitly configured for the parameter to take effect.
+                          - sysOffsetOutOfSyncThreshold: phc2sys-to-CLOCK_REALTIME offset threshold, in
+                            nanoseconds, that when exceeded gates the OS Clock Sync (E3) FREERUN state.
+                            Independent of sysOffsetInSyncThreshold; together they form a hysteresis band.
+                            No default; must be explicitly configured for the parameter to take effect.
+                          - sysOffsetSamples: number of consecutive phc2sys samples required for E3
+                            state transitions in either direction (relative to sysOffsetInSyncThreshold
+                            for LOCKED, or sysOffsetOutOfSyncThreshold for FREERUN). Default: 10.
                       type: object
                     synce4lConf:
                       type: string


### PR DESCRIPTION
Add OS clock E3 settings
    
Stage 1 (API only) of a 3-stage cross-repo feature implementing the T-BC OS Clock Sync (E3) threshold parameters defined in clock-requirements/tbc/spec.md section 11.1.6/12.5 (gap G13 in gaps.md).
Adds three new PtpProfile.PtpSettings keys, validated in the PtpConfig admission webhook following the existing inSyncConditionThreshold/ inSyncConditionTimes precedent (unsigned-integer parsing, same error message format):


/cc @lack @nocturnalastro @sebsoto @jzding 
I used ptpSettings, which is a map[string]string. Should we consider adding proper CRD structures for configurations?  I don't mind adding a new settings structure if you think it is appropriate and will better serve us in the long run.
This is based on https://github.com/k8snetworkplumbingwg/ptp-operator/pull/292
Please review only the last commit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation for supported system-offset thresholds and synchronization sample settings in `PtpConfig`, with clear errors for invalid values.
  * Added a `HardwareConfig` v2alpha1 example, including clock-chain and network-interface configuration.

* **Documentation**
  * Expanded `PtpConfig` documentation to explain supported settings, defaults, thresholds, hysteresis, and clock synchronization state transitions.
  * Improved `HardwareConfig` resource metadata and examples for easier discovery and adoption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->