### PR TITLE
[WIP] Add mTLS + OAuth authentication to PTP event publisher APIs (CNF-26787)

### DIFF
--- a/bindata/linuxptp/auth-config.yaml
+++ b/bindata/linuxptp/auth-config.yaml
@@ -1,0 +1,89 @@
+---
+# CA bundle used to verify peer certificates for the event publisher's mTLS.
+# The OpenShift Service CA operator injects the cluster service CA into
+# service-ca.crt. All serving certificates minted below are signed by this CA,
+# so it is trusted for both the server certificate and presented client
+# certificates.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ptp-event-publisher-ca-bundle
+  namespace: {{.Namespace}}
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+  labels:
+    app: linuxptp-daemon
+---
+# Headless service whose serving certificate is presented by the event
+# publisher (cloud-event-proxy) on port 9043. The Service CA operator generates
+# ptp-event-publisher-server-tls (tls.crt/tls.key) with SANs for this service's
+# DNS name. External consumers verifying the server certificate should target
+# this service name (or set it as the TLS ServerName) so hostname verification
+# succeeds; per-node routing continues via ptp-event-publisher-service-<node>.
+apiVersion: v1
+kind: Service
+metadata:
+  name: ptp-event-publisher-server
+  namespace: {{.Namespace}}
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: ptp-event-publisher-server-tls
+  labels:
+    app: linuxptp-daemon
+spec:
+  clusterIP: None
+  selector:
+    app: linuxptp-daemon
+  ports:
+    - name: server-port
+      port: 9043
+  sessionAffinity: None
+  type: ClusterIP
+---
+# Authentication configuration consumed by cloud-event-proxy via --auth-config.
+# Enables mTLS (Service CA signed certs) and OAuth on ALL exposed event APIs.
+# OAuth bearer tokens are validated in-process against the Kubernetes
+# TokenReview API, so no OAuth issuer / JWKS URL is required. The TLS profile
+# (min version and cipher suites) mirrors the cluster-wide TLSSecurityProfile
+# for Post-Quantum Cryptography readiness (CNF-21982).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ptp-event-publisher-auth
+  namespace: {{.Namespace}}
+  labels:
+    app: linuxptp-daemon
+data:
+  config.json: |
+    {
+      "enableMTLS": true,
+      "useServiceCA": true,
+      "caCertPath": "/etc/cloud-event-proxy/ca-bundle/service-ca.crt",
+      "serverCertPath": "/etc/cloud-event-proxy/server-certs/tls.crt",
+      "serverKeyPath": "/etc/cloud-event-proxy/server-certs/tls.key",
+      "enableOAuth": true,
+      "useOpenShiftOAuth": true,
+      "requiredAudiences": ["https://kubernetes.default.svc"],
+      "serviceAccountName": "linuxptp-daemon",
+      "serviceAccountToken": "/var/run/secrets/kubernetes.io/serviceaccount/token",
+      "tlsMinVersion": "{{.TLSMinVersion}}",
+      "tlsCipherSuites": {{.TLSCipherSuitesJSON}}
+    }
+---
+# Allows the linuxptp-daemon ServiceAccount (under which cloud-event-proxy runs)
+# to create TokenReviews so it can cryptographically validate bearer tokens
+# (ServiceAccount JWTs and opaque OpenShift OAuth tokens) presented to the
+# event APIs.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: linuxptp-daemon-auth-delegator
+  labels:
+    app: linuxptp-daemon
+subjects:
+- kind: ServiceAccount
+  name: linuxptp-daemon
+  namespace: {{.Namespace}}
+roleRef:
+  kind: ClusterRole
+  name: system:auth-delegator
+  apiGroup: rbac.authorization.k8s.io

--- a/bindata/linuxptp/ptp-daemon.yaml
+++ b/bindata/linuxptp/ptp-daemon.yaml
@@ -216,7 +216,7 @@ spec:
           hostPath:
             path: /var/run/ptp
             type: DirectoryOrCreate
-        {{- if .EnableEventAuth }}
+        {{- if and (eq .EnableEventPublisher true) .EnableEventAuth }}
         - name: server-certs
           secret:
             secretName: ptp-event-publisher-server-tls

--- a/bindata/linuxptp/ptp-daemon.yaml
+++ b/bindata/linuxptp/ptp-daemon.yaml
@@ -41,11 +41,25 @@ spec:
           args:
             - "--api-port=9043"
             - "--store-path=/var/run"
+            {{- if .EnableEventAuth }}
+            - "--auth-config=/etc/cloud-event-proxy/auth/config.json"
+            {{- end }}
           volumeMounts:
             - name: config-volume
               mountPath: /etc/linuxptp
             - name: socket-dir
               mountPath: /var/run
+            {{- if .EnableEventAuth }}
+            - name: server-certs
+              mountPath: /etc/cloud-event-proxy/server-certs
+              readOnly: true
+            - name: ca-bundle
+              mountPath: /etc/cloud-event-proxy/ca-bundle
+              readOnly: true
+            - name: auth-config
+              mountPath: /etc/cloud-event-proxy/auth
+              readOnly: true
+            {{- end }}
           ports:
             - name: api-port
               containerPort: 9043
@@ -66,6 +80,9 @@ spec:
             - "--transport-host={{ .EventTransportHost }}"
             - "--api-version={{ .EventApiVersion }}"
             - "--api-port=9043"
+            {{- if .EnableEventAuth }}
+            - "--auth-config=/etc/cloud-event-proxy/auth/config.json"
+            {{- end }}
           volumeMounts:
             - name: config-volume
               mountPath: /etc/linuxptp
@@ -75,6 +92,17 @@ spec:
               mountPath: /cloud-native
             - name: socket-dir
               mountPath: /var/run
+            {{- if .EnableEventAuth }}
+            - name: server-certs
+              mountPath: /etc/cloud-event-proxy/server-certs
+              readOnly: true
+            - name: ca-bundle
+              mountPath: /etc/cloud-event-proxy/ca-bundle
+              readOnly: true
+            - name: auth-config
+              mountPath: /etc/cloud-event-proxy/auth
+              readOnly: true
+            {{- end }}
           ports:
             - name: metrics-port
               containerPort: 9091
@@ -128,7 +156,11 @@ spec:
           args:
           {{ $cmd := "/usr/local/bin/ptp --alsologtostderr -v 10" }}
           {{- if (eq .EnableEventPublisher true) }}
+            {{- if .EnableEventAuth }}
+            - "until [ $(curl -s -k -w '%{http_code}' 'https://localhost:9043/api/ocloudNotifications/v2/health' -o /dev/null) -eq 200 ]; do echo 'waiting for cloud event proxy to start'; sleep 10s; done; {{ $cmd }}"
+            {{- else }}
             - "until [ $(curl -s -w '%{http_code}' 'http://localhost:9043/api/ocloudNotifications/v2/health' -o /dev/null) -eq 200 ]; do echo 'waiting for cloud event proxy to start'; sleep 10s; done; {{ $cmd }}"
+            {{- end }}
           {{- else }}
             - {{ $cmd }}
           {{- end }}
@@ -184,6 +216,17 @@ spec:
           hostPath:
             path: /var/run/ptp
             type: DirectoryOrCreate
+        {{- if .EnableEventAuth }}
+        - name: server-certs
+          secret:
+            secretName: ptp-event-publisher-server-tls
+        - name: ca-bundle
+          configMap:
+            name: ptp-event-publisher-ca-bundle
+        - name: auth-config
+          configMap:
+            name: ptp-event-publisher-auth
+        {{- end }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/bundle/manifests/ptp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ptp-operator.clusterserviceversion.yaml
@@ -427,7 +427,7 @@ spec:
                   value: quay.io/openshift/origin-cloud-event-proxy:5.0
                 - name: EVENT_PROXY_IMAGE
                 - name: ENABLE_EVENT_AUTH
-                  value: "true"
+                  value: "false"
                 - name: OPERATOR_NAMESPACE
                   valueFrom:
                     fieldRef:

--- a/bundle/manifests/ptp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ptp-operator.clusterserviceversion.yaml
@@ -308,6 +308,26 @@ spec:
           verbs:
           - '*'
         - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resourceNames:
+          - system:auth-delegator
+          resources:
+          - clusterroles
+          verbs:
+          - bind
+        - apiGroups:
           - config.openshift.io
           resources:
           - apiservers

--- a/bundle/manifests/ptp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ptp-operator.clusterserviceversion.yaml
@@ -406,6 +406,8 @@ spec:
                 - name: SIDECAR_EVENT_IMAGE
                   value: quay.io/openshift/origin-cloud-event-proxy:5.0
                 - name: EVENT_PROXY_IMAGE
+                - name: ENABLE_EVENT_AUTH
+                  value: "true"
                 - name: OPERATOR_NAMESPACE
                   valueFrom:
                     fieldRef:

--- a/bundle/manifests/ptp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ptp-operator.clusterserviceversion.yaml
@@ -313,12 +313,19 @@ spec:
           - clusterrolebindings
           verbs:
           - create
-          - delete
-          - get
           - list
-          - patch
-          - update
           - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resourceNames:
+          - linuxptp-daemon-auth-delegator
+          resources:
+          - clusterrolebindings
+          verbs:
+          - get
+          - update
+          - patch
+          - delete
         - apiGroups:
           - rbac.authorization.k8s.io
           resourceNames:

--- a/config/custom/rbac.yaml
+++ b/config/custom/rbac.yaml
@@ -54,9 +54,17 @@ rules:
   verbs: ["*"]
 # The operator creates/removes the linuxptp-daemon-auth-delegator
 # ClusterRoleBinding when event authentication is toggled.
+# create/list/watch cannot be constrained by resourceNames (Kubernetes RBAC
+# only honors resourceNames for get/update/patch/delete), and the cache-backed
+# controller-runtime client needs cluster-wide list/watch on the type.
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["clusterrolebindings"]
-  verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  verbs: ["create", "list", "watch"]
+# Mutating/reading the specific binding the operator owns is scoped by name.
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["clusterrolebindings"]
+  resourceNames: ["linuxptp-daemon-auth-delegator"]
+  verbs: ["get", "update", "patch", "delete"]
 # Binding to system:auth-delegator requires the "bind" verb on it (RBAC
 # escalation prevention), since the operator does not itself hold that role.
 - apiGroups: ["rbac.authorization.k8s.io"]

--- a/config/custom/rbac.yaml
+++ b/config/custom/rbac.yaml
@@ -52,6 +52,17 @@ rules:
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["rolebindings"]
   verbs: ["*"]
+# The operator creates/removes the linuxptp-daemon-auth-delegator
+# ClusterRoleBinding when event authentication is toggled.
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["clusterrolebindings"]
+  verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+# Binding to system:auth-delegator requires the "bind" verb on it (RBAC
+# escalation prevention), since the operator does not itself hold that role.
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["clusterroles"]
+  resourceNames: ["system:auth-delegator"]
+  verbs: ["bind"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/config/manager/env.yaml
+++ b/config/manager/env.yaml
@@ -26,6 +26,7 @@ spec:
               value: ""
             # Enables mTLS + OAuth authentication on the PTP event publisher APIs.
             # Requires the OpenShift Service CA operator (serving certs + CA bundle
-            # injection). Set to "false" on clusters without Service CA.
+            # injection). Defaults to "false" here for the upstream/community
+            # manifests; the OpenShift OLM bundle CSVs set this to "true".
             - name: ENABLE_EVENT_AUTH
-              value: "true"
+              value: "false"

--- a/config/manager/env.yaml
+++ b/config/manager/env.yaml
@@ -24,3 +24,8 @@ spec:
             # The final naming/usage of this should be discussed before release.
             - name: EVENT_PROXY_IMAGE
               value: ""
+            # Enables mTLS + OAuth authentication on the PTP event publisher APIs.
+            # Requires the OpenShift Service CA operator (serving certs + CA bundle
+            # injection). Set to "false" on clusters without Service CA.
+            - name: ENABLE_EVENT_AUTH
+              value: "true"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -77,3 +77,5 @@ spec:
               value: $SIDECAR_EVENT_IMAGE
             - name: EVENT_PROXY_IMAGE
               value: $EVENT_PROXY_IMAGE
+            - name: ENABLE_EVENT_AUTH
+              value: "$ENABLE_EVENT_AUTH"

--- a/controllers/event_auth_test.go
+++ b/controllers/event_auth_test.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -8,10 +9,94 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	libgocrypto "github.com/openshift/library-go/pkg/crypto"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/k8snetworkplumbingwg/ptp-operator/pkg/render"
 )
+
+// authTestNamespace matches makeTestRenderData's Namespace.
+const authTestNamespace = "openshift-ptp"
+
+// newAuthTestReconciler builds a reconciler backed by a fake client preloaded
+// with the given objects.
+func newAuthTestReconciler(t *testing.T, objs ...client.Object) *PtpOperatorConfigReconciler {
+	t.Helper()
+	// syncEventAuth renders via names.ManifestDir ("./bindata"), which is
+	// relative to the repo root; tests run from ./controllers.
+	t.Chdir("..")
+	scheme := runtime.NewScheme()
+	assert.NoError(t, clientgoscheme.AddToScheme(scheme))
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	return &PtpOperatorConfigReconciler{Client: c, Scheme: scheme}
+}
+
+// authRenderData returns render data with the fields the auth-config manifest
+// needs to render.
+func authRenderData() *render.RenderData {
+	data := makeTestRenderData()
+	data.Data["TLSMinVersion"] = ""
+	data.Data["TLSCipherSuitesJSON"] = "[]"
+	return data
+}
+
+// authResourceExists reports whether the named object is present in the client.
+func authResourceExists(t *testing.T, r *PtpOperatorConfigReconciler, obj client.Object, name, namespace string) bool {
+	t.Helper()
+	err := r.Get(context.Background(), types.NamespacedName{Name: name, Namespace: namespace}, obj)
+	if err == nil {
+		return true
+	}
+	if apierrors.IsNotFound(err) {
+		return false
+	}
+	t.Fatalf("unexpected error getting %s/%s: %v", namespace, name, err)
+	return false
+}
+
+// TestSyncEventAuthDisabledDeletesResources verifies that when authentication is
+// disabled the previously-created auth resources - including the cluster-scoped
+// ClusterRoleBinding - are torn down rather than orphaned.
+func TestSyncEventAuthDisabledDeletesResources(t *testing.T) {
+	seed := []client.Object{
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "ptp-event-publisher-ca-bundle", Namespace: authTestNamespace}},
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "ptp-event-publisher-server", Namespace: authTestNamespace}},
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "ptp-event-publisher-auth", Namespace: authTestNamespace}},
+		&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "linuxptp-daemon-auth-delegator"}},
+	}
+	r := newAuthTestReconciler(t, seed...)
+
+	assert.NoError(t, r.syncEventAuth(context.Background(), authRenderData(), false))
+
+	assert.False(t, authResourceExists(t, r, &corev1.ConfigMap{}, "ptp-event-publisher-ca-bundle", authTestNamespace))
+	assert.False(t, authResourceExists(t, r, &corev1.Service{}, "ptp-event-publisher-server", authTestNamespace))
+	assert.False(t, authResourceExists(t, r, &corev1.ConfigMap{}, "ptp-event-publisher-auth", authTestNamespace))
+	assert.False(t, authResourceExists(t, r, &rbacv1.ClusterRoleBinding{}, "linuxptp-daemon-auth-delegator", ""))
+
+	// Deleting again when nothing is present must be a no-op (NotFound tolerated).
+	assert.NoError(t, r.syncEventAuth(context.Background(), authRenderData(), false))
+}
+
+// TestSyncEventAuthEnabledCreatesResources verifies the enabled path creates the
+// full set of auth resources.
+func TestSyncEventAuthEnabledCreatesResources(t *testing.T) {
+	r := newAuthTestReconciler(t)
+
+	assert.NoError(t, r.syncEventAuth(context.Background(), authRenderData(), true))
+
+	assert.True(t, authResourceExists(t, r, &corev1.ConfigMap{}, "ptp-event-publisher-ca-bundle", authTestNamespace))
+	assert.True(t, authResourceExists(t, r, &corev1.Service{}, "ptp-event-publisher-server", authTestNamespace))
+	assert.True(t, authResourceExists(t, r, &corev1.ConfigMap{}, "ptp-event-publisher-auth", authTestNamespace))
+	assert.True(t, authResourceExists(t, r, &rbacv1.ClusterRoleBinding{}, "linuxptp-daemon-auth-delegator", ""))
+}
 
 // daemonSidecarArgs returns the args of the cloud-event-proxy container from a
 // rendered ptp-daemon.yaml DaemonSet object.

--- a/controllers/event_auth_test.go
+++ b/controllers/event_auth_test.go
@@ -1,0 +1,112 @@
+package controllers
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	libgocrypto "github.com/openshift/library-go/pkg/crypto"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/k8snetworkplumbingwg/ptp-operator/pkg/render"
+)
+
+// daemonSidecarArgs returns the args of the cloud-event-proxy container from a
+// rendered ptp-daemon.yaml DaemonSet object.
+func daemonSidecarArgs(t *testing.T, objs []*unstructured.Unstructured) []string {
+	t.Helper()
+	for _, obj := range objs {
+		if obj.GetKind() != "DaemonSet" {
+			continue
+		}
+		containers, found, err := unstructuredContainers(obj.Object)
+		assert.NoError(t, err)
+		assert.True(t, found)
+		for _, c := range containers {
+			container := c.(map[string]interface{})
+			if container["name"] == "cloud-event-proxy" {
+				var args []string
+				if raw, ok := container["args"].([]interface{}); ok {
+					for _, a := range raw {
+						args = append(args, a.(string))
+					}
+				}
+				return args
+			}
+		}
+	}
+	return nil
+}
+
+// TestEventAuthDisabled verifies the sidecar carries no auth wiring when
+// ENABLE_EVENT_AUTH is off, so the operator stays usable without Service CA.
+func TestEventAuthDisabled(t *testing.T) {
+	data := makeTestRenderData()
+	data.Data["EnableEventPublisher"] = true
+	data.Data["SideCarV2"] = ""
+	data.Data["EventTransportHost"] = "http://ptp-event-publisher-service-NODE_NAME.openshift-ptp.svc.cluster.local:9043"
+	data.Data["TLSMinVersion"] = ""
+	data.Data["TLSCipherSuites"] = ""
+	data.Data["EnableEventAuth"] = false
+
+	objs, err := render.RenderTemplate("../bindata/linuxptp/ptp-daemon.yaml", data)
+	assert.NoError(t, err)
+	args := daemonSidecarArgs(t, objs)
+	for _, a := range args {
+		assert.NotContains(t, a, "--auth-config", "auth-config must not be set when auth disabled")
+	}
+}
+
+// TestEventAuthEnabled verifies the sidecar gets the auth-config flag and the
+// auth manifest renders the expected resources with a valid, TLS-profiled JSON.
+func TestEventAuthEnabled(t *testing.T) {
+	profile := *configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+	ianaCiphers := libgocrypto.OpenSSLToIANACipherSuites(profile.Ciphers)
+
+	data := makeTestRenderData()
+	data.Data["Namespace"] = "custom-ns"
+	data.Data["EnableEventPublisher"] = true
+	data.Data["SideCarV2"] = ""
+	data.Data["EventTransportHost"] = "http://ptp-event-publisher-service-NODE_NAME.custom-ns.svc.cluster.local:9043"
+	data.Data["TLSMinVersion"] = string(profile.MinTLSVersion)
+	data.Data["TLSCipherSuites"] = strings.Join(ianaCiphers, ",")
+	data.Data["TLSCipherSuitesJSON"] = ciphersToJSONArray(ianaCiphers)
+	data.Data["EnableEventAuth"] = true
+
+	// Sidecar must reference the auth config.
+	objs, err := render.RenderTemplate("../bindata/linuxptp/ptp-daemon.yaml", data)
+	assert.NoError(t, err)
+	args := daemonSidecarArgs(t, objs)
+	assert.Contains(t, args, "--auth-config=/etc/cloud-event-proxy/auth/config.json")
+
+	// Auth manifest must produce the CA bundle, serving-cert service, auth
+	// ConfigMap and the auth-delegator ClusterRoleBinding.
+	authObjs, err := render.RenderTemplate("../bindata/linuxptp/auth-config.yaml", data)
+	assert.NoError(t, err)
+	kinds := map[string]bool{}
+	var cfgJSON string
+	for _, o := range authObjs {
+		kinds[o.GetKind()+"/"+o.GetName()] = true
+		if o.GetKind() == "ConfigMap" && o.GetName() == "ptp-event-publisher-auth" {
+			d, ok := o.Object["data"].(map[string]interface{})
+			assert.True(t, ok)
+			cfgJSON = d["config.json"].(string)
+		}
+	}
+	assert.True(t, kinds["ConfigMap/ptp-event-publisher-ca-bundle"])
+	assert.True(t, kinds["Service/ptp-event-publisher-server"])
+	assert.True(t, kinds["ConfigMap/ptp-event-publisher-auth"])
+	assert.True(t, kinds["ClusterRoleBinding/linuxptp-daemon-auth-delegator"])
+
+	// config.json must be valid and carry the cluster TLS profile.
+	var cfg map[string]interface{}
+	assert.NoError(t, json.Unmarshal([]byte(cfgJSON), &cfg))
+	assert.Equal(t, true, cfg["enableMTLS"])
+	assert.Equal(t, true, cfg["enableOAuth"])
+	assert.Equal(t, string(profile.MinTLSVersion), cfg["tlsMinVersion"])
+	suites, ok := cfg["tlsCipherSuites"].([]interface{})
+	assert.True(t, ok)
+	assert.NotEmpty(t, suites)
+}

--- a/controllers/ptpoperatorconfig_controller.go
+++ b/controllers/ptpoperatorconfig_controller.go
@@ -311,6 +311,13 @@ func (r *PtpOperatorConfigReconciler) syncLinuxptpDaemon(ctx context.Context, de
 	}
 
 	if defaultCfg.Spec.EventConfig == nil {
+		// The publisher (and therefore auth) is off. Reconcile the auth manifest
+		// with authEnabled=false so that any resources left over from a
+		// previously-enabled EventConfig - e.g. the CR had EventConfig removed
+		// entirely - are torn down instead of orphaned.
+		if err = r.syncEventAuth(ctx, &data, false); err != nil {
+			return err
+		}
 		return nil
 	}
 

--- a/controllers/ptpoperatorconfig_controller.go
+++ b/controllers/ptpoperatorconfig_controller.go
@@ -239,6 +239,12 @@ func (r *PtpOperatorConfigReconciler) syncLinuxptpDaemon(ctx context.Context, de
 	data.Data["NodeName"] = os.Getenv("NODE_NAME")
 	data.Data["StorageType"] = DefaultStorageType
 	data.Data["EventApiVersion"] = DefaultApiVersion
+	// EnableEventAuth turns on mTLS + OAuth on the event publisher APIs. It
+	// depends on the OpenShift Service CA operator to mint serving certificates
+	// and inject the CA bundle, so it is opt-in (default off) to keep the
+	// operator usable on clusters without Service CA. The OpenShift deployment
+	// sets ENABLE_EVENT_AUTH=true.
+	data.Data["EnableEventAuth"] = os.Getenv("ENABLE_EVENT_AUTH") == "true"
 	// configure EventConfig
 	if defaultCfg.Spec.EventConfig == nil {
 		data.Data["EnableEventPublisher"] = false
@@ -306,6 +312,22 @@ func (r *PtpOperatorConfigReconciler) syncLinuxptpDaemon(ctx context.Context, de
 
 	if defaultCfg.Spec.EventConfig == nil {
 		return nil
+	}
+
+	// When the event publisher is enabled, render and apply the authentication
+	// manifest (mTLS serving cert service, injected CA bundle, auth-config
+	// ConfigMap and the TokenReview RBAC). These are cluster/namespace scoped
+	// and rendered once, independent of the per-node event services below.
+	if defaultCfg.Spec.EventConfig.EnableEventPublisher && data.Data["EnableEventAuth"] == true {
+		authObjs, aErr := render.RenderTemplate(filepath.Join(names.ManifestDir, "linuxptp/auth-config.yaml"), &data)
+		if aErr != nil {
+			return fmt.Errorf("failed to render event auth-config manifest: %v", aErr)
+		}
+		for _, obj := range authObjs {
+			if err = apply.ApplyObject(ctx, r.Client, obj); err != nil {
+				return fmt.Errorf("failed to apply auth-config object %v with err: %v", obj, err)
+			}
+		}
 	}
 
 	if defaultCfg.Spec.EventConfig.EnableEventPublisher {
@@ -451,12 +473,29 @@ func (r *PtpOperatorConfigReconciler) setTLSTemplateData(data *render.RenderData
 		ianaCiphers := libgocrypto.OpenSSLToIANACipherSuites(r.TLSProfileSpec.Ciphers)
 		data.Data["TLSMinVersion"] = string(r.TLSProfileSpec.MinTLSVersion)
 		data.Data["TLSCipherSuites"] = strings.Join(ianaCiphers, ",")
+		// Same profile in JSON-array form for the cloud-event-proxy auth-config.
+		data.Data["TLSCipherSuitesJSON"] = ciphersToJSONArray(ianaCiphers)
 		// TODO: pass TLSGroups to kube-rbac-proxy once it supports --tls-curve-preferences
 		// (upstream: https://github.com/kube-rbac-proxy/kube-rbac-proxy/issues/414)
 	} else {
 		data.Data["TLSMinVersion"] = ""
 		data.Data["TLSCipherSuites"] = legacyCipherSuites
+		data.Data["TLSCipherSuitesJSON"] = ciphersToJSONArray(strings.Split(legacyCipherSuites, ","))
 	}
+}
+
+// ciphersToJSONArray renders IANA cipher-suite names as a JSON array literal for
+// embedding in the cloud-event-proxy auth-config template.
+func ciphersToJSONArray(ciphers []string) string {
+	quoted := make([]string, 0, len(ciphers))
+	for _, c := range ciphers {
+		c = strings.TrimSpace(c)
+		if c == "" {
+			continue
+		}
+		quoted = append(quoted, fmt.Sprintf("%q", c))
+	}
+	return "[" + strings.Join(quoted, ", ") + "]"
 }
 
 func (r *PtpOperatorConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/controllers/ptpoperatorconfig_controller.go
+++ b/controllers/ptpoperatorconfig_controller.go
@@ -314,20 +314,9 @@ func (r *PtpOperatorConfigReconciler) syncLinuxptpDaemon(ctx context.Context, de
 		return nil
 	}
 
-	// When the event publisher is enabled, render and apply the authentication
-	// manifest (mTLS serving cert service, injected CA bundle, auth-config
-	// ConfigMap and the TokenReview RBAC). These are cluster/namespace scoped
-	// and rendered once, independent of the per-node event services below.
-	if defaultCfg.Spec.EventConfig.EnableEventPublisher && data.Data["EnableEventAuth"] == true {
-		authObjs, aErr := render.RenderTemplate(filepath.Join(names.ManifestDir, "linuxptp/auth-config.yaml"), &data)
-		if aErr != nil {
-			return fmt.Errorf("failed to render event auth-config manifest: %v", aErr)
-		}
-		for _, obj := range authObjs {
-			if err = apply.ApplyObject(ctx, r.Client, obj); err != nil {
-				return fmt.Errorf("failed to apply auth-config object %v with err: %v", obj, err)
-			}
-		}
+	authEnabled := defaultCfg.Spec.EventConfig.EnableEventPublisher && data.Data["EnableEventAuth"] == true
+	if err = r.syncEventAuth(ctx, &data, authEnabled); err != nil {
+		return err
 	}
 
 	if defaultCfg.Spec.EventConfig.EnableEventPublisher {
@@ -345,6 +334,35 @@ func (r *PtpOperatorConfigReconciler) syncLinuxptpDaemon(ctx context.Context, de
 		}
 	}
 
+	return nil
+}
+
+// syncEventAuth reconciles the event-publisher authentication manifest (mTLS
+// serving-cert Service, injected CA bundle, auth-config ConfigMap and the
+// TokenReview ClusterRoleBinding). It renders the manifest unconditionally so
+// that when authentication is disabled - either the publisher is off or auth
+// was turned off - any resources left over from a previously-enabled state are
+// torn down. Otherwise the cluster-scoped ClusterRoleBinding and the
+// serving-cert Service would be orphaned after a user turns authentication off.
+func (r *PtpOperatorConfigReconciler) syncEventAuth(ctx context.Context, data *render.RenderData, enabled bool) error {
+	authObjs, err := render.RenderTemplate(filepath.Join(names.ManifestDir, "linuxptp/auth-config.yaml"), data)
+	if err != nil {
+		return fmt.Errorf("failed to render event auth-config manifest: %v", err)
+	}
+	if enabled {
+		for _, obj := range authObjs {
+			if err = apply.ApplyObject(ctx, r.Client, obj); err != nil {
+				return fmt.Errorf("failed to apply auth-config object %v with err: %v", obj, err)
+			}
+		}
+		return nil
+	}
+	for _, obj := range authObjs {
+		if err = r.Delete(ctx, obj); err != nil && !errors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete auth-config object %s/%s with err: %v",
+				obj.GetKind(), obj.GetName(), err)
+		}
+	}
 	return nil
 }
 

--- a/controllers/tls_profile_test.go
+++ b/controllers/tls_profile_test.go
@@ -71,6 +71,7 @@ func makeTestRenderData() *render.RenderData {
 	data.Data["SideCar"] = "test-sidecar"
 	data.Data["NodeName"] = "test-node"
 	data.Data["EnableEventPublisher"] = false
+	data.Data["EnableEventAuth"] = false
 	data.Data["EnabledPlugins"] = "e810"
 	data.Data["StorageType"] = "emptyDir"
 	data.Data["EventApiVersion"] = "2.0"

--- a/manifests/stable/ptp-operator.clusterserviceversion.yaml
+++ b/manifests/stable/ptp-operator.clusterserviceversion.yaml
@@ -427,7 +427,7 @@ spec:
                   value: quay.io/openshift/origin-cloud-event-proxy:5.0
                 - name: EVENT_PROXY_IMAGE
                 - name: ENABLE_EVENT_AUTH
-                  value: "true"
+                  value: "false"
                 - name: OPERATOR_NAMESPACE
                   valueFrom:
                     fieldRef:

--- a/manifests/stable/ptp-operator.clusterserviceversion.yaml
+++ b/manifests/stable/ptp-operator.clusterserviceversion.yaml
@@ -308,6 +308,26 @@ spec:
           verbs:
           - '*'
         - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resourceNames:
+          - system:auth-delegator
+          resources:
+          - clusterroles
+          verbs:
+          - bind
+        - apiGroups:
           - config.openshift.io
           resources:
           - apiservers

--- a/manifests/stable/ptp-operator.clusterserviceversion.yaml
+++ b/manifests/stable/ptp-operator.clusterserviceversion.yaml
@@ -406,6 +406,8 @@ spec:
                 - name: SIDECAR_EVENT_IMAGE
                   value: quay.io/openshift/origin-cloud-event-proxy:5.0
                 - name: EVENT_PROXY_IMAGE
+                - name: ENABLE_EVENT_AUTH
+                  value: "true"
                 - name: OPERATOR_NAMESPACE
                   valueFrom:
                     fieldRef:

--- a/manifests/stable/ptp-operator.clusterserviceversion.yaml
+++ b/manifests/stable/ptp-operator.clusterserviceversion.yaml
@@ -313,12 +313,19 @@ spec:
           - clusterrolebindings
           verbs:
           - create
-          - delete
-          - get
           - list
-          - patch
-          - update
           - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resourceNames:
+          - linuxptp-daemon-auth-delegator
+          resources:
+          - clusterrolebindings
+          verbs:
+          - get
+          - update
+          - patch
+          - delete
         - apiGroups:
           - rbac.authorization.k8s.io
           resourceNames:

--- a/scripts/run-on-vm.sh
+++ b/scripts/run-on-vm.sh
@@ -281,6 +281,28 @@ run_ptp_tools_parallel_make_step_rows() {
   run_step_rows_end
 }
 
+# Podman image builds and exports must share one storage database. Running
+# multiple build-and-save targets concurrently can leave a freshly committed
+# image unavailable to `podman save` ("image not known"). Keep the image
+# artifact phase deterministic on CI runners.
+run_ptp_tools_sequential_make_step_rows() {
+  local row_prefix="$1"
+  local make_prefix="$2"
+  shift 2
+  local -a rows=()
+  local _img
+  for _img in "$@"; do
+    rows+=("${row_prefix} ${_img}")
+  done
+  run_step_rows_begin "${rows[@]}"
+  for _img in "$@"; do
+    run_quiet_with_log_dump_on_failure "${make_prefix}-${_img}" \
+      make -s "${make_prefix}-${_img}"
+    run_step_row_done "${row_prefix} ${_img}"
+  done
+  run_step_rows_end
+}
+
 step "Switching to script directory"
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
@@ -303,7 +325,7 @@ if [[ "$RUN_PHASE" == "images" ]]; then
     read_ptp_tool_images
     step "Building and saving ptp-tools images"
     cd "${PTP_TOOLS_DIR}"
-    run_ptp_tools_parallel_make_step_rows BUILD podman-build-and-save build-save "${_ptp_tool_images[@]}"
+    run_ptp_tools_sequential_make_step_rows BUILD podman-build-and-save "${_ptp_tool_images[@]}"
     cd -
 
     tar cf /tmp/ptp-images.tar -C /tmp/ptp-images .

--- a/vendor/k8s.io/apimachinery/pkg/util/rand/rand.go
+++ b/vendor/k8s.io/apimachinery/pkg/util/rand/rand.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package rand provides utilities related to randomization.
+package rand
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+)
+
+var rng = struct {
+	sync.Mutex
+	rand *rand.Rand
+}{
+	rand: rand.New(rand.NewSource(time.Now().UnixNano())),
+}
+
+// Int returns a non-negative pseudo-random int.
+func Int() int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Int()
+}
+
+// Intn generates an integer in range [0,max).
+// By design this should panic if input is invalid, <= 0.
+func Intn(max int) int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Intn(max)
+}
+
+// IntnRange generates an integer in range [min,max).
+// By design this should panic if input is invalid, <= 0.
+func IntnRange(min, max int) int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Intn(max-min) + min
+}
+
+// IntnRange generates an int64 integer in range [min,max).
+// By design this should panic if input is invalid, <= 0.
+func Int63nRange(min, max int64) int64 {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Int63n(max-min) + min
+}
+
+// Seed seeds the rng with the provided seed.
+func Seed(seed int64) {
+	rng.Lock()
+	defer rng.Unlock()
+
+	rng.rand = rand.New(rand.NewSource(seed))
+}
+
+// Perm returns, as a slice of n ints, a pseudo-random permutation of the integers [0,n)
+// from the default Source.
+func Perm(n int) []int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Perm(n)
+}
+
+const (
+	// We omit vowels from the set of available characters to reduce the chances
+	// of "bad words" being formed.
+	alphanums = "bcdfghjklmnpqrstvwxz2456789"
+	// No. of bits required to index into alphanums string.
+	alphanumsIdxBits = 5
+	// Mask used to extract last alphanumsIdxBits of an int.
+	alphanumsIdxMask = 1<<alphanumsIdxBits - 1
+	// No. of random letters we can extract from a single int63.
+	maxAlphanumsPerInt = 63 / alphanumsIdxBits
+)
+
+// String generates a random alphanumeric string, without vowels, which is n
+// characters long.  This will panic if n is less than zero.
+// How the random string is created:
+// - we generate random int63's
+// - from each int63, we are extracting multiple random letters by bit-shifting and masking
+// - if some index is out of range of alphanums we neglect it (unlikely to happen multiple times in a row)
+func String(n int) string {
+	b := make([]byte, n)
+	rng.Lock()
+	defer rng.Unlock()
+
+	randomInt63 := rng.rand.Int63()
+	remaining := maxAlphanumsPerInt
+	for i := 0; i < n; {
+		if remaining == 0 {
+			randomInt63, remaining = rng.rand.Int63(), maxAlphanumsPerInt
+		}
+		if idx := int(randomInt63 & alphanumsIdxMask); idx < len(alphanums) {
+			b[i] = alphanums[idx]
+			i++
+		}
+		randomInt63 >>= alphanumsIdxBits
+		remaining--
+	}
+	return string(b)
+}
+
+// SafeEncodeString encodes s using the same characters as rand.String. This reduces the chances of bad words and
+// ensures that strings generated from hash functions appear consistent throughout the API.
+func SafeEncodeString(s string) string {
+	r := make([]byte, len(s))
+	for i, b := range []rune(s) {
+		r[i] = alphanums[(int(b) % len(alphanums))]
+	}
+	return string(r)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -549,6 +549,7 @@ k8s.io/apimachinery/pkg/util/naming
 k8s.io/apimachinery/pkg/util/net
 k8s.io/apimachinery/pkg/util/portforward
 k8s.io/apimachinery/pkg/util/proxy
+k8s.io/apimachinery/pkg/util/rand
 k8s.io/apimachinery/pkg/util/remotecommand
 k8s.io/apimachinery/pkg/util/runtime
 k8s.io/apimachinery/pkg/util/sets
@@ -957,6 +958,8 @@ sigs.k8s.io/controller-runtime/pkg/certwatcher/metrics
 sigs.k8s.io/controller-runtime/pkg/client
 sigs.k8s.io/controller-runtime/pkg/client/apiutil
 sigs.k8s.io/controller-runtime/pkg/client/config
+sigs.k8s.io/controller-runtime/pkg/client/fake
+sigs.k8s.io/controller-runtime/pkg/client/interceptor
 sigs.k8s.io/controller-runtime/pkg/cluster
 sigs.k8s.io/controller-runtime/pkg/config
 sigs.k8s.io/controller-runtime/pkg/controller
@@ -972,6 +975,7 @@ sigs.k8s.io/controller-runtime/pkg/internal/field/selector
 sigs.k8s.io/controller-runtime/pkg/internal/httpserver
 sigs.k8s.io/controller-runtime/pkg/internal/log
 sigs.k8s.io/controller-runtime/pkg/internal/metrics
+sigs.k8s.io/controller-runtime/pkg/internal/objectutil
 sigs.k8s.io/controller-runtime/pkg/internal/recorder
 sigs.k8s.io/controller-runtime/pkg/internal/source
 sigs.k8s.io/controller-runtime/pkg/internal/syncs

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/fake/client.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/fake/client.go
@@ -1,0 +1,1720 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	/*
+	  Stick with gopkg.in/evanphx/json-patch.v4 here to match
+	  upstream Kubernetes code and avoid breaking changes introduced in v5.
+	  - Kubernetes itself remains on json-patch v4 to avoid compatibility issues
+	    tied to v5’s stricter RFC6902 compliance.
+	  - The fake client code is adapted from client-go’s testing fixture, which also
+	    relies on json-patch v4.
+	  See:
+	    https://github.com/kubernetes/kubernetes/pull/91622 (discussion of why K8s
+	    stays on v4)
+	    https://github.com/kubernetes/kubernetes/pull/120326 (v5.6.0+incompatible
+	    missing a critical fix)
+	*/
+
+	jsonpatch "gopkg.in/evanphx/json-patch.v4"
+	appsv1 "k8s.io/api/apps/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/validation"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/json"
+	"k8s.io/apimachinery/pkg/util/managedfields"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"k8s.io/apimachinery/pkg/watch"
+	clientgoapplyconfigurations "k8s.io/client-go/applyconfigurations"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/testing"
+	"k8s.io/utils/ptr"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/internal/field/selector"
+	"sigs.k8s.io/controller-runtime/pkg/internal/objectutil"
+)
+
+type fakeClient struct {
+	// trackerWriteLock must be acquired before writing to
+	// the tracker or performing reads that affect a following
+	// write.
+	trackerWriteLock sync.Mutex
+	tracker          versionedTracker
+
+	schemeLock sync.RWMutex
+	scheme     *runtime.Scheme
+
+	restMapper            meta.RESTMapper
+	withStatusSubresource sets.Set[schema.GroupVersionKind]
+
+	// indexes maps each GroupVersionKind (GVK) to the indexes registered for that GVK.
+	// The inner map maps from index name to IndexerFunc.
+	indexes map[schema.GroupVersionKind]map[string]client.IndexerFunc
+	// indexesLock must be held when accessing indexes.
+	indexesLock sync.RWMutex
+
+	returnManagedFields bool
+}
+
+var _ client.WithWatch = &fakeClient{}
+
+const (
+	maxNameLength          = 63
+	randomLength           = 5
+	maxGeneratedNameLength = maxNameLength - randomLength
+
+	subResourceScale = "scale"
+)
+
+// NewFakeClient creates a new fake client for testing.
+// You can choose to initialize it with a slice of runtime.Object.
+func NewFakeClient(initObjs ...runtime.Object) client.WithWatch {
+	return NewClientBuilder().WithRuntimeObjects(initObjs...).Build()
+}
+
+// NewClientBuilder returns a new builder to create a fake client.
+func NewClientBuilder() *ClientBuilder {
+	return &ClientBuilder{}
+}
+
+// ClientBuilder builds a fake client.
+type ClientBuilder struct {
+	scheme                *runtime.Scheme
+	restMapper            meta.RESTMapper
+	initObject            []client.Object
+	initLists             []client.ObjectList
+	initRuntimeObjects    []runtime.Object
+	withStatusSubresource []client.Object
+	objectTracker         testing.ObjectTracker
+	interceptorFuncs      *interceptor.Funcs
+	typeConverters        []managedfields.TypeConverter
+	returnManagedFields   bool
+	isBuilt               bool
+
+	// indexes maps each GroupVersionKind (GVK) to the indexes registered for that GVK.
+	// The inner map maps from index name to IndexerFunc.
+	indexes map[schema.GroupVersionKind]map[string]client.IndexerFunc
+}
+
+// WithScheme sets this builder's internal scheme.
+// If not set, defaults to client-go's global scheme.Scheme.
+func (f *ClientBuilder) WithScheme(scheme *runtime.Scheme) *ClientBuilder {
+	f.scheme = scheme
+	return f
+}
+
+// WithRESTMapper sets this builder's restMapper.
+// The restMapper is directly set as mapper in the Client. This can be used for example
+// with a meta.DefaultRESTMapper to provide a static rest mapping.
+// If not set, defaults to an empty meta.DefaultRESTMapper.
+func (f *ClientBuilder) WithRESTMapper(restMapper meta.RESTMapper) *ClientBuilder {
+	f.restMapper = restMapper
+	return f
+}
+
+// WithObjects can be optionally used to initialize this fake client with client.Object(s).
+func (f *ClientBuilder) WithObjects(initObjs ...client.Object) *ClientBuilder {
+	f.initObject = append(f.initObject, initObjs...)
+	return f
+}
+
+// WithLists can be optionally used to initialize this fake client with client.ObjectList(s).
+func (f *ClientBuilder) WithLists(initLists ...client.ObjectList) *ClientBuilder {
+	f.initLists = append(f.initLists, initLists...)
+	return f
+}
+
+// WithRuntimeObjects can be optionally used to initialize this fake client with runtime.Object(s).
+func (f *ClientBuilder) WithRuntimeObjects(initRuntimeObjs ...runtime.Object) *ClientBuilder {
+	f.initRuntimeObjects = append(f.initRuntimeObjects, initRuntimeObjs...)
+	return f
+}
+
+// WithObjectTracker can be optionally used to initialize this fake client with testing.ObjectTracker.
+// Setting this is incompatible with setting WithTypeConverters, as they are a setting on the
+// tracker.
+func (f *ClientBuilder) WithObjectTracker(ot testing.ObjectTracker) *ClientBuilder {
+	f.objectTracker = ot
+	return f
+}
+
+// WithIndex can be optionally used to register an index with name `field` and indexer `extractValue`
+// for API objects of the same GroupVersionKind (GVK) as `obj` in the fake client.
+// It can be invoked multiple times, both with objects of the same GVK or different ones.
+// Invoking WithIndex twice with the same `field` and GVK (via `obj`) arguments will panic.
+// WithIndex retrieves the GVK of `obj` using the scheme registered via WithScheme if
+// WithScheme was previously invoked, the default scheme otherwise.
+func (f *ClientBuilder) WithIndex(obj runtime.Object, field string, extractValue client.IndexerFunc) *ClientBuilder {
+	objScheme := f.scheme
+	if objScheme == nil {
+		objScheme = scheme.Scheme
+	}
+
+	gvk, err := apiutil.GVKForObject(obj, objScheme)
+	if err != nil {
+		panic(err)
+	}
+
+	// If this is the first index being registered, we initialize the map storing all the indexes.
+	if f.indexes == nil {
+		f.indexes = make(map[schema.GroupVersionKind]map[string]client.IndexerFunc)
+	}
+
+	// If this is the first index being registered for the GroupVersionKind of `obj`, we initialize
+	// the map storing the indexes for that GroupVersionKind.
+	if f.indexes[gvk] == nil {
+		f.indexes[gvk] = make(map[string]client.IndexerFunc)
+	}
+
+	if _, fieldAlreadyIndexed := f.indexes[gvk][field]; fieldAlreadyIndexed {
+		panic(fmt.Errorf("indexer conflict: field %s for GroupVersionKind %v is already indexed",
+			field, gvk))
+	}
+
+	f.indexes[gvk][field] = extractValue
+
+	return f
+}
+
+// WithStatusSubresource configures the passed object with a status subresource, which means
+// calls to Update and Patch will not alter its status.
+func (f *ClientBuilder) WithStatusSubresource(o ...client.Object) *ClientBuilder {
+	f.withStatusSubresource = append(f.withStatusSubresource, o...)
+	return f
+}
+
+// WithInterceptorFuncs configures the client methods to be intercepted using the provided interceptor.Funcs.
+func (f *ClientBuilder) WithInterceptorFuncs(interceptorFuncs interceptor.Funcs) *ClientBuilder {
+	f.interceptorFuncs = &interceptorFuncs
+	return f
+}
+
+// WithTypeConverters sets the type converters for the fake client. The list is ordered and the first
+// non-erroring converter is used. A type converter must be provided for all types the client is used
+// for, otherwise it will error.
+//
+// This setting is incompatible with WithObjectTracker, as the type converters are a setting on the tracker.
+//
+// If unset, this defaults to:
+// * clientgoapplyconfigurations.NewTypeConverter(scheme.Scheme),
+// * managedfields.NewDeducedTypeConverter(),
+//
+// Be aware that the behavior of the `NewDeducedTypeConverter` might not match the behavior of the
+// Kubernetes APIServer, it is recommended to provide a type converter for your types. TypeConverters
+// are generated along with ApplyConfigurations.
+func (f *ClientBuilder) WithTypeConverters(typeConverters ...managedfields.TypeConverter) *ClientBuilder {
+	f.typeConverters = append(f.typeConverters, typeConverters...)
+	return f
+}
+
+// WithReturnManagedFields configures the fake client to return managedFields
+// on objects.
+func (f *ClientBuilder) WithReturnManagedFields() *ClientBuilder {
+	f.returnManagedFields = true
+	return f
+}
+
+// Build builds and returns a new fake client.
+func (f *ClientBuilder) Build() client.WithWatch {
+	if f.isBuilt {
+		panic("Build() must not be called multiple times when creating a ClientBuilder")
+	}
+	if f.scheme == nil {
+		f.scheme = scheme.Scheme
+	}
+	if f.restMapper == nil {
+		f.restMapper = meta.NewDefaultRESTMapper([]schema.GroupVersion{})
+	}
+
+	withStatusSubResource := sets.New(inTreeResourcesWithStatus()...)
+	for _, o := range f.withStatusSubresource {
+		gvk, err := apiutil.GVKForObject(o, f.scheme)
+		if err != nil {
+			panic(fmt.Errorf("failed to get gvk for object %T: %w", withStatusSubResource, err))
+		}
+		withStatusSubResource.Insert(gvk)
+	}
+
+	if f.objectTracker != nil && len(f.typeConverters) > 0 {
+		panic(errors.New("WithObjectTracker and WithTypeConverters are incompatible"))
+	}
+
+	var usesFieldManagedObjectTracker bool
+	if f.objectTracker == nil {
+		if len(f.typeConverters) == 0 {
+			// Use corresponding scheme to ensure the converter error
+			// for types it can't handle.
+			clientGoScheme := runtime.NewScheme()
+			if err := scheme.AddToScheme(clientGoScheme); err != nil {
+				panic(fmt.Sprintf("failed to construct client-go scheme: %v", err))
+			}
+			f.typeConverters = []managedfields.TypeConverter{
+				clientgoapplyconfigurations.NewTypeConverter(clientGoScheme),
+				managedfields.NewDeducedTypeConverter(),
+			}
+		}
+		f.objectTracker = testing.NewFieldManagedObjectTracker(
+			f.scheme,
+			serializer.NewCodecFactory(f.scheme).UniversalDecoder(),
+			multiTypeConverter{upstream: f.typeConverters},
+		)
+		usesFieldManagedObjectTracker = true
+	}
+	tracker := versionedTracker{
+		upstream:                      f.objectTracker,
+		scheme:                        f.scheme,
+		withStatusSubresource:         withStatusSubResource,
+		usesFieldManagedObjectTracker: usesFieldManagedObjectTracker,
+	}
+
+	for _, obj := range f.initObject {
+		if err := tracker.Add(obj); err != nil {
+			panic(fmt.Errorf("failed to add object %v to fake client: %w", obj, err))
+		}
+	}
+	for _, obj := range f.initLists {
+		if err := tracker.Add(obj); err != nil {
+			panic(fmt.Errorf("failed to add list %v to fake client: %w", obj, err))
+		}
+	}
+	for _, obj := range f.initRuntimeObjects {
+		if err := tracker.Add(obj); err != nil {
+			panic(fmt.Errorf("failed to add runtime object %v to fake client: %w", obj, err))
+		}
+	}
+
+	var result client.WithWatch = &fakeClient{
+		tracker:               tracker,
+		scheme:                f.scheme,
+		restMapper:            f.restMapper,
+		indexes:               f.indexes,
+		withStatusSubresource: withStatusSubResource,
+		returnManagedFields:   f.returnManagedFields,
+	}
+
+	if f.interceptorFuncs != nil {
+		result = interceptor.NewClient(result, *f.interceptorFuncs)
+	}
+
+	f.isBuilt = true
+	return result
+}
+
+const trackerAddResourceVersion = "999"
+
+// convertFromUnstructuredIfNecessary will convert runtime.Unstructured for a GVK that is recognized
+// by the schema into the whatever the schema produces with New() for said GVK.
+// This is required because the tracker unconditionally saves on manipulations, but its List() implementation
+// tries to assign whatever it finds into a ListType it gets from schema.New() - Thus we have to ensure
+// we save as the very same type, otherwise subsequent List requests will fail.
+func convertFromUnstructuredIfNecessary(s *runtime.Scheme, o runtime.Object) (runtime.Object, error) {
+	u, isUnstructured := o.(runtime.Unstructured)
+	if !isUnstructured {
+		return o, nil
+	}
+	gvk := o.GetObjectKind().GroupVersionKind()
+	if !s.Recognizes(gvk) {
+		return o, nil
+	}
+
+	typed, err := s.New(gvk)
+	if err != nil {
+		return nil, fmt.Errorf("scheme recognizes %s but failed to produce an object for it: %w", gvk, err)
+	}
+	if _, isTypedUnstructured := typed.(runtime.Unstructured); isTypedUnstructured {
+		return o, nil
+	}
+
+	unstructuredSerialized, err := json.Marshal(u)
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize %T: %w", unstructuredSerialized, err)
+	}
+	if err := json.Unmarshal(unstructuredSerialized, typed); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal the content of %T into %T: %w", u, typed, err)
+	}
+
+	return typed, nil
+}
+
+func (c *fakeClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if err := c.addToSchemeIfUnknownAndUnstructuredOrPartial(obj); err != nil {
+		return err
+	}
+
+	c.schemeLock.RLock()
+	defer c.schemeLock.RUnlock()
+	gvr, err := getGVRFromObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	gvk, err := apiutil.GVKForObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	o, err := c.tracker.Get(gvr, key.Namespace, key.Name)
+	if err != nil {
+		return err
+	}
+
+	ta, err := meta.TypeAccessor(o)
+	if err != nil {
+		return err
+	}
+
+	// If the final object is unstructuctured, the json
+	// representation must contain GVK or the apimachinery
+	// json serializer will error out.
+	ta.SetAPIVersion(gvk.GroupVersion().String())
+	ta.SetKind(gvk.Kind)
+
+	j, err := json.Marshal(o)
+	if err != nil {
+		return err
+	}
+	zero(obj)
+	if err := json.Unmarshal(j, obj); err != nil {
+		return err
+	}
+
+	if !c.returnManagedFields {
+		obj.SetManagedFields(nil)
+	}
+
+	return ensureTypeMeta(obj, gvk)
+}
+
+func (c *fakeClient) Watch(ctx context.Context, list client.ObjectList, opts ...client.ListOption) (watch.Interface, error) {
+	if err := c.addToSchemeIfUnknownAndUnstructuredOrPartial(list); err != nil {
+		return nil, err
+	}
+
+	c.schemeLock.RLock()
+	defer c.schemeLock.RUnlock()
+
+	gvk, err := apiutil.GVKForObject(list, c.scheme)
+	if err != nil {
+		return nil, err
+	}
+
+	gvk.Kind = strings.TrimSuffix(gvk.Kind, "List")
+
+	listOpts := client.ListOptions{}
+	listOpts.ApplyOptions(opts)
+
+	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+	return c.tracker.Watch(gvr, listOpts.Namespace)
+}
+
+func (c *fakeClient) List(ctx context.Context, obj client.ObjectList, opts ...client.ListOption) error {
+	if err := c.addToSchemeIfUnknownAndUnstructuredOrPartial(obj); err != nil {
+		return err
+	}
+
+	c.schemeLock.RLock()
+	defer c.schemeLock.RUnlock()
+	gvk, err := apiutil.GVKForObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+
+	originalGVK := gvk
+	gvk.Kind = strings.TrimSuffix(gvk.Kind, "List")
+	listGVK := gvk
+	listGVK.Kind += "List"
+
+	if _, isUnstructuredList := obj.(runtime.Unstructured); isUnstructuredList && !c.scheme.Recognizes(listGVK) {
+		// We need to register the ListKind with UnstructuredList:
+		// https://github.com/kubernetes/kubernetes/blob/7b2776b89fb1be28d4e9203bdeec079be903c103/staging/src/k8s.io/client-go/dynamic/fake/simple.go#L44-L51
+		c.schemeLock.RUnlock()
+		c.schemeLock.Lock()
+		c.scheme.AddKnownTypeWithName(gvk.GroupVersion().WithKind(gvk.Kind+"List"), &unstructured.UnstructuredList{})
+		c.schemeLock.Unlock()
+		c.schemeLock.RLock()
+	}
+
+	listOpts := client.ListOptions{}
+	listOpts.ApplyOptions(opts)
+
+	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+	o, err := c.tracker.List(gvr, gvk, listOpts.Namespace)
+	if err != nil {
+		return err
+	}
+
+	j, err := json.Marshal(o)
+	if err != nil {
+		return err
+	}
+	zero(obj)
+	if err := ensureTypeMeta(obj, originalGVK); err != nil {
+		return err
+	}
+	objCopy := obj.DeepCopyObject().(client.ObjectList)
+	if err := json.Unmarshal(j, objCopy); err != nil {
+		return err
+	}
+
+	objs, err := meta.ExtractList(objCopy)
+	if err != nil {
+		return err
+	}
+
+	for _, o := range objs {
+		if err := ensureTypeMeta(o, gvk); err != nil {
+			return err
+		}
+
+		if !c.returnManagedFields {
+			o.(metav1.Object).SetManagedFields(nil)
+		}
+	}
+
+	if listOpts.LabelSelector == nil && listOpts.FieldSelector == nil {
+		return meta.SetList(obj, objs)
+	}
+
+	// If we're here, either a label or field selector are specified (or both), so before we return
+	// the list we must filter it. If both selectors are set, they are ANDed.
+	filteredList, err := c.filterList(objs, gvk, listOpts.LabelSelector, listOpts.FieldSelector)
+	if err != nil {
+		return err
+	}
+
+	return meta.SetList(obj, filteredList)
+}
+
+func (c *fakeClient) filterList(list []runtime.Object, gvk schema.GroupVersionKind, ls labels.Selector, fs fields.Selector) ([]runtime.Object, error) {
+	// Filter the objects with the label selector
+	filteredList := list
+	if ls != nil {
+		objsFilteredByLabel, err := objectutil.FilterWithLabels(list, ls)
+		if err != nil {
+			return nil, err
+		}
+		filteredList = objsFilteredByLabel
+	}
+
+	// Filter the result of the previous pass with the field selector
+	if fs != nil {
+		objsFilteredByField, err := c.filterWithFields(filteredList, gvk, fs)
+		if err != nil {
+			return nil, err
+		}
+		filteredList = objsFilteredByField
+	}
+
+	return filteredList, nil
+}
+
+func (c *fakeClient) filterWithFields(list []runtime.Object, gvk schema.GroupVersionKind, fs fields.Selector) ([]runtime.Object, error) {
+	requiresExact := selector.RequiresExactMatch(fs)
+	if !requiresExact {
+		return nil, fmt.Errorf(`field selector %s is not in one of the two supported forms "key==val" or "key=val"`, fs)
+	}
+
+	c.indexesLock.RLock()
+	defer c.indexesLock.RUnlock()
+	// Field selection is mimicked via indexes, so there's no sane answer this function can give
+	// if there are no indexes registered for the GroupVersionKind of the objects in the list.
+	indexes := c.indexes[gvk]
+	for _, req := range fs.Requirements() {
+		if len(indexes) == 0 || indexes[req.Field] == nil {
+			return nil, fmt.Errorf("List on GroupVersionKind %v specifies selector on field %s, but no "+
+				"index with name %s has been registered for GroupVersionKind %v", gvk, req.Field, req.Field, gvk)
+		}
+	}
+
+	filteredList := make([]runtime.Object, 0, len(list))
+	for _, obj := range list {
+		matches := true
+		for _, req := range fs.Requirements() {
+			indexExtractor := indexes[req.Field]
+			if !c.objMatchesFieldSelector(obj, indexExtractor, req.Value) {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			filteredList = append(filteredList, obj)
+		}
+	}
+	return filteredList, nil
+}
+
+func (c *fakeClient) objMatchesFieldSelector(o runtime.Object, extractIndex client.IndexerFunc, val string) bool {
+	obj, isClientObject := o.(client.Object)
+	if !isClientObject {
+		panic(fmt.Errorf("expected object %v to be of type client.Object, but it's not", o))
+	}
+
+	return slices.Contains(extractIndex(obj), val)
+}
+
+func (c *fakeClient) Scheme() *runtime.Scheme {
+	return c.scheme
+}
+
+func (c *fakeClient) RESTMapper() meta.RESTMapper {
+	return c.restMapper
+}
+
+// GroupVersionKindFor returns the GroupVersionKind for the given object.
+func (c *fakeClient) GroupVersionKindFor(obj runtime.Object) (schema.GroupVersionKind, error) {
+	return apiutil.GVKForObject(obj, c.scheme)
+}
+
+// IsObjectNamespaced returns true if the GroupVersionKind of the object is namespaced.
+func (c *fakeClient) IsObjectNamespaced(obj runtime.Object) (bool, error) {
+	return apiutil.IsObjectNamespaced(obj, c.scheme, c.restMapper)
+}
+
+func (c *fakeClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	if err := c.addToSchemeIfUnknownAndUnstructuredOrPartial(obj); err != nil {
+		return err
+	}
+
+	c.schemeLock.RLock()
+	defer c.schemeLock.RUnlock()
+
+	createOptions := &client.CreateOptions{}
+	createOptions.ApplyOptions(opts)
+
+	if slices.Contains(createOptions.DryRun, metav1.DryRunAll) {
+		return nil
+	}
+
+	gvr, err := getGVRFromObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+
+	if accessor.GetName() == "" && accessor.GetGenerateName() != "" {
+		base := accessor.GetGenerateName()
+		if len(base) > maxGeneratedNameLength {
+			base = base[:maxGeneratedNameLength]
+		}
+		accessor.SetName(fmt.Sprintf("%s%s", base, utilrand.String(randomLength)))
+	}
+	// Ignore attempts to set deletion timestamp
+	if !accessor.GetDeletionTimestamp().IsZero() {
+		accessor.SetDeletionTimestamp(nil)
+	}
+
+	gvk, err := apiutil.GVKForObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+
+	c.trackerWriteLock.Lock()
+	defer c.trackerWriteLock.Unlock()
+
+	if err := c.tracker.Create(gvr, obj, accessor.GetNamespace(), *createOptions.AsCreateOptions()); err != nil {
+		// The managed fields tracker sets gvk even on errors
+		_ = ensureTypeMeta(obj, gvk)
+		return err
+	}
+
+	if !c.returnManagedFields {
+		obj.SetManagedFields(nil)
+	}
+
+	return ensureTypeMeta(obj, gvk)
+}
+
+func (c *fakeClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	if err := c.addToSchemeIfUnknownAndUnstructuredOrPartial(obj); err != nil {
+		return err
+	}
+
+	c.schemeLock.RLock()
+	defer c.schemeLock.RUnlock()
+
+	gvr, err := getGVRFromObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+	delOptions := client.DeleteOptions{}
+	delOptions.ApplyOptions(opts)
+
+	if slices.Contains(delOptions.DryRun, metav1.DryRunAll) {
+		return nil
+	}
+
+	c.trackerWriteLock.Lock()
+	defer c.trackerWriteLock.Unlock()
+	// Check the ResourceVersion if that Precondition was specified.
+	if delOptions.Preconditions != nil && delOptions.Preconditions.ResourceVersion != nil {
+		name := accessor.GetName()
+		dbObj, err := c.tracker.Get(gvr, accessor.GetNamespace(), name)
+		if err != nil {
+			return err
+		}
+		oldAccessor, err := meta.Accessor(dbObj)
+		if err != nil {
+			return err
+		}
+		actualRV := oldAccessor.GetResourceVersion()
+		expectRV := *delOptions.Preconditions.ResourceVersion
+		if actualRV != expectRV {
+			msg := fmt.Sprintf(
+				"the ResourceVersion in the precondition (%s) does not match the ResourceVersion in record (%s). "+
+					"The object might have been modified",
+				expectRV, actualRV)
+			return apierrors.NewConflict(gvr.GroupResource(), name, errors.New(msg))
+		}
+	}
+
+	return c.deleteObjectLocked(gvr, accessor)
+}
+
+func (c *fakeClient) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
+	if err := c.addToSchemeIfUnknownAndUnstructuredOrPartial(obj); err != nil {
+		return err
+	}
+
+	c.schemeLock.RLock()
+	defer c.schemeLock.RUnlock()
+
+	gvk, err := apiutil.GVKForObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+
+	dcOptions := client.DeleteAllOfOptions{}
+	dcOptions.ApplyOptions(opts)
+
+	if slices.Contains(dcOptions.DryRun, metav1.DryRunAll) {
+		return nil
+	}
+
+	c.trackerWriteLock.Lock()
+	defer c.trackerWriteLock.Unlock()
+
+	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+	o, err := c.tracker.List(gvr, gvk, dcOptions.Namespace)
+	if err != nil {
+		return err
+	}
+
+	objs, err := meta.ExtractList(o)
+	if err != nil {
+		return err
+	}
+	filteredObjs, err := objectutil.FilterWithLabels(objs, dcOptions.LabelSelector)
+	if err != nil {
+		return err
+	}
+	for _, o := range filteredObjs {
+		accessor, err := meta.Accessor(o)
+		if err != nil {
+			return err
+		}
+		err = c.deleteObjectLocked(gvr, accessor)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *fakeClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	return c.update(obj, false, opts...)
+}
+
+func (c *fakeClient) update(obj client.Object, isStatus bool, opts ...client.UpdateOption) error {
+	if err := c.addToSchemeIfUnknownAndUnstructuredOrPartial(obj); err != nil {
+		return err
+	}
+
+	c.schemeLock.RLock()
+	defer c.schemeLock.RUnlock()
+
+	updateOptions := &client.UpdateOptions{}
+	updateOptions.ApplyOptions(opts)
+
+	if slices.Contains(updateOptions.DryRun, metav1.DryRunAll) {
+		return nil
+	}
+
+	gvr, err := getGVRFromObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	gvk, err := apiutil.GVKForObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+
+	c.trackerWriteLock.Lock()
+	defer c.trackerWriteLock.Unlock()
+
+	// Retain managed fields
+	// We can ignore all errors here since update will fail if we encounter an error.
+	obj.SetManagedFields(nil)
+	current, _ := c.tracker.Get(gvr, accessor.GetNamespace(), accessor.GetName())
+	if currentMetaObj, ok := current.(metav1.Object); ok {
+		obj.SetManagedFields(currentMetaObj.GetManagedFields())
+	}
+
+	if err := c.tracker.update(gvr, obj, accessor.GetNamespace(), isStatus, false, *updateOptions.AsUpdateOptions()); err != nil {
+		return err
+	}
+
+	if !c.returnManagedFields {
+		obj.SetManagedFields(nil)
+	}
+
+	return ensureTypeMeta(obj, gvk)
+}
+
+func (c *fakeClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	return c.patch(obj, patch, opts...)
+}
+
+func (c *fakeClient) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...client.ApplyOption) error {
+	applyOpts := &client.ApplyOptions{}
+	applyOpts.ApplyOptions(opts)
+
+	data, err := json.Marshal(obj)
+	if err != nil {
+		return fmt.Errorf("failed to marshal apply configuration: %w", err)
+	}
+
+	u := &unstructured.Unstructured{}
+	if err := json.Unmarshal(data, u); err != nil {
+		return fmt.Errorf("failed to unmarshal apply configuration: %w", err)
+	}
+
+	applyPatch := &fakeApplyPatch{}
+
+	patchOpts := &client.PatchOptions{}
+	patchOpts.Raw = applyOpts.AsPatchOptions()
+
+	if err := c.patch(u, applyPatch, patchOpts); err != nil {
+		return err
+	}
+
+	acJSON, err := json.Marshal(u)
+	if err != nil {
+		return fmt.Errorf("failed to marshal patched object: %w", err)
+	}
+
+	// We have to zero the object in case it contained a status and there is a
+	// status subresource. If its the private `unstructuredApplyConfiguration`
+	// we can not zero all of it, as that will cause the embedded Unstructured
+	// to be nil which then causes a NPD in the json.Unmarshal below.
+	switch reflect.TypeOf(obj).String() {
+	case "*client.unstructuredApplyConfiguration":
+		zero(reflect.ValueOf(obj).Elem().FieldByName("Unstructured").Interface())
+	default:
+		zero(obj)
+	}
+	if err := json.Unmarshal(acJSON, obj); err != nil {
+		return fmt.Errorf("failed to unmarshal patched object: %w", err)
+	}
+
+	return nil
+}
+
+type fakeApplyPatch struct{}
+
+func (p *fakeApplyPatch) Type() types.PatchType {
+	return types.ApplyPatchType
+}
+
+func (p *fakeApplyPatch) Data(obj client.Object) ([]byte, error) {
+	return json.Marshal(obj)
+}
+
+func (c *fakeClient) patch(obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	if err := c.addToSchemeIfUnknownAndUnstructuredOrPartial(obj); err != nil {
+		return err
+	}
+
+	patchOptions := &client.PatchOptions{}
+	patchOptions.ApplyOptions(opts)
+
+	if errs := validation.ValidatePatchOptions(patchOptions.AsPatchOptions(), patch.Type()); len(errs) > 0 {
+		return apierrors.NewInvalid(schema.GroupKind{Group: "meta.k8s.io", Kind: "PatchOptions"}, "", errs)
+	}
+
+	c.schemeLock.RLock()
+	defer c.schemeLock.RUnlock()
+
+	if slices.Contains(patchOptions.DryRun, metav1.DryRunAll) {
+		return nil
+	}
+
+	gvr, err := getGVRFromObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	gvk, err := apiutil.GVKForObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+
+	var isApplyCreate bool
+	c.trackerWriteLock.Lock()
+	defer c.trackerWriteLock.Unlock()
+	oldObj, err := c.tracker.Get(gvr, accessor.GetNamespace(), accessor.GetName())
+	if err != nil {
+		if !apierrors.IsNotFound(err) || patch.Type() != types.ApplyPatchType {
+			return err
+		}
+		oldObj = &unstructured.Unstructured{}
+		isApplyCreate = true
+	}
+	oldAccessor, err := meta.Accessor(oldObj)
+	if err != nil {
+		return err
+	}
+
+	if patch.Type() == types.ApplyPatchType {
+		if isApplyCreate {
+			// Overwrite it unconditionally, this matches the apiserver behavior
+			// which allows to set it on create, but will then ignore it.
+			obj.SetResourceVersion("1")
+		} else {
+			// SSA deletionTimestamp updates are silently ignored
+			obj.SetDeletionTimestamp(oldAccessor.GetDeletionTimestamp())
+		}
+	}
+
+	data, err := patch.Data(obj)
+	if err != nil {
+		return err
+	}
+
+	action := testing.NewPatchActionWithOptions(
+		gvr,
+		accessor.GetNamespace(),
+		accessor.GetName(),
+		patch.Type(),
+		data,
+		*patchOptions.AsPatchOptions(),
+	)
+
+	// Apply is implemented in the tracker and calling it has side-effects
+	// such as bumping RV and updating managedFields timestamps, hence we
+	// can not dry-run it. Luckily, the only validation we use it for
+	// doesn't apply to SSA - Creating objects with non-nil deletionTimestamp
+	// through SSA is possible and updating the deletionTimestamp is valid,
+	// but has no effect.
+	if patch.Type() != types.ApplyPatchType {
+		// Apply patch without updating object.
+		// To remain in accordance with the behavior of k8s api behavior,
+		// a patch must not allow for changes to the deletionTimestamp of an object.
+		// The reaction() function applies the patch to the object and calls Update(),
+		// whereas dryPatch() replicates this behavior but skips the call to Update().
+		// This ensures that the patch may be rejected if a deletionTimestamp is modified, prior
+		// to updating the object.
+		o, err := dryPatch(action, c.tracker)
+		if err != nil {
+			return err
+		}
+		newObj, err := meta.Accessor(o)
+		if err != nil {
+			return err
+		}
+
+		// Validate that deletionTimestamp has not been changed
+		if !deletionTimestampEqual(newObj, oldAccessor) {
+			return fmt.Errorf("rejected patch, metadata.deletionTimestamp immutable")
+		}
+	}
+
+	reaction := testing.ObjectReaction(c.tracker)
+	handled, o, err := reaction(action)
+	if err != nil {
+		// The reaction calls tracker.Get after tracker.Apply to return the object,
+		// but we may have deleted it in tracker.Apply if there was no finalizer
+		// left.
+		if apierrors.IsNotFound(err) &&
+			patch.Type() == types.ApplyPatchType &&
+			oldAccessor.GetDeletionTimestamp() != nil &&
+			len(obj.GetFinalizers()) == 0 {
+			return nil
+		}
+		return err
+	}
+	if !handled {
+		panic("tracker could not handle patch method")
+	}
+
+	ta, err := meta.TypeAccessor(o)
+	if err != nil {
+		return err
+	}
+
+	ta.SetAPIVersion(gvk.GroupVersion().String())
+	ta.SetKind(gvk.Kind)
+
+	j, err := json.Marshal(o)
+	if err != nil {
+		return err
+	}
+	zero(obj)
+	if err := json.Unmarshal(j, obj); err != nil {
+		return err
+	}
+
+	if !c.returnManagedFields {
+		obj.SetManagedFields(nil)
+	}
+
+	return ensureTypeMeta(obj, gvk)
+}
+
+// Applying a patch results in a deletionTimestamp that is truncated to the nearest second.
+// Check that the diff between a new and old deletion timestamp is within a reasonable threshold
+// to be considered unchanged.
+func deletionTimestampEqual(newObj metav1.Object, obj metav1.Object) bool {
+	newTime := newObj.GetDeletionTimestamp()
+	oldTime := obj.GetDeletionTimestamp()
+
+	if newTime == nil || oldTime == nil {
+		return newTime == oldTime
+	}
+	return newTime.Time.Sub(oldTime.Time).Abs() < time.Second
+}
+
+// The behavior of applying the patch is pulled out into dryPatch(),
+// which applies the patch and returns an object, but does not Update() the object.
+// This function returns a patched runtime object that may then be validated before a call to Update() is executed.
+// This results in some code duplication, but was found to be a cleaner alternative than unmarshalling and introspecting the patch data
+// and easier than refactoring the k8s client-go method upstream.
+// Duplicate of upstream: https://github.com/kubernetes/client-go/blob/783d0d33626e59d55d52bfd7696b775851f92107/testing/fixture.go#L146-L194
+func dryPatch(action testing.PatchActionImpl, tracker testing.ObjectTracker) (runtime.Object, error) {
+	ns := action.GetNamespace()
+	gvr := action.GetResource()
+
+	obj, err := tracker.Get(gvr, ns, action.GetName())
+	if err != nil {
+		if apierrors.IsNotFound(err) && action.GetPatchType() == types.ApplyPatchType {
+			return &unstructured.Unstructured{}, nil
+		}
+		return nil, err
+	}
+
+	old, err := json.Marshal(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	// reset the object in preparation to unmarshal, since unmarshal does not guarantee that fields
+	// in obj that are removed by patch are cleared
+	value := reflect.ValueOf(obj)
+	value.Elem().Set(reflect.New(value.Type().Elem()).Elem())
+
+	switch action.GetPatchType() {
+	case types.JSONPatchType:
+		patch, err := jsonpatch.DecodePatch(action.GetPatch())
+		if err != nil {
+			return nil, err
+		}
+		modified, err := patch.Apply(old)
+		if err != nil {
+			return nil, err
+		}
+
+		if err = json.Unmarshal(modified, obj); err != nil {
+			return nil, err
+		}
+	case types.MergePatchType:
+		modified, err := jsonpatch.MergePatch(old, action.GetPatch())
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(modified, obj); err != nil {
+			return nil, err
+		}
+	case types.StrategicMergePatchType:
+		mergedByte, err := strategicpatch.StrategicMergePatch(old, action.GetPatch(), obj)
+		if err != nil {
+			return nil, err
+		}
+		if err = json.Unmarshal(mergedByte, obj); err != nil {
+			return nil, err
+		}
+	case types.ApplyCBORPatchType:
+		return nil, errors.New("apply CBOR patches are not supported in the fake client")
+	case types.ApplyPatchType:
+		return nil, errors.New("bug in controller-runtime: should not end up in dryPatch for SSA")
+	default:
+		return nil, fmt.Errorf("%s PatchType is not supported", action.GetPatchType())
+	}
+	return obj, nil
+}
+
+// copyStatusFrom copies the status from old into new
+func copyStatusFrom(old, n runtime.Object) error {
+	oldMapStringAny, err := toMapStringAny(old)
+	if err != nil {
+		return fmt.Errorf("failed to convert old to *unstructured.Unstructured: %w", err)
+	}
+	newMapStringAny, err := toMapStringAny(n)
+	if err != nil {
+		return fmt.Errorf("failed to convert new to *unststructured.Unstructured: %w", err)
+	}
+
+	newMapStringAny["status"] = oldMapStringAny["status"]
+
+	if err := fromMapStringAny(newMapStringAny, n); err != nil {
+		return fmt.Errorf("failed to convert back from map[string]any: %w", err)
+	}
+
+	return nil
+}
+
+// copyFrom copies from old into new
+func copyFrom(old, n runtime.Object) error {
+	oldMapStringAny, err := toMapStringAny(old)
+	if err != nil {
+		return fmt.Errorf("failed to convert old to *unstructured.Unstructured: %w", err)
+	}
+	if err := fromMapStringAny(oldMapStringAny, n); err != nil {
+		return fmt.Errorf("failed to convert back from map[string]any: %w", err)
+	}
+
+	return nil
+}
+
+func toMapStringAny(obj runtime.Object) (map[string]any, error) {
+	if unstructured, isUnstructured := obj.(*unstructured.Unstructured); isUnstructured {
+		return unstructured.Object, nil
+	}
+
+	serialized, err := json.Marshal(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	u := map[string]any{}
+	return u, json.Unmarshal(serialized, &u)
+}
+
+func fromMapStringAny(u map[string]any, target runtime.Object) error {
+	if targetUnstructured, isUnstructured := target.(*unstructured.Unstructured); isUnstructured {
+		targetUnstructured.Object = u
+		return nil
+	}
+
+	serialized, err := json.Marshal(u)
+	if err != nil {
+		return fmt.Errorf("failed to serialize: %w", err)
+	}
+
+	zero(target)
+	if err := json.Unmarshal(serialized, &target); err != nil {
+		return fmt.Errorf("failed to deserialize: %w", err)
+	}
+
+	return nil
+}
+
+func (c *fakeClient) Status() client.SubResourceWriter {
+	return c.SubResource("status")
+}
+
+func (c *fakeClient) SubResource(subResource string) client.SubResourceClient {
+	return &fakeSubResourceClient{client: c, subResource: subResource}
+}
+
+func (c *fakeClient) deleteObjectLocked(gvr schema.GroupVersionResource, accessor metav1.Object) error {
+	old, err := c.tracker.Get(gvr, accessor.GetNamespace(), accessor.GetName())
+	if err == nil {
+		oldAccessor, err := meta.Accessor(old)
+		if err == nil {
+			if len(oldAccessor.GetFinalizers()) > 0 {
+				now := metav1.Now()
+				oldAccessor.SetDeletionTimestamp(&now)
+				// Call update directly with mutability parameter set to true to allow
+				// changes to deletionTimestamp
+				return c.tracker.update(gvr, old, accessor.GetNamespace(), false, true, metav1.UpdateOptions{})
+			}
+		}
+	}
+
+	// TODO: implement propagation
+	return c.tracker.Delete(gvr, accessor.GetNamespace(), accessor.GetName())
+}
+
+func getGVRFromObject(obj runtime.Object, scheme *runtime.Scheme) (schema.GroupVersionResource, error) {
+	gvk, err := apiutil.GVKForObject(obj, scheme)
+	if err != nil {
+		return schema.GroupVersionResource{}, err
+	}
+	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+	return gvr, nil
+}
+
+type fakeSubResourceClient struct {
+	client      *fakeClient
+	subResource string
+}
+
+func (sw *fakeSubResourceClient) Get(ctx context.Context, obj, subResource client.Object, opts ...client.SubResourceGetOption) error {
+	switch sw.subResource {
+	case subResourceScale:
+		// Actual client looks up resource, then extracts the scale sub-resource:
+		// https://github.com/kubernetes/kubernetes/blob/fb6bbc9781d11a87688c398778525c4e1dcb0f08/pkg/registry/apps/deployment/storage/storage.go#L307
+		if err := sw.client.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
+			return err
+		}
+		scale, isScale := subResource.(*autoscalingv1.Scale)
+		if !isScale {
+			return apierrors.NewBadRequest(fmt.Sprintf("expected Scale, got %T", subResource))
+		}
+		scaleOut, err := extractScale(obj)
+		if err != nil {
+			return err
+		}
+		*scale = *scaleOut
+		return nil
+	default:
+		return fmt.Errorf("fakeSubResourceClient does not support get for %s", sw.subResource)
+	}
+}
+
+func (sw *fakeSubResourceClient) Create(ctx context.Context, obj client.Object, subResource client.Object, opts ...client.SubResourceCreateOption) error {
+	switch sw.subResource {
+	case "eviction":
+		_, isEviction := subResource.(*policyv1beta1.Eviction)
+		if !isEviction {
+			_, isEviction = subResource.(*policyv1.Eviction)
+		}
+		if !isEviction {
+			return apierrors.NewBadRequest(fmt.Sprintf("got invalid type %T, expected Eviction", subResource))
+		}
+		if _, isPod := obj.(*corev1.Pod); !isPod {
+			return apierrors.NewNotFound(schema.GroupResource{}, "")
+		}
+
+		return sw.client.Delete(ctx, obj)
+	case "token":
+		tokenRequest, isTokenRequest := subResource.(*authenticationv1.TokenRequest)
+		if !isTokenRequest {
+			return apierrors.NewBadRequest(fmt.Sprintf("got invalid type %T, expected TokenRequest", subResource))
+		}
+		if _, isServiceAccount := obj.(*corev1.ServiceAccount); !isServiceAccount {
+			return apierrors.NewNotFound(schema.GroupResource{}, "")
+		}
+
+		tokenRequest.Status.Token = "fake-token"
+		tokenRequest.Status.ExpirationTimestamp = metav1.Date(6041, 1, 1, 0, 0, 0, 0, time.UTC)
+
+		return sw.client.Get(ctx, client.ObjectKeyFromObject(obj), obj)
+	default:
+		return fmt.Errorf("fakeSubResourceWriter does not support create for %s", sw.subResource)
+	}
+}
+
+func (sw *fakeSubResourceClient) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+	updateOptions := client.SubResourceUpdateOptions{}
+	updateOptions.ApplyOptions(opts)
+
+	switch sw.subResource {
+	case subResourceScale:
+		if err := sw.client.Get(ctx, client.ObjectKeyFromObject(obj), obj.DeepCopyObject().(client.Object)); err != nil {
+			return err
+		}
+		if updateOptions.SubResourceBody == nil {
+			return apierrors.NewBadRequest("missing SubResourceBody")
+		}
+
+		scale, isScale := updateOptions.SubResourceBody.(*autoscalingv1.Scale)
+		if !isScale {
+			return apierrors.NewBadRequest(fmt.Sprintf("expected Scale, got %T", updateOptions.SubResourceBody))
+		}
+		if err := applyScale(obj, scale); err != nil {
+			return err
+		}
+		return sw.client.update(obj, false, &updateOptions.UpdateOptions)
+	default:
+		body := obj
+		if updateOptions.SubResourceBody != nil {
+			body = updateOptions.SubResourceBody
+		}
+		return sw.client.update(body, true, &updateOptions.UpdateOptions)
+	}
+}
+
+func (sw *fakeSubResourceClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+	patchOptions := client.SubResourcePatchOptions{}
+	patchOptions.ApplyOptions(opts)
+
+	body := obj
+	if patchOptions.SubResourceBody != nil {
+		body = patchOptions.SubResourceBody
+	}
+
+	// this is necessary to identify that last call was made for status patch, through stack trace.
+	if sw.subResource == "status" {
+		return sw.statusPatch(body, patch, patchOptions)
+	}
+
+	return sw.client.patch(body, patch, &patchOptions.PatchOptions)
+}
+
+func (sw *fakeSubResourceClient) statusPatch(body client.Object, patch client.Patch, patchOptions client.SubResourcePatchOptions) error {
+	return sw.client.patch(body, patch, &patchOptions.PatchOptions)
+}
+
+func (sw *fakeSubResourceClient) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption) error {
+	if sw.subResource != "status" {
+		return errors.New("fakeSubResourceClient currently only supports Apply for status subresource")
+	}
+
+	applyOpts := &client.SubResourceApplyOptions{}
+	applyOpts.ApplyOpts(opts)
+
+	data, err := json.Marshal(obj)
+	if err != nil {
+		return fmt.Errorf("failed to marshal apply configuration: %w", err)
+	}
+
+	u := &unstructured.Unstructured{}
+	if err := json.Unmarshal(data, u); err != nil {
+		return fmt.Errorf("failed to unmarshal apply configuration: %w", err)
+	}
+
+	patchOpts := &client.SubResourcePatchOptions{}
+	patchOpts.Raw = applyOpts.AsPatchOptions()
+
+	if applyOpts.SubResourceBody != nil {
+		subResourceBodySerialized, err := json.Marshal(applyOpts.SubResourceBody)
+		if err != nil {
+			return fmt.Errorf("failed to serialize subresource body: %w", err)
+		}
+		subResourceBody := &unstructured.Unstructured{}
+		if err := json.Unmarshal(subResourceBodySerialized, subResourceBody); err != nil {
+			return fmt.Errorf("failed to unmarshal subresource body: %w", err)
+		}
+		patchOpts.SubResourceBody = subResourceBody
+	}
+
+	return sw.Patch(ctx, u, &fakeApplyPatch{}, patchOpts)
+}
+
+func allowsUnconditionalUpdate(gvk schema.GroupVersionKind) bool {
+	switch gvk.Group {
+	case "apps":
+		switch gvk.Kind {
+		case "ControllerRevision", "DaemonSet", "Deployment", "ReplicaSet", "StatefulSet":
+			return true
+		}
+	case "autoscaling":
+		switch gvk.Kind {
+		case "HorizontalPodAutoscaler":
+			return true
+		}
+	case "batch":
+		switch gvk.Kind {
+		case "CronJob", "Job":
+			return true
+		}
+	case "certificates":
+		switch gvk.Kind {
+		case "Certificates":
+			return true
+		}
+	case "flowcontrol":
+		switch gvk.Kind {
+		case "FlowSchema", "PriorityLevelConfiguration":
+			return true
+		}
+	case "networking":
+		switch gvk.Kind {
+		case "Ingress", "IngressClass", "NetworkPolicy":
+			return true
+		}
+	case "policy":
+		switch gvk.Kind {
+		case "PodSecurityPolicy":
+			return true
+		}
+	case "rbac.authorization.k8s.io":
+		switch gvk.Kind {
+		case "ClusterRole", "ClusterRoleBinding", "Role", "RoleBinding":
+			return true
+		}
+	case "scheduling":
+		switch gvk.Kind {
+		case "PriorityClass":
+			return true
+		}
+	case "settings":
+		switch gvk.Kind {
+		case "PodPreset":
+			return true
+		}
+	case "storage":
+		switch gvk.Kind {
+		case "StorageClass":
+			return true
+		}
+	case "":
+		switch gvk.Kind {
+		case "ConfigMap", "Endpoint", "Event", "LimitRange", "Namespace", "Node",
+			"PersistentVolume", "PersistentVolumeClaim", "Pod", "PodTemplate",
+			"ReplicationController", "ResourceQuota", "Secret", "Service",
+			"ServiceAccount", "EndpointSlice":
+			return true
+		}
+	}
+
+	return false
+}
+
+func allowsCreateOnUpdate(gvk schema.GroupVersionKind) bool {
+	switch gvk.Group {
+	case "coordination":
+		switch gvk.Kind {
+		case "Lease":
+			return true
+		}
+	case "node":
+		switch gvk.Kind {
+		case "RuntimeClass":
+			return true
+		}
+	case "rbac":
+		switch gvk.Kind {
+		case "ClusterRole", "ClusterRoleBinding", "Role", "RoleBinding":
+			return true
+		}
+	case "":
+		switch gvk.Kind {
+		case "Endpoint", "Event", "LimitRange", "Service":
+			return true
+		}
+	}
+
+	return false
+}
+
+func inTreeResourcesWithStatus() []schema.GroupVersionKind {
+	return []schema.GroupVersionKind{
+		{Version: "v1", Kind: "Namespace"},
+		{Version: "v1", Kind: "Node"},
+		{Version: "v1", Kind: "PersistentVolumeClaim"},
+		{Version: "v1", Kind: "PersistentVolume"},
+		{Version: "v1", Kind: "Pod"},
+		{Version: "v1", Kind: "ReplicationController"},
+		{Version: "v1", Kind: "Service"},
+
+		{Group: "apps", Version: "v1", Kind: "Deployment"},
+		{Group: "apps", Version: "v1", Kind: "DaemonSet"},
+		{Group: "apps", Version: "v1", Kind: "ReplicaSet"},
+		{Group: "apps", Version: "v1", Kind: "StatefulSet"},
+
+		{Group: "autoscaling", Version: "v1", Kind: "HorizontalPodAutoscaler"},
+
+		{Group: "batch", Version: "v1", Kind: "CronJob"},
+		{Group: "batch", Version: "v1", Kind: "Job"},
+
+		{Group: "certificates.k8s.io", Version: "v1", Kind: "CertificateSigningRequest"},
+
+		{Group: "networking.k8s.io", Version: "v1", Kind: "Ingress"},
+		{Group: "networking.k8s.io", Version: "v1", Kind: "NetworkPolicy"},
+
+		{Group: "policy", Version: "v1", Kind: "PodDisruptionBudget"},
+
+		{Group: "storage.k8s.io", Version: "v1", Kind: "VolumeAttachment"},
+
+		{Group: "apiextensions.k8s.io", Version: "v1", Kind: "CustomResourceDefinition"},
+
+		{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta2", Kind: "FlowSchema"},
+		{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta2", Kind: "PriorityLevelConfiguration"},
+		{Group: "flowcontrol.apiserver.k8s.io", Version: "v1", Kind: "FlowSchema"},
+		{Group: "flowcontrol.apiserver.k8s.io", Version: "v1", Kind: "PriorityLevelConfiguration"},
+	}
+}
+
+// zero zeros the value of a pointer.
+func zero(x any) {
+	if x == nil {
+		return
+	}
+	res := reflect.ValueOf(x).Elem()
+	res.Set(reflect.Zero(res.Type()))
+}
+
+// getSingleOrZeroOptions returns the single options value in the slice, its
+// zero value if the slice is empty, or an error if the slice contains more than
+// one option value.
+func getSingleOrZeroOptions[T any](opts []T) (opt T, err error) {
+	switch len(opts) {
+	case 0:
+	case 1:
+		opt = opts[0]
+	default:
+		err = fmt.Errorf("expected single or no options value, got %d values", len(opts))
+	}
+	return
+}
+
+func extractScale(obj client.Object) (*autoscalingv1.Scale, error) {
+	switch obj := obj.(type) {
+	case *appsv1.Deployment:
+		var replicas int32 = 1
+		if obj.Spec.Replicas != nil {
+			replicas = *obj.Spec.Replicas
+		}
+		var selector string
+		if obj.Spec.Selector != nil {
+			selector = obj.Spec.Selector.String()
+		}
+		return &autoscalingv1.Scale{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         obj.Namespace,
+				Name:              obj.Name,
+				UID:               obj.UID,
+				ResourceVersion:   obj.ResourceVersion,
+				CreationTimestamp: obj.CreationTimestamp,
+			},
+			Spec: autoscalingv1.ScaleSpec{
+				Replicas: replicas,
+			},
+			Status: autoscalingv1.ScaleStatus{
+				Replicas: obj.Status.Replicas,
+				Selector: selector,
+			},
+		}, nil
+	case *appsv1.ReplicaSet:
+		var replicas int32 = 1
+		if obj.Spec.Replicas != nil {
+			replicas = *obj.Spec.Replicas
+		}
+		var selector string
+		if obj.Spec.Selector != nil {
+			selector = obj.Spec.Selector.String()
+		}
+		return &autoscalingv1.Scale{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         obj.Namespace,
+				Name:              obj.Name,
+				UID:               obj.UID,
+				ResourceVersion:   obj.ResourceVersion,
+				CreationTimestamp: obj.CreationTimestamp,
+			},
+			Spec: autoscalingv1.ScaleSpec{
+				Replicas: replicas,
+			},
+			Status: autoscalingv1.ScaleStatus{
+				Replicas: obj.Status.Replicas,
+				Selector: selector,
+			},
+		}, nil
+	case *corev1.ReplicationController:
+		var replicas int32 = 1
+		if obj.Spec.Replicas != nil {
+			replicas = *obj.Spec.Replicas
+		}
+		return &autoscalingv1.Scale{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         obj.Namespace,
+				Name:              obj.Name,
+				UID:               obj.UID,
+				ResourceVersion:   obj.ResourceVersion,
+				CreationTimestamp: obj.CreationTimestamp,
+			},
+			Spec: autoscalingv1.ScaleSpec{
+				Replicas: replicas,
+			},
+			Status: autoscalingv1.ScaleStatus{
+				Replicas: obj.Status.Replicas,
+				Selector: labels.Set(obj.Spec.Selector).String(),
+			},
+		}, nil
+	case *appsv1.StatefulSet:
+		var replicas int32 = 1
+		if obj.Spec.Replicas != nil {
+			replicas = *obj.Spec.Replicas
+		}
+		var selector string
+		if obj.Spec.Selector != nil {
+			selector = obj.Spec.Selector.String()
+		}
+		return &autoscalingv1.Scale{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         obj.Namespace,
+				Name:              obj.Name,
+				UID:               obj.UID,
+				ResourceVersion:   obj.ResourceVersion,
+				CreationTimestamp: obj.CreationTimestamp,
+			},
+			Spec: autoscalingv1.ScaleSpec{
+				Replicas: replicas,
+			},
+			Status: autoscalingv1.ScaleStatus{
+				Replicas: obj.Status.Replicas,
+				Selector: selector,
+			},
+		}, nil
+	default:
+		// TODO: CRDs https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#scale-subresource
+		return nil, fmt.Errorf("unimplemented scale subresource for resource %T", obj)
+	}
+}
+
+func applyScale(obj client.Object, scale *autoscalingv1.Scale) error {
+	switch obj := obj.(type) {
+	case *appsv1.Deployment:
+		obj.Spec.Replicas = ptr.To(scale.Spec.Replicas)
+	case *appsv1.ReplicaSet:
+		obj.Spec.Replicas = ptr.To(scale.Spec.Replicas)
+	case *corev1.ReplicationController:
+		obj.Spec.Replicas = ptr.To(scale.Spec.Replicas)
+	case *appsv1.StatefulSet:
+		obj.Spec.Replicas = ptr.To(scale.Spec.Replicas)
+	default:
+		// TODO: CRDs https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#scale-subresource
+		return fmt.Errorf("unimplemented scale subresource for resource %T", obj)
+	}
+	return nil
+}
+
+// AddIndex adds an index to a fake client. It will panic if used with a client that is not a fake client.
+// It will error if there is already an index for given object with the same name as field.
+//
+// It can be used to test code that adds indexes to the cache at runtime.
+func AddIndex(c client.Client, obj runtime.Object, field string, extractValue client.IndexerFunc) error {
+	fakeClient, isFakeClient := c.(*fakeClient)
+	if !isFakeClient {
+		panic("AddIndex can only be used with a fake client")
+	}
+	fakeClient.indexesLock.Lock()
+	defer fakeClient.indexesLock.Unlock()
+
+	if fakeClient.indexes == nil {
+		fakeClient.indexes = make(map[schema.GroupVersionKind]map[string]client.IndexerFunc, 1)
+	}
+
+	gvk, err := apiutil.GVKForObject(obj, fakeClient.scheme)
+	if err != nil {
+		return fmt.Errorf("failed to get gvk for %T: %w", obj, err)
+	}
+
+	if fakeClient.indexes[gvk] == nil {
+		fakeClient.indexes[gvk] = make(map[string]client.IndexerFunc, 1)
+	}
+
+	if fakeClient.indexes[gvk][field] != nil {
+		return fmt.Errorf("index %s already exists", field)
+	}
+
+	fakeClient.indexes[gvk][field] = extractValue
+
+	return nil
+}
+
+func (c *fakeClient) addToSchemeIfUnknownAndUnstructuredOrPartial(obj runtime.Object) error {
+	c.schemeLock.Lock()
+	defer c.schemeLock.Unlock()
+
+	_, isUnstructured := obj.(*unstructured.Unstructured)
+	_, isUnstructuredList := obj.(*unstructured.UnstructuredList)
+	_, isPartial := obj.(*metav1.PartialObjectMetadata)
+	_, isPartialList := obj.(*metav1.PartialObjectMetadataList)
+	if !isUnstructured && !isUnstructuredList && !isPartial && !isPartialList {
+		return nil
+	}
+
+	gvk, err := apiutil.GVKForObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+
+	if isUnstructuredList || isPartialList {
+		if !strings.HasSuffix(gvk.Kind, "List") {
+			gvk.Kind += "List"
+		}
+	}
+
+	if !c.scheme.Recognizes(gvk) {
+		c.scheme.AddKnownTypeWithName(gvk, obj)
+	}
+
+	return nil
+}
+
+func ensureTypeMeta(obj runtime.Object, gvk schema.GroupVersionKind) error {
+	ta, err := meta.TypeAccessor(obj)
+	if err != nil {
+		return err
+	}
+	_, isUnstructured := obj.(runtime.Unstructured)
+	_, isPartialObject := obj.(*metav1.PartialObjectMetadata)
+	_, isPartialObjectList := obj.(*metav1.PartialObjectMetadataList)
+	if !isUnstructured && !isPartialObject && !isPartialObjectList {
+		ta.SetKind("")
+		ta.SetAPIVersion("")
+		return nil
+	}
+
+	ta.SetKind(gvk.Kind)
+	ta.SetAPIVersion(gvk.GroupVersion().String())
+
+	return nil
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/fake/doc.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/fake/doc.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package fake provides a fake client for testing.
+
+A fake client is backed by its simple object store indexed by GroupVersionResource.
+You can create a fake client with optional objects.
+
+	client := NewClientBuilder().WithScheme(scheme).WithObjects(initObjs...).Build()
+
+You can invoke the methods defined in the Client interface.
+
+When in doubt, it's almost always better not to use this package and instead use
+envtest.Environment with a real client and API server.
+
+WARNING: ⚠️ Current Limitations / Known Issues with the fake Client ⚠️
+  - This client does not have a way to inject specific errors to test handled vs. unhandled errors.
+  - There is some support for sub resources which can cause issues with tests if you're trying to update
+    e.g. metadata and status in the same reconcile.
+  - No OpenAPI validation is performed when creating or updating objects.
+  - ObjectMeta's `Generation` and `ResourceVersion` don't behave properly, Patch or Update
+    operations that rely on these fields will fail, or give false positives.
+*/
+package fake

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/fake/typeconverter.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/fake/typeconverter.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/managedfields"
+	"sigs.k8s.io/structured-merge-diff/v6/typed"
+)
+
+type multiTypeConverter struct {
+	upstream []managedfields.TypeConverter
+}
+
+func (m multiTypeConverter) ObjectToTyped(r runtime.Object, o ...typed.ValidationOptions) (*typed.TypedValue, error) {
+	var errs []error
+	for _, u := range m.upstream {
+		res, err := u.ObjectToTyped(r, o...)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		return res, nil
+	}
+
+	return nil, fmt.Errorf("failed to convert Object to TypedValue: %w", kerrors.NewAggregate(errs))
+}
+
+func (m multiTypeConverter) TypedToObject(v *typed.TypedValue) (runtime.Object, error) {
+	var errs []error
+	for _, u := range m.upstream {
+		res, err := u.TypedToObject(v)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		return res, nil
+	}
+
+	return nil, fmt.Errorf("failed to convert TypedValue to Object: %w", kerrors.NewAggregate(errs))
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/fake/versioned_tracker.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/fake/versioned_tracker.go
@@ -1,0 +1,368 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"runtime/debug"
+	"strconv"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/managedfields"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/testing"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+var _ testing.ObjectTracker = (*versionedTracker)(nil)
+
+type versionedTracker struct {
+	upstream                      testing.ObjectTracker
+	scheme                        *runtime.Scheme
+	withStatusSubresource         sets.Set[schema.GroupVersionKind]
+	usesFieldManagedObjectTracker bool
+}
+
+func (t versionedTracker) Add(obj runtime.Object) error {
+	var objects []runtime.Object
+	if meta.IsListType(obj) {
+		var err error
+		objects, err = meta.ExtractList(obj)
+		if err != nil {
+			return err
+		}
+	} else {
+		objects = []runtime.Object{obj}
+	}
+	for _, obj := range objects {
+		accessor, err := meta.Accessor(obj)
+		if err != nil {
+			return fmt.Errorf("failed to get accessor for object: %w", err)
+		}
+		if accessor.GetDeletionTimestamp() != nil && len(accessor.GetFinalizers()) == 0 {
+			return fmt.Errorf("refusing to create obj %s with metadata.deletionTimestamp but no finalizers", accessor.GetName())
+		}
+		if accessor.GetResourceVersion() == "" {
+			// We use a "magic" value of 999 here because this field
+			// is parsed as uint and and 0 is already used in Update.
+			// As we can't go lower, go very high instead so this can
+			// be recognized
+			accessor.SetResourceVersion(trackerAddResourceVersion)
+		}
+
+		obj, err = convertFromUnstructuredIfNecessary(t.scheme, obj)
+		if err != nil {
+			return err
+		}
+
+		// If the fieldManager can not decode fields, it will just silently clear them. This is pretty
+		// much guaranteed not to be what someone that initializes a fake client with objects that
+		// have them set wants, so validate them here.
+		// Ref https://github.com/kubernetes/kubernetes/blob/a956ef4862993b825bcd524a19260192ff1da72d/staging/src/k8s.io/apimachinery/pkg/util/managedfields/internal/fieldmanager.go#L105
+		if t.usesFieldManagedObjectTracker {
+			if err := managedfields.ValidateManagedFields(accessor.GetManagedFields()); err != nil {
+				return fmt.Errorf("invalid managedFields on %T: %w", obj, err)
+			}
+		}
+		if err := t.upstream.Add(obj); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (t versionedTracker) Create(gvr schema.GroupVersionResource, obj runtime.Object, ns string, opts ...metav1.CreateOptions) error {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return fmt.Errorf("failed to get accessor for object: %w", err)
+	}
+	if accessor.GetName() == "" {
+		gvk, _ := apiutil.GVKForObject(obj, t.scheme)
+		return apierrors.NewInvalid(
+			gvk.GroupKind(),
+			accessor.GetName(),
+			field.ErrorList{field.Required(field.NewPath("metadata.name"), "name is required")})
+	}
+	if accessor.GetResourceVersion() != "" {
+		return apierrors.NewBadRequest("resourceVersion can not be set for Create requests")
+	}
+	accessor.SetResourceVersion("1")
+	obj, err = convertFromUnstructuredIfNecessary(t.scheme, obj)
+	if err != nil {
+		return err
+	}
+	if err := t.upstream.Create(gvr, obj, ns, opts...); err != nil {
+		accessor.SetResourceVersion("")
+		return err
+	}
+
+	return nil
+}
+
+func (t versionedTracker) Update(gvr schema.GroupVersionResource, obj runtime.Object, ns string, opts ...metav1.UpdateOptions) error {
+	updateOpts, err := getSingleOrZeroOptions(opts)
+	if err != nil {
+		return err
+	}
+
+	return t.update(gvr, obj, ns, false, false, updateOpts)
+}
+
+func (t versionedTracker) update(gvr schema.GroupVersionResource, obj runtime.Object, ns string, isStatus, deleting bool, opts metav1.UpdateOptions) error {
+	gvk, err := apiutil.GVKForObject(obj, t.scheme)
+	if err != nil {
+		return err
+	}
+	obj, needsCreate, err := t.updateObject(gvr, gvk, obj, ns, isStatus, deleting, allowsCreateOnUpdate(gvk), opts.DryRun)
+	if err != nil {
+		return err
+	}
+
+	if needsCreate {
+		opts := metav1.CreateOptions{DryRun: opts.DryRun, FieldManager: opts.FieldManager}
+		return t.Create(gvr, obj, ns, opts)
+	}
+
+	if obj == nil { // Object was deleted in updateObject
+		return nil
+	}
+
+	if u, unstructured := obj.(*unstructured.Unstructured); unstructured {
+		u.SetGroupVersionKind(gvk)
+	}
+
+	return t.upstream.Update(gvr, obj, ns, opts)
+}
+
+func (t versionedTracker) Patch(gvr schema.GroupVersionResource, obj runtime.Object, ns string, opts ...metav1.PatchOptions) error {
+	patchOptions, err := getSingleOrZeroOptions(opts)
+	if err != nil {
+		return err
+	}
+
+	gvk, err := apiutil.GVKForObject(obj, t.scheme)
+	if err != nil {
+		return err
+	}
+
+	// We apply patches using a client-go reaction that ends up calling the trackers Patch. As we can't change
+	// that reaction, we use the callstack to figure out if this originated from the status client.
+	isStatus := bytes.Contains(debug.Stack(), []byte("sigs.k8s.io/controller-runtime/pkg/client/fake.(*fakeSubResourceClient).statusPatch"))
+
+	obj, needsCreate, err := t.updateObject(gvr, gvk, obj, ns, isStatus, false, allowsCreateOnUpdate(gvk), patchOptions.DryRun)
+	if err != nil {
+		return err
+	}
+	if needsCreate {
+		opts := metav1.CreateOptions{DryRun: patchOptions.DryRun, FieldManager: patchOptions.FieldManager}
+		return t.Create(gvr, obj, ns, opts)
+	}
+
+	if obj == nil { // Object was deleted in updateObject
+		return nil
+	}
+
+	return t.upstream.Patch(gvr, obj, ns, patchOptions)
+}
+
+// updateObject performs a number of validations and changes related to
+// object updates, such as checking and updating the resourceVersion.
+func (t versionedTracker) updateObject(
+	gvr schema.GroupVersionResource,
+	gvk schema.GroupVersionKind,
+	obj runtime.Object,
+	ns string,
+	isStatus bool,
+	deleting bool,
+	allowCreateOnUpdate bool,
+	dryRun []string,
+) (result runtime.Object, needsCreate bool, _ error) {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to get accessor for object: %w", err)
+	}
+
+	if accessor.GetName() == "" {
+		return nil, false, apierrors.NewInvalid(
+			gvk.GroupKind(),
+			accessor.GetName(),
+			field.ErrorList{field.Required(field.NewPath("metadata.name"), "name is required")})
+	}
+
+	oldObject, err := t.Get(gvr, ns, accessor.GetName())
+	if err != nil {
+		// If the resource is not found and the resource allows create on update, issue a
+		// create instead.
+		if apierrors.IsNotFound(err) && allowCreateOnUpdate {
+			// Pass this info to the caller rather than create, because in the SSA case it
+			// must be created by calling Apply in the upstream tracker, not Create.
+			// This is because SSA considers Apply and Non-Apply operations to be different
+			// even when they use the same fieldManager. This behavior is also observable
+			// with a real Kubernetes apiserver.
+			//
+			// Ref https://kubernetes.slack.com/archives/C0EG7JC6T/p1757868204458989?thread_ts=1757808656.002569&cid=C0EG7JC6T
+			return obj, true, nil
+		}
+		return obj, false, err
+	}
+
+	if t.withStatusSubresource.Has(gvk) {
+		if isStatus { // copy everything but status, managedFields and metadata.ResourceVersion from original object
+			if err := copyStatusFrom(obj, oldObject); err != nil {
+				return nil, false, fmt.Errorf("failed to copy non-status field for object with status subresouce: %w", err)
+			}
+			passedRV := accessor.GetResourceVersion()
+			passedManagedFields := accessor.GetManagedFields()
+			if err := copyFrom(oldObject, obj); err != nil {
+				return nil, false, fmt.Errorf("failed to restore non-status fields: %w", err)
+			}
+			accessor.SetResourceVersion(passedRV)
+			accessor.SetManagedFields(passedManagedFields)
+		} else { // copy status from original object
+			if err := copyStatusFrom(oldObject, obj); err != nil {
+				return nil, false, fmt.Errorf("failed to copy the status for object with status subresource: %w", err)
+			}
+		}
+	} else if isStatus {
+		return nil, false, apierrors.NewNotFound(gvr.GroupResource(), accessor.GetName())
+	}
+
+	oldAccessor, err := meta.Accessor(oldObject)
+	if err != nil {
+		return nil, false, err
+	}
+
+	// If the new object does not have the resource version set and it allows unconditional update,
+	// default it to the resource version of the existing resource
+	if accessor.GetResourceVersion() == "" {
+		switch {
+		case allowsUnconditionalUpdate(gvk):
+			accessor.SetResourceVersion(oldAccessor.GetResourceVersion())
+			// This is needed because if the patch explicitly sets the RV to null, the client-go reaction we use
+			// to apply it and whose output we process here will have it unset. It is not clear why the Kubernetes
+			// apiserver accepts such a patch, but it does so we just copy that behavior.
+			// Kubernetes apiserver behavior can be checked like this:
+			// `kubectl patch configmap foo --patch '{"metadata":{"annotations":{"foo":"bar"},"resourceVersion":null}}' -v=9`
+		case bytes.Contains(debug.Stack(), []byte("sigs.k8s.io/controller-runtime/pkg/client/fake.(*fakeClient).Patch")),
+			bytes.Contains(debug.Stack(), []byte("sigs.k8s.io/controller-runtime/pkg/client/fake.(*fakeSubResourceClient).Patch")):
+			// We apply patches using a client-go reaction that ends up calling the trackers Update. As we can't change
+			// that reaction, we use the callstack to figure out if this originated from the "fake[SubResource]Client.Patch" func.
+			accessor.SetResourceVersion(oldAccessor.GetResourceVersion())
+		case bytes.Contains(debug.Stack(), []byte("sigs.k8s.io/controller-runtime/pkg/client/fake.(*fakeClient).Apply")),
+			bytes.Contains(debug.Stack(), []byte("sigs.k8s.io/controller-runtime/pkg/client/fake.(*fakeSubResourceClient).Apply")):
+			// We apply patches using a client-go reaction that ends up calling the trackers Update. As we can't change
+			// that reaction, we use the callstack to figure out if this originated from the "fake[SubResource]Client.Apply" func.
+			accessor.SetResourceVersion(oldAccessor.GetResourceVersion())
+		}
+	}
+
+	if accessor.GetResourceVersion() != oldAccessor.GetResourceVersion() {
+		return nil, false, apierrors.NewConflict(gvr.GroupResource(), accessor.GetName(), errors.New("object was modified"))
+	}
+	if oldAccessor.GetResourceVersion() == "" {
+		oldAccessor.SetResourceVersion("0")
+	}
+	intResourceVersion, err := strconv.ParseUint(oldAccessor.GetResourceVersion(), 10, 64)
+	if err != nil {
+		return nil, false, fmt.Errorf("can not convert resourceVersion %q to int: %w", oldAccessor.GetResourceVersion(), err)
+	}
+	intResourceVersion++
+	accessor.SetResourceVersion(strconv.FormatUint(intResourceVersion, 10))
+
+	if !deleting && !deletionTimestampEqual(accessor, oldAccessor) {
+		return nil, false, fmt.Errorf("error: Unable to edit %s: metadata.deletionTimestamp field is immutable", accessor.GetName())
+	}
+
+	if !accessor.GetDeletionTimestamp().IsZero() && len(accessor.GetFinalizers()) == 0 {
+		return nil, false, t.Delete(gvr, accessor.GetNamespace(), accessor.GetName(), metav1.DeleteOptions{DryRun: dryRun})
+	}
+
+	obj, err = convertFromUnstructuredIfNecessary(t.scheme, obj)
+	return obj, false, err
+}
+
+func (t versionedTracker) Apply(gvr schema.GroupVersionResource, applyConfiguration runtime.Object, ns string, opts ...metav1.PatchOptions) error {
+	patchOptions, err := getSingleOrZeroOptions(opts)
+	if err != nil {
+		return err
+	}
+	gvk, err := apiutil.GVKForObject(applyConfiguration, t.scheme)
+	if err != nil {
+		return err
+	}
+	isStatus := bytes.Contains(debug.Stack(), []byte("sigs.k8s.io/controller-runtime/pkg/client/fake.(*fakeSubResourceClient).statusPatch"))
+
+	applyConfiguration, needsCreate, err := t.updateObject(gvr, gvk, applyConfiguration, ns, isStatus, false, true, patchOptions.DryRun)
+	if err != nil {
+		return err
+	}
+
+	if needsCreate {
+		//		https://github.com/kubernetes/kubernetes/blob/81affffa1b8d8079836f4cac713ea8d1b2bbf10f/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go#L606
+		accessor, err := meta.Accessor(applyConfiguration)
+		if err != nil {
+			return fmt.Errorf("failed to get accessor for object: %w", err)
+		}
+		if accessor.GetUID() != "" {
+			return apierrors.NewConflict(gvr.GroupResource(), accessor.GetName(), fmt.Errorf("uid mismatch: the provided object specified uid %s, and no existing object was found", accessor.GetUID()))
+		}
+
+		if t.withStatusSubresource.Has(gvk) {
+			// Clear out status for create, for update this is handled in updateObject
+			if err := copyStatusFrom(&unstructured.Unstructured{}, applyConfiguration); err != nil {
+				return err
+			}
+		}
+	}
+
+	if applyConfiguration == nil { // Object was deleted in updateObject
+		return nil
+	}
+
+	if isStatus {
+		// We restore everything but status from the tracker where we don't put GVK
+		// into the object but it must be set for the ManagedFieldsObjectTracker
+		applyConfiguration.GetObjectKind().SetGroupVersionKind(gvk)
+	}
+	return t.upstream.Apply(gvr, applyConfiguration, ns, opts...)
+}
+
+func (t versionedTracker) Delete(gvr schema.GroupVersionResource, ns, name string, opts ...metav1.DeleteOptions) error {
+	return t.upstream.Delete(gvr, ns, name, opts...)
+}
+
+func (t versionedTracker) Get(gvr schema.GroupVersionResource, ns, name string, opts ...metav1.GetOptions) (runtime.Object, error) {
+	return t.upstream.Get(gvr, ns, name, opts...)
+}
+
+func (t versionedTracker) List(gvr schema.GroupVersionResource, gvk schema.GroupVersionKind, ns string, opts ...metav1.ListOptions) (runtime.Object, error) {
+	return t.upstream.List(gvr, gvk, ns, opts...)
+}
+
+func (t versionedTracker) Watch(gvr schema.GroupVersionResource, ns string, opts ...metav1.ListOptions) (watch.Interface, error) {
+	return t.upstream.Watch(gvr, ns, opts...)
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/interceptor/intercept.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/interceptor/intercept.go
@@ -1,0 +1,183 @@
+package interceptor
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Funcs contains functions that are called instead of the underlying client's methods.
+type Funcs struct {
+	Get               func(ctx context.Context, client client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error
+	List              func(ctx context.Context, client client.WithWatch, list client.ObjectList, opts ...client.ListOption) error
+	Create            func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.CreateOption) error
+	Delete            func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.DeleteOption) error
+	DeleteAllOf       func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.DeleteAllOfOption) error
+	Update            func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.UpdateOption) error
+	Patch             func(ctx context.Context, client client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error
+	Apply             func(ctx context.Context, client client.WithWatch, obj runtime.ApplyConfiguration, opts ...client.ApplyOption) error
+	Watch             func(ctx context.Context, client client.WithWatch, obj client.ObjectList, opts ...client.ListOption) (watch.Interface, error)
+	SubResource       func(client client.WithWatch, subResource string) client.SubResourceClient
+	SubResourceGet    func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, subResource client.Object, opts ...client.SubResourceGetOption) error
+	SubResourceCreate func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, subResource client.Object, opts ...client.SubResourceCreateOption) error
+	SubResourceUpdate func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, opts ...client.SubResourceUpdateOption) error
+	SubResourcePatch  func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error
+	SubResourceApply  func(ctx context.Context, client client.Client, subResourceName string, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption) error
+}
+
+// NewClient returns a new interceptor client that calls the functions in funcs instead of the underlying client's methods, if they are not nil.
+func NewClient(interceptedClient client.WithWatch, funcs Funcs) client.WithWatch {
+	return interceptor{
+		client: interceptedClient,
+		funcs:  funcs,
+	}
+}
+
+type interceptor struct {
+	client client.WithWatch
+	funcs  Funcs
+}
+
+var _ client.WithWatch = &interceptor{}
+
+func (c interceptor) GroupVersionKindFor(obj runtime.Object) (schema.GroupVersionKind, error) {
+	return c.client.GroupVersionKindFor(obj)
+}
+
+func (c interceptor) IsObjectNamespaced(obj runtime.Object) (bool, error) {
+	return c.client.IsObjectNamespaced(obj)
+}
+
+func (c interceptor) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if c.funcs.Get != nil {
+		return c.funcs.Get(ctx, c.client, key, obj, opts...)
+	}
+	return c.client.Get(ctx, key, obj, opts...)
+}
+
+func (c interceptor) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	if c.funcs.List != nil {
+		return c.funcs.List(ctx, c.client, list, opts...)
+	}
+	return c.client.List(ctx, list, opts...)
+}
+
+func (c interceptor) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	if c.funcs.Create != nil {
+		return c.funcs.Create(ctx, c.client, obj, opts...)
+	}
+	return c.client.Create(ctx, obj, opts...)
+}
+
+func (c interceptor) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	if c.funcs.Delete != nil {
+		return c.funcs.Delete(ctx, c.client, obj, opts...)
+	}
+	return c.client.Delete(ctx, obj, opts...)
+}
+
+func (c interceptor) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	if c.funcs.Update != nil {
+		return c.funcs.Update(ctx, c.client, obj, opts...)
+	}
+	return c.client.Update(ctx, obj, opts...)
+}
+
+func (c interceptor) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	if c.funcs.Patch != nil {
+		return c.funcs.Patch(ctx, c.client, obj, patch, opts...)
+	}
+	return c.client.Patch(ctx, obj, patch, opts...)
+}
+
+func (c interceptor) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...client.ApplyOption) error {
+	if c.funcs.Apply != nil {
+		return c.funcs.Apply(ctx, c.client, obj, opts...)
+	}
+
+	return c.client.Apply(ctx, obj, opts...)
+}
+
+func (c interceptor) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
+	if c.funcs.DeleteAllOf != nil {
+		return c.funcs.DeleteAllOf(ctx, c.client, obj, opts...)
+	}
+	return c.client.DeleteAllOf(ctx, obj, opts...)
+}
+
+func (c interceptor) Status() client.SubResourceWriter {
+	return c.SubResource("status")
+}
+
+func (c interceptor) SubResource(subResource string) client.SubResourceClient {
+	if c.funcs.SubResource != nil {
+		return c.funcs.SubResource(c.client, subResource)
+	}
+	return subResourceInterceptor{
+		subResourceName: subResource,
+		client:          c.client,
+		funcs:           c.funcs,
+	}
+}
+
+func (c interceptor) Scheme() *runtime.Scheme {
+	return c.client.Scheme()
+}
+
+func (c interceptor) RESTMapper() meta.RESTMapper {
+	return c.client.RESTMapper()
+}
+
+func (c interceptor) Watch(ctx context.Context, obj client.ObjectList, opts ...client.ListOption) (watch.Interface, error) {
+	if c.funcs.Watch != nil {
+		return c.funcs.Watch(ctx, c.client, obj, opts...)
+	}
+	return c.client.Watch(ctx, obj, opts...)
+}
+
+type subResourceInterceptor struct {
+	subResourceName string
+	client          client.Client
+	funcs           Funcs
+}
+
+var _ client.SubResourceClient = &subResourceInterceptor{}
+
+func (s subResourceInterceptor) Get(ctx context.Context, obj client.Object, subResource client.Object, opts ...client.SubResourceGetOption) error {
+	if s.funcs.SubResourceGet != nil {
+		return s.funcs.SubResourceGet(ctx, s.client, s.subResourceName, obj, subResource, opts...)
+	}
+	return s.client.SubResource(s.subResourceName).Get(ctx, obj, subResource, opts...)
+}
+
+func (s subResourceInterceptor) Create(ctx context.Context, obj client.Object, subResource client.Object, opts ...client.SubResourceCreateOption) error {
+	if s.funcs.SubResourceCreate != nil {
+		return s.funcs.SubResourceCreate(ctx, s.client, s.subResourceName, obj, subResource, opts...)
+	}
+	return s.client.SubResource(s.subResourceName).Create(ctx, obj, subResource, opts...)
+}
+
+func (s subResourceInterceptor) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+	if s.funcs.SubResourceUpdate != nil {
+		return s.funcs.SubResourceUpdate(ctx, s.client, s.subResourceName, obj, opts...)
+	}
+	return s.client.SubResource(s.subResourceName).Update(ctx, obj, opts...)
+}
+
+func (s subResourceInterceptor) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+	if s.funcs.SubResourcePatch != nil {
+		return s.funcs.SubResourcePatch(ctx, s.client, s.subResourceName, obj, patch, opts...)
+	}
+	return s.client.SubResource(s.subResourceName).Patch(ctx, obj, patch, opts...)
+}
+
+func (s subResourceInterceptor) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption) error {
+	if s.funcs.SubResourceApply != nil {
+		return s.funcs.SubResourceApply(ctx, s.client, s.subResourceName, obj, opts...)
+	}
+	return s.client.SubResource(s.subResourceName).Apply(ctx, obj, opts...)
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/internal/objectutil/objectutil.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/internal/objectutil/objectutil.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package objectutil
+
+import (
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// FilterWithLabels returns a copy of the items in objs matching labelSel.
+func FilterWithLabels(objs []runtime.Object, labelSel labels.Selector) ([]runtime.Object, error) {
+	outItems := make([]runtime.Object, 0, len(objs))
+	for _, obj := range objs {
+		meta, err := apimeta.Accessor(obj)
+		if err != nil {
+			return nil, err
+		}
+		if labelSel != nil {
+			lbls := labels.Set(meta.GetLabels())
+			if !labelSel.Matches(lbls) {
+				continue
+			}
+		}
+		outItems = append(outItems, obj.DeepCopyObject())
+	}
+	return outItems, nil
+}


### PR DESCRIPTION
## Summary

Deploy the PTP event publisher with **mTLS + OAuth** authentication on **all** exposed O-RAN ocloudNotifications APIs, implementing [CNF-26787](https://redhat.atlassian.net/browse/CNF-26787). This is the operator side of the change; the enforcement lives in the cloud-event-proxy sidecar (redhat-cne/cloud-event-proxy#746, redhat-cne/rest-api#112).

Ports openshift/ptp-operator#632 to upstream, reworked for the dual CEPv1/CEPv2 sidecar layout and simplified to use the Kubernetes TokenReview API (no cluster OAuth issuer / JWKS plumbing).

### What changed
- **`bindata/linuxptp/auth-config.yaml`** (new) — renders, gated on `ENABLE_EVENT_AUTH`:
  - ConfigMap `ptp-event-publisher-ca-bundle` (`service.beta.openshift.io/inject-cabundle`)
  - Service `ptp-event-publisher-server` with an OpenShift Service-CA serving cert
  - ConfigMap `ptp-event-publisher-auth` carrying `config.json`
  - ClusterRoleBinding `linuxptp-daemon-auth-delegator` (existing `linuxptp-daemon` SA → `system:auth-delegator`)
- **`bindata/linuxptp/ptp-daemon.yaml`** — both CEPv2 and legacy sidecars get `--auth-config`, the server-cert / ca-bundle / auth-config volume mounts, and an HTTPS health check — all gated on `EnableEventAuth`.
- **`controllers/ptpoperatorconfig_controller.go`** — render the auth manifest when `EnableEventPublisher && EnableEventAuth`; inject the cluster TLS profile (`TLSMinVersion` + `TLSCipherSuitesJSON`) into `config.json` per CNF-21982 (PQC readiness).
- `config/manager` env + CSVs add `ENABLE_EVENT_AUTH` (default **off** upstream so vanilla-k8s/Kind CI is unaffected; **on** in the OpenShift bundle).

### Testing
New `controllers/event_auth_test.go` (disabled/enabled render paths, valid TLS-profiled `config.json`) plus existing controller tests pass.

### Follow-up
Consumers must target `ptp-event-publisher-server.<ns>.svc` (or set `ServerName`) for hostname verification against the shared serving cert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional event-publisher authentication with mutual TLS and OAuth token validation.
  * Added Service CA-managed certificates, trust bundles, and authorization configuration.
  * Updated event-publisher connections and health checks to use HTTPS when authentication is enabled.

* **Configuration**
  * Event authentication is disabled by default and can be enabled where OpenShift Service CA support is available.

* **Tests**
  * Added coverage for enabled and disabled event-authentication configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
