### PR TITLE
CNF-17431: Add smoke test mode for CI infrastructure validation

### DIFF
--- a/hack/run-functests.sh
+++ b/hack/run-functests.sh
@@ -63,6 +63,8 @@ VALIDATION_SUIT_SUBSTR="validation"
 go version
 if [[ $SUITE == *"$VALIDATION_SUIT_SUBSTR"* ]]; then
   GOFLAGS=-mod=vendor ginkgo --output-dir=$JUNIT_OUTPUT_DIR --junit-report=$JUNIT_OUTPUT_FILE -v -p "$SUITE"
+elif [[ "${PTP_TEST_MODE:-}" == "smoke" ]]; then
+  GOFLAGS=-mod=vendor ginkgo --output-dir=$JUNIT_OUTPUT_DIR --junit-report=$JUNIT_OUTPUT_FILE -v "$SUITE"/serial
 else
   GOFLAGS=-mod=vendor ginkgo --keep-going --output-dir=$JUNIT_OUTPUT_DIR --junit-report=$JUNIT_OUTPUT_FILE -v -p "$SUITE"/serial "$SUITE"/parallel
 fi

--- a/test/conformance/serial/ptp.go
+++ b/test/conformance/serial/ptp.go
@@ -66,7 +66,7 @@ var (
 )
 var DesiredMode = testconfig.GetDesiredConfig(true).PtpModeDesired
 
-var _ = Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, func() {
+var _ = strings.EqualFold(os.Getenv("PTP_TEST_MODE"), "smoke") || Describe("["+strings.ToLower(DesiredMode.String())+"-serial]", Serial, func() {
 	BeforeEach(func() {
 		Expect(client.Client).NotTo(BeNil())
 		if DesiredMode == testconfig.DualNICBoundaryClockHA || DesiredMode == testconfig.DualFollowerClock {

--- a/test/conformance/serial/serial_suite_test.go
+++ b/test/conformance/serial/serial_suite_test.go
@@ -34,43 +34,62 @@ func InitDeletePtpConfig() {
 	logrus.Infof("DeletePtpConfig=%t", DeletePtpConfig)
 }
 
+func isSmokeMode() bool {
+	return strings.EqualFold(os.Getenv("PTP_TEST_MODE"), "smoke")
+}
+
 func TestTest(t *testing.T) {
 	logging.InitLogLevel()
 	RegisterFailHandler(Fail)
 	InitDeletePtpConfig()
 	suiteCfg, repCfg := GinkgoConfiguration()
+	if isSmokeMode() && !suiteCfg.DryRun {
+		testclient.Client = testclient.New("")
+		if testclient.Client == nil {
+			t.Fatal("failed to initialize Kubernetes client")
+		}
+	}
 	repCfg.SilenceSkips = true
 	RunSpecs(t, "PTP e2e integration tests", suiteCfg, repCfg)
 }
 
-var _ = BeforeSuite(func() {
-	logrus.Info("Executed from serial suite")
-	testclient.Client = testclient.New("")
-	Expect(testclient.Client).NotTo(BeNil())
-
-	// Initialize the pub/sub system for event handling
-	event.InitPubSub()
-
-	// Start log collection if enabled
-	suiteName := "serial"
-	if mode := os.Getenv("PTP_TEST_MODE"); mode != "" {
-		suiteName = suiteName + "_" + strings.ToLower(mode)
-	}
-	err := logging.StartLogCollection(suiteName)
-	if err != nil {
-		logrus.Errorf("Failed to start log collection: %v", err)
-	}
-})
-
-var _ = AfterSuite(func() {
-
-	if DeletePtpConfig && testconfig.GetDesiredConfig(false).PtpModeDesired != testconfig.Discovery {
-		clean.All()
+func registerNormalModeSuiteHooks() bool {
+	if isSmokeMode() {
+		return true
 	}
 
-	// Stop log collection
-	logging.StopLogCollection()
-})
+	BeforeSuite(func() {
+		logrus.Info("Executed from serial suite")
+		testclient.Client = testclient.New("")
+		Expect(testclient.Client).NotTo(BeNil())
+
+		// Initialize the pub/sub system for event handling
+		event.InitPubSub()
+
+		// Start log collection if enabled
+		suiteName := "serial"
+		if mode := os.Getenv("PTP_TEST_MODE"); mode != "" {
+			suiteName = suiteName + "_" + strings.ToLower(mode)
+		}
+		err := logging.StartLogCollection(suiteName)
+		if err != nil {
+			logrus.Errorf("Failed to start log collection: %v", err)
+		}
+	})
+
+	AfterSuite(func() {
+		if DeletePtpConfig && testconfig.GetDesiredConfig(false).PtpModeDesired != testconfig.Discovery {
+			clean.All()
+		}
+
+		// Stop log collection
+		logging.StopLogCollection()
+	})
+
+	return true
+}
+
+var _ = registerNormalModeSuiteHooks()
 
 var _ = ReportBeforeEach(func(report SpecReport) {
 	// Write test start marker to all log files

--- a/test/conformance/serial/smoke.go
+++ b/test/conformance/serial/smoke.go
@@ -1,0 +1,70 @@
+//go:build !unittests
+// +build !unittests
+
+package test
+
+import (
+	"context"
+	"os"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/k8snetworkplumbingwg/ptp-operator/test/pkg/client"
+)
+
+// Smoke tests are minimal infrastructure validation tests that run quickly
+// to verify the test framework, cluster connectivity, and basic setup.
+// Set PTP_TEST_MODE=smoke to run only these tests.
+
+var _ = Describe("[smoke]", Serial, func() {
+	BeforeEach(func() {
+		// Only run smoke tests when PTP_TEST_MODE=smoke
+		mode := strings.ToLower(os.Getenv("PTP_TEST_MODE"))
+		if mode != "smoke" {
+			Skip("Skipping smoke tests - PTP_TEST_MODE is not set to 'smoke'")
+		}
+	})
+
+	Context("Smoke Tests - Infrastructure Validation", func() {
+		It("Should validate test infrastructure is working", func() {
+			logrus.Info("=== SMOKE TEST: Hello World ===")
+			logrus.Info("Test framework initialized successfully")
+			logrus.Info("Ginkgo/Gomega test runner operational")
+
+			// Basic assertion to verify test framework
+			Expect(true).To(BeTrue(), "Basic assertion check")
+
+			logrus.Info("=== SMOKE TEST: PASSED ===")
+		})
+
+		It("Should verify cluster client connectivity", func() {
+			logrus.Info("=== SMOKE TEST: Client Connectivity ===")
+
+			// Verify k8s client is initialized
+			Expect(client.Client).NotTo(BeNil(), "Kubernetes client should be initialized")
+
+			// Try to connect to the cluster
+			_, err := client.Client.Nodes().List(context.Background(), metav1.ListOptions{})
+			Expect(err).NotTo(HaveOccurred(), "Should be able to list nodes")
+
+			logrus.Info("Cluster connectivity verified")
+			logrus.Info("=== SMOKE TEST: PASSED ===")
+		})
+
+		It("Should verify PTP namespace exists", func() {
+			logrus.Info("=== SMOKE TEST: PTP Namespace Check ===")
+
+			// Check if openshift-ptp namespace exists
+			ns, err := client.Client.Namespaces().Get(context.Background(), "openshift-ptp", metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred(), "openshift-ptp namespace should exist")
+			Expect(ns).NotTo(BeNil())
+
+			logrus.Infof("PTP namespace found: %s", ns.Name)
+			logrus.Info("=== SMOKE TEST: PASSED ===")
+		})
+	})
+})


### PR DESCRIPTION
## Summary

Add a focused `PTP_TEST_MODE=smoke` mode for quickly validating the PTP conformance-test infrastructure without requiring a complete PTP topology.

The smoke suite verifies:

- Ginkgo/Gomega test execution
- Kubernetes client connectivity and node listing
- Availability of the `openshift-ptp` namespace

## Smoke-mode isolation

- Run only the serial smoke suite from `hack/run-functests.sh`; the parallel suite is not part of smoke testing.
- Do not register the topology-dependent serial test container in smoke mode, preventing its setup and configuration-discovery hooks from running or appearing as pending tests.
- Do not register the normal serial `BeforeSuite` and `AfterSuite` hooks in smoke mode, removing irrelevant hook output and cleanup work.
- Initialize the Kubernetes client directly for non-dry-run smoke tests so connectivity checks remain functional.
- Preserve normal serial and parallel behavior when `PTP_TEST_MODE` is not `smoke`.

These changes allow smoke runs on minimal or single-node labs where normal PTP topology discovery is unavailable, while producing a concise report with no topology-related failures or pending tests.

## Verification

```text
make fmt
INFO: gofmt success

PTP_TEST_MODE=smoke go test ./test/conformance/serial -run TestTest -count=1 -v \
  -args -ginkgo.dry-run
Ran 3 of 3 Specs
SUCCESS! -- 3 Passed | 0 Failed | 0 Pending | 0 Skipped
```
